### PR TITLE
Empty Cell Bug Fix 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -157,3 +157,4 @@ examples/data_temp/
 .vscode/settings.json
 .vscode/launch.json
 
+examples/dev_sandbox/temp/*

--- a/examples/04_coupling_riverine_NSM_modules_testUpdatedHDFfile.ipynb
+++ b/examples/04_coupling_riverine_NSM_modules_testUpdatedHDFfile.ipynb
@@ -1,0 +1,3262 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "9466a47a-b847-4d63-b323-ca996a0650b3",
+   "metadata": {},
+   "source": [
+    "# ClearWater-Riverine Demo 2: Coupling Transport to Water Quality Reactions with ClearWater-Modules\n",
+    "\n",
+    "**Objective**: Demonstrate a more complex scenario of coupled transport and reaction models in Sumwere Creek, using the [ClearWater-modules](https://github.com/EcohydrologyTeam/ClearWater-modules) to simulate heat exchange with the atmosphere.\n",
+    "\n",
+    "This second notebook builds on the introduction to using [ClearWater-riverine](https://github.com/EcohydrologyTeam/ClearWater-riverine) provided in demo notebook 1.\n",
+    "\n",
+    "## Background \n",
+    "This notebook couples Clearwater-riverine (transport) with Clearwater-modules (reactions) - specifically, the Temperature Simulation Model (TSM). The Temperature Simulation Module (TSM) is an essential component of ClearWater (Corps Library for Environmental Analysis and Restoration of Watersheds). TSM plays a crucial role in simulating and predicting water temperature within aquatic ecosystems. TSM utilizes a comprehensive energy balance approach to account for various factors contributing to heat inputs and outputs in the water environment. It considers both external forcing functions and heat exchanges occurring at the water surface and the sediment-water interface. The primary contributors to heat exchange at the water surface include shortwave solar radiation, longwave atmospheric radiation, heat conduction from the atmosphere to the water, and direct heat inputs. Conversely, the primary factors that remove heat from the system are longwave radiation emitted by the water, evaporation, and heat conduction from the water to the atmosphere. \n",
+    "The core principle behind TSM is the application of the laws of conservation of energy to compute water temperature. This means that the change in heat content of the water is directly related to changes in temperature, which, in turn, are influenced by various heat flux components. The specific heat of water is employed to establish this relationship. Each term of the heat flux equation can be calculated based on the input provided by the user, allowing for flexibility in modeling different environmental conditions\n",
+    "\n",
+    "## Example Case Study\n",
+    "\n",
+    "This example shows how to run Clearwater Riverine coupled with Clearwater Modules in a fictional location, \"Sumwere Creek\" (shown below). The flow field for Sumwere Creek comes from a HEC-RAS 2D model, which has a domain of 200x200 meters and a base mesh of 10x10 meters. \n",
+    "\n",
+    "![image.png](../docs/imgs/SumwereCreek_coarse.png)\n",
+    "\n",
+    "The upstream boundary for Sumwere Creek is at the top left of the model domain, flowing into the domain at a constant 3 cms. At the first bend in the creek, there is an additional boundary representing a spring-fed tributary to the creek (1 cms). Further downstream, there is a meander in the stream forming a slow-flowing oxbow lake. There is another boundary flowing into that oxbow lake, representing a powerplant discharge (0.5 cms). \n",
+    "\n",
+    "The downstream boundary is a constant stage set at 20.75  The upstream inflows have a water temperature of 15 degrees C; the spring-fed creek has constant inflows of 5 C, and the powerplant is steady at 20 C with periodic higher temperature (25 C) discharges in a downstream meander.  \n",
+    "\n",
+    "We simulate this scenario over the course of two full days, using meteorological parameters from Arizona (extreme temperature swings between night and day) to help show off the impacts of TSM.\n",
+    "\n",
+    "### Data Availability\n",
+    "All data required run this notebook is available at this [Google Drive](https://drive.google.com/drive/folders/1I_di8WrK95QwBga-W8iuJaJJMZsnIYSS?usp=drive_link). Please download the entire folder and place it in the `data_temp` folder of this repository to run the rest of the notebook."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f34af218-4b58-447d-907c-3fc89f057499",
+   "metadata": {},
+   "source": [
+    "## Model Set-Up\n",
+    "### General Imports"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "c280997b-7e02-4079-b8fe-707a0729ed86",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pathlib import Path\n",
+    "import logging\n",
+    "import numpy as np\n",
+    "import pandas as pd\n",
+    "import xarray as xr\n",
+    "#import holoviews as hv\n",
+    "#import geoviews as gv\n",
+    "# from holoviews import opts\n",
+    "#import panel as pn\n",
+    "#hv.extension(\"bokeh\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "baed1b6e-f756-4ca1-b959-4628ab2df47a",
+   "metadata": {},
+   "source": [
+    "### Import ClearWater-riverine\n",
+    "These steps require first completing **[Installation](https://github.com/EcohydrologyTeam/ClearWater-riverine?tab=readme-ov-file#installation)** of a [conda](https://conda.io/docs/) virtual environment customized for the ClearWater-riverine library."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "41338e34-2b59-4cd4-b6b3-a52f6edf7768",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "WindowsPath('d:/Clearwater/ClearWater-riverine')"
+      ]
+     },
+     "execution_count": 2,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Find project directory (i.e. the parent to `/examples` directory for this notebook)\n",
+    "project_path = Path.cwd().parent\n",
+    "project_path"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "e2bcf299-c36b-432a-8e28-d1366d0b9c87",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "WindowsPath('d:/Clearwater/ClearWater-riverine/src')"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Your source directory should be: \n",
+    "src_path = project_path / 'src'\n",
+    "src_path"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5cd020f2-ace9-4f32-a818-9a8716d21e53",
+   "metadata": {},
+   "source": [
+    "Next, we'll need to import Clearwater Riverine. While the package is still under development, the easiest way to do this is to use the [`conda develop`](https://docs.conda.io/projects/conda-build/en/latest/resources/commands/conda-develop.html) command in the console or terminal like this, replacing the `'/path/to/module/src'` with your specific path to the source directory. In other words:\n",
+    "- Copy from the output of `src_path` from the cell above, and \n",
+    "- Paste it after `!conda develop` in the cell below (replacing the previous user's path). \n",
+    "\n",
+    "NOTE: If your path has any blank spaces, you must enclose the path with quotes."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "9874c4fb-a442-46d9-a442-0df0f3cd01b3",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "path exists, skipping d:\\Clearwater\\ClearWater-riverine\\examples\\'\\Users\\aaufdenkampe\\Documents\\Python\\ClearWater-riverine\\src'\n",
+      "completed operation for: d:\\Clearwater\\ClearWater-riverine\\examples\\'\\Users\\aaufdenkampe\\Documents\\Python\\ClearWater-riverine\\src'\n"
+     ]
+    }
+   ],
+   "source": [
+    "!conda develop '/Users/aaufdenkampe/Documents/Python/ClearWater-riverine/src'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "d0676e2a-bdc9-4774-ab6c-c81927353da4",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/javascript": "(function(root) {\n  function now() {\n    return new Date();\n  }\n\n  var force = true;\n  var py_version = '3.4.1'.replace('rc', '-rc.').replace('.dev', '-dev.');\n  var reloading = false;\n  var Bokeh = root.Bokeh;\n\n  if (typeof (root._bokeh_timeout) === \"undefined\" || force) {\n    root._bokeh_timeout = Date.now() + 5000;\n    root._bokeh_failed_load = false;\n  }\n\n  function run_callbacks() {\n    try {\n      root._bokeh_onload_callbacks.forEach(function(callback) {\n        if (callback != null)\n          callback();\n      });\n    } finally {\n      delete root._bokeh_onload_callbacks;\n    }\n    console.debug(\"Bokeh: all callbacks have finished\");\n  }\n\n  function load_libs(css_urls, js_urls, js_modules, js_exports, callback) {\n    if (css_urls == null) css_urls = [];\n    if (js_urls == null) js_urls = [];\n    if (js_modules == null) js_modules = [];\n    if (js_exports == null) js_exports = {};\n\n    root._bokeh_onload_callbacks.push(callback);\n\n    if (root._bokeh_is_loading > 0) {\n      console.debug(\"Bokeh: BokehJS is being loaded, scheduling callback at\", now());\n      return null;\n    }\n    if (js_urls.length === 0 && js_modules.length === 0 && Object.keys(js_exports).length === 0) {\n      run_callbacks();\n      return null;\n    }\n    if (!reloading) {\n      console.debug(\"Bokeh: BokehJS not loaded, scheduling load and callback at\", now());\n    }\n\n    function on_load() {\n      root._bokeh_is_loading--;\n      if (root._bokeh_is_loading === 0) {\n        console.debug(\"Bokeh: all BokehJS libraries/stylesheets loaded\");\n        run_callbacks()\n      }\n    }\n    window._bokeh_on_load = on_load\n\n    function on_error() {\n      console.error(\"failed to load \" + url);\n    }\n\n    var skip = [];\n    if (window.requirejs) {\n      window.requirejs.config({'packages': {}, 'paths': {}, 'shim': {}});\n      root._bokeh_is_loading = css_urls.length + 0;\n    } else {\n      root._bokeh_is_loading = css_urls.length + js_urls.length + js_modules.length + Object.keys(js_exports).length;\n    }\n\n    var existing_stylesheets = []\n    var links = document.getElementsByTagName('link')\n    for (var i = 0; i < links.length; i++) {\n      var link = links[i]\n      if (link.href != null) {\n\texisting_stylesheets.push(link.href)\n      }\n    }\n    for (var i = 0; i < css_urls.length; i++) {\n      var url = css_urls[i];\n      if (existing_stylesheets.indexOf(url) !== -1) {\n\ton_load()\n\tcontinue;\n      }\n      const element = document.createElement(\"link\");\n      element.onload = on_load;\n      element.onerror = on_error;\n      element.rel = \"stylesheet\";\n      element.type = \"text/css\";\n      element.href = url;\n      console.debug(\"Bokeh: injecting link tag for BokehJS stylesheet: \", url);\n      document.body.appendChild(element);\n    }    var existing_scripts = []\n    var scripts = document.getElementsByTagName('script')\n    for (var i = 0; i < scripts.length; i++) {\n      var script = scripts[i]\n      if (script.src != null) {\n\texisting_scripts.push(script.src)\n      }\n    }\n    for (var i = 0; i < js_urls.length; i++) {\n      var url = js_urls[i];\n      if (skip.indexOf(url) !== -1 || existing_scripts.indexOf(url) !== -1) {\n\tif (!window.requirejs) {\n\t  on_load();\n\t}\n\tcontinue;\n      }\n      var element = document.createElement('script');\n      element.onload = on_load;\n      element.onerror = on_error;\n      element.async = false;\n      element.src = url;\n      console.debug(\"Bokeh: injecting script tag for BokehJS library: \", url);\n      document.head.appendChild(element);\n    }\n    for (var i = 0; i < js_modules.length; i++) {\n      var url = js_modules[i];\n      if (skip.indexOf(url) !== -1 || existing_scripts.indexOf(url) !== -1) {\n\tif (!window.requirejs) {\n\t  on_load();\n\t}\n\tcontinue;\n      }\n      var element = document.createElement('script');\n      element.onload = on_load;\n      element.onerror = on_error;\n      element.async = false;\n      element.src = url;\n      element.type = \"module\";\n      console.debug(\"Bokeh: injecting script tag for BokehJS library: \", url);\n      document.head.appendChild(element);\n    }\n    for (const name in js_exports) {\n      var url = js_exports[name];\n      if (skip.indexOf(url) >= 0 || root[name] != null) {\n\tif (!window.requirejs) {\n\t  on_load();\n\t}\n\tcontinue;\n      }\n      var element = document.createElement('script');\n      element.onerror = on_error;\n      element.async = false;\n      element.type = \"module\";\n      console.debug(\"Bokeh: injecting script tag for BokehJS library: \", url);\n      element.textContent = `\n      import ${name} from \"${url}\"\n      window.${name} = ${name}\n      window._bokeh_on_load()\n      `\n      document.head.appendChild(element);\n    }\n    if (!js_urls.length && !js_modules.length) {\n      on_load()\n    }\n  };\n\n  function inject_raw_css(css) {\n    const element = document.createElement(\"style\");\n    element.appendChild(document.createTextNode(css));\n    document.body.appendChild(element);\n  }\n\n  var js_urls = [\"https://cdn.bokeh.org/bokeh/release/bokeh-3.4.1.min.js\", \"https://cdn.bokeh.org/bokeh/release/bokeh-gl-3.4.1.min.js\", \"https://cdn.bokeh.org/bokeh/release/bokeh-widgets-3.4.1.min.js\", \"https://cdn.bokeh.org/bokeh/release/bokeh-tables-3.4.1.min.js\", \"https://cdn.holoviz.org/panel/1.4.2/dist/panel.min.js\", \"https://cdn.jsdelivr.net/npm/@holoviz/geoviews@1.12.0/dist/geoviews.min.js\"];\n  var js_modules = [];\n  var js_exports = {};\n  var css_urls = [];\n  var inline_js = [    function(Bokeh) {\n      Bokeh.set_log_level(\"info\");\n    },\nfunction(Bokeh) {} // ensure no trailing comma for IE\n  ];\n\n  function run_inline_js() {\n    if ((root.Bokeh !== undefined) || (force === true)) {\n      for (var i = 0; i < inline_js.length; i++) {\n\ttry {\n          inline_js[i].call(root, root.Bokeh);\n\t} catch(e) {\n\t  if (!reloading) {\n\t    throw e;\n\t  }\n\t}\n      }\n      // Cache old bokeh versions\n      if (Bokeh != undefined && !reloading) {\n\tvar NewBokeh = root.Bokeh;\n\tif (Bokeh.versions === undefined) {\n\t  Bokeh.versions = new Map();\n\t}\n\tif (NewBokeh.version !== Bokeh.version) {\n\t  Bokeh.versions.set(NewBokeh.version, NewBokeh)\n\t}\n\troot.Bokeh = Bokeh;\n      }} else if (Date.now() < root._bokeh_timeout) {\n      setTimeout(run_inline_js, 100);\n    } else if (!root._bokeh_failed_load) {\n      console.log(\"Bokeh: BokehJS failed to load within specified timeout.\");\n      root._bokeh_failed_load = true;\n    }\n    root._bokeh_is_initializing = false\n  }\n\n  function load_or_wait() {\n    // Implement a backoff loop that tries to ensure we do not load multiple\n    // versions of Bokeh and its dependencies at the same time.\n    // In recent versions we use the root._bokeh_is_initializing flag\n    // to determine whether there is an ongoing attempt to initialize\n    // bokeh, however for backward compatibility we also try to ensure\n    // that we do not start loading a newer (Panel>=1.0 and Bokeh>3) version\n    // before older versions are fully initialized.\n    if (root._bokeh_is_initializing && Date.now() > root._bokeh_timeout) {\n      root._bokeh_is_initializing = false;\n      root._bokeh_onload_callbacks = undefined;\n      console.log(\"Bokeh: BokehJS was loaded multiple times but one version failed to initialize.\");\n      load_or_wait();\n    } else if (root._bokeh_is_initializing || (typeof root._bokeh_is_initializing === \"undefined\" && root._bokeh_onload_callbacks !== undefined)) {\n      setTimeout(load_or_wait, 100);\n    } else {\n      root._bokeh_is_initializing = true\n      root._bokeh_onload_callbacks = []\n      var bokeh_loaded = Bokeh != null && (Bokeh.version === py_version || (Bokeh.versions !== undefined && Bokeh.versions.has(py_version)));\n      if (!reloading && !bokeh_loaded) {\n\troot.Bokeh = undefined;\n      }\n      load_libs(css_urls, js_urls, js_modules, js_exports, function() {\n\tconsole.debug(\"Bokeh: BokehJS plotting callback run at\", now());\n\trun_inline_js();\n      });\n    }\n  }\n  // Give older versions of the autoload script a head-start to ensure\n  // they initialize before we start loading newer version.\n  setTimeout(load_or_wait, 100)\n}(window));",
+      "application/vnd.holoviews_load.v0+json": ""
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/javascript": "\nif ((window.PyViz === undefined) || (window.PyViz instanceof HTMLElement)) {\n  window.PyViz = {comms: {}, comm_status:{}, kernels:{}, receivers: {}, plot_index: []}\n}\n\n\n    function JupyterCommManager() {\n    }\n\n    JupyterCommManager.prototype.register_target = function(plot_id, comm_id, msg_handler) {\n      if (window.comm_manager || ((window.Jupyter !== undefined) && (Jupyter.notebook.kernel != null))) {\n        var comm_manager = window.comm_manager || Jupyter.notebook.kernel.comm_manager;\n        comm_manager.register_target(comm_id, function(comm) {\n          comm.on_msg(msg_handler);\n        });\n      } else if ((plot_id in window.PyViz.kernels) && (window.PyViz.kernels[plot_id])) {\n        window.PyViz.kernels[plot_id].registerCommTarget(comm_id, function(comm) {\n          comm.onMsg = msg_handler;\n        });\n      } else if (typeof google != 'undefined' && google.colab.kernel != null) {\n        google.colab.kernel.comms.registerTarget(comm_id, (comm) => {\n          var messages = comm.messages[Symbol.asyncIterator]();\n          function processIteratorResult(result) {\n            var message = result.value;\n            console.log(message)\n            var content = {data: message.data, comm_id};\n            var buffers = []\n            for (var buffer of message.buffers || []) {\n              buffers.push(new DataView(buffer))\n            }\n            var metadata = message.metadata || {};\n            var msg = {content, buffers, metadata}\n            msg_handler(msg);\n            return messages.next().then(processIteratorResult);\n          }\n          return messages.next().then(processIteratorResult);\n        })\n      }\n    }\n\n    JupyterCommManager.prototype.get_client_comm = function(plot_id, comm_id, msg_handler) {\n      if (comm_id in window.PyViz.comms) {\n        return window.PyViz.comms[comm_id];\n      } else if (window.comm_manager || ((window.Jupyter !== undefined) && (Jupyter.notebook.kernel != null))) {\n        var comm_manager = window.comm_manager || Jupyter.notebook.kernel.comm_manager;\n        var comm = comm_manager.new_comm(comm_id, {}, {}, {}, comm_id);\n        if (msg_handler) {\n          comm.on_msg(msg_handler);\n        }\n      } else if ((plot_id in window.PyViz.kernels) && (window.PyViz.kernels[plot_id])) {\n        var comm = window.PyViz.kernels[plot_id].connectToComm(comm_id);\n        comm.open();\n        if (msg_handler) {\n          comm.onMsg = msg_handler;\n        }\n      } else if (typeof google != 'undefined' && google.colab.kernel != null) {\n        var comm_promise = google.colab.kernel.comms.open(comm_id)\n        comm_promise.then((comm) => {\n          window.PyViz.comms[comm_id] = comm;\n          if (msg_handler) {\n            var messages = comm.messages[Symbol.asyncIterator]();\n            function processIteratorResult(result) {\n              var message = result.value;\n              var content = {data: message.data};\n              var metadata = message.metadata || {comm_id};\n              var msg = {content, metadata}\n              msg_handler(msg);\n              return messages.next().then(processIteratorResult);\n            }\n            return messages.next().then(processIteratorResult);\n          }\n        }) \n        var sendClosure = (data, metadata, buffers, disposeOnDone) => {\n          return comm_promise.then((comm) => {\n            comm.send(data, metadata, buffers, disposeOnDone);\n          });\n        };\n        var comm = {\n          send: sendClosure\n        };\n      }\n      window.PyViz.comms[comm_id] = comm;\n      return comm;\n    }\n    window.PyViz.comm_manager = new JupyterCommManager();\n    \n\n\nvar JS_MIME_TYPE = 'application/javascript';\nvar HTML_MIME_TYPE = 'text/html';\nvar EXEC_MIME_TYPE = 'application/vnd.holoviews_exec.v0+json';\nvar CLASS_NAME = 'output';\n\n/**\n * Render data to the DOM node\n */\nfunction render(props, node) {\n  var div = document.createElement(\"div\");\n  var script = document.createElement(\"script\");\n  node.appendChild(div);\n  node.appendChild(script);\n}\n\n/**\n * Handle when a new output is added\n */\nfunction handle_add_output(event, handle) {\n  var output_area = handle.output_area;\n  var output = handle.output;\n  if ((output.data == undefined) || (!output.data.hasOwnProperty(EXEC_MIME_TYPE))) {\n    return\n  }\n  var id = output.metadata[EXEC_MIME_TYPE][\"id\"];\n  var toinsert = output_area.element.find(\".\" + CLASS_NAME.split(' ')[0]);\n  if (id !== undefined) {\n    var nchildren = toinsert.length;\n    var html_node = toinsert[nchildren-1].children[0];\n    html_node.innerHTML = output.data[HTML_MIME_TYPE];\n    var scripts = [];\n    var nodelist = html_node.querySelectorAll(\"script\");\n    for (var i in nodelist) {\n      if (nodelist.hasOwnProperty(i)) {\n        scripts.push(nodelist[i])\n      }\n    }\n\n    scripts.forEach( function (oldScript) {\n      var newScript = document.createElement(\"script\");\n      var attrs = [];\n      var nodemap = oldScript.attributes;\n      for (var j in nodemap) {\n        if (nodemap.hasOwnProperty(j)) {\n          attrs.push(nodemap[j])\n        }\n      }\n      attrs.forEach(function(attr) { newScript.setAttribute(attr.name, attr.value) });\n      newScript.appendChild(document.createTextNode(oldScript.innerHTML));\n      oldScript.parentNode.replaceChild(newScript, oldScript);\n    });\n    if (JS_MIME_TYPE in output.data) {\n      toinsert[nchildren-1].children[1].textContent = output.data[JS_MIME_TYPE];\n    }\n    output_area._hv_plot_id = id;\n    if ((window.Bokeh !== undefined) && (id in Bokeh.index)) {\n      window.PyViz.plot_index[id] = Bokeh.index[id];\n    } else {\n      window.PyViz.plot_index[id] = null;\n    }\n  } else if (output.metadata[EXEC_MIME_TYPE][\"server_id\"] !== undefined) {\n    var bk_div = document.createElement(\"div\");\n    bk_div.innerHTML = output.data[HTML_MIME_TYPE];\n    var script_attrs = bk_div.children[0].attributes;\n    for (var i = 0; i < script_attrs.length; i++) {\n      toinsert[toinsert.length - 1].childNodes[1].setAttribute(script_attrs[i].name, script_attrs[i].value);\n    }\n    // store reference to server id on output_area\n    output_area._bokeh_server_id = output.metadata[EXEC_MIME_TYPE][\"server_id\"];\n  }\n}\n\n/**\n * Handle when an output is cleared or removed\n */\nfunction handle_clear_output(event, handle) {\n  var id = handle.cell.output_area._hv_plot_id;\n  var server_id = handle.cell.output_area._bokeh_server_id;\n  if (((id === undefined) || !(id in PyViz.plot_index)) && (server_id !== undefined)) { return; }\n  var comm = window.PyViz.comm_manager.get_client_comm(\"hv-extension-comm\", \"hv-extension-comm\", function () {});\n  if (server_id !== null) {\n    comm.send({event_type: 'server_delete', 'id': server_id});\n    return;\n  } else if (comm !== null) {\n    comm.send({event_type: 'delete', 'id': id});\n  }\n  delete PyViz.plot_index[id];\n  if ((window.Bokeh !== undefined) & (id in window.Bokeh.index)) {\n    var doc = window.Bokeh.index[id].model.document\n    doc.clear();\n    const i = window.Bokeh.documents.indexOf(doc);\n    if (i > -1) {\n      window.Bokeh.documents.splice(i, 1);\n    }\n  }\n}\n\n/**\n * Handle kernel restart event\n */\nfunction handle_kernel_cleanup(event, handle) {\n  delete PyViz.comms[\"hv-extension-comm\"];\n  window.PyViz.plot_index = {}\n}\n\n/**\n * Handle update_display_data messages\n */\nfunction handle_update_output(event, handle) {\n  handle_clear_output(event, {cell: {output_area: handle.output_area}})\n  handle_add_output(event, handle)\n}\n\nfunction register_renderer(events, OutputArea) {\n  function append_mime(data, metadata, element) {\n    // create a DOM node to render to\n    var toinsert = this.create_output_subarea(\n    metadata,\n    CLASS_NAME,\n    EXEC_MIME_TYPE\n    );\n    this.keyboard_manager.register_events(toinsert);\n    // Render to node\n    var props = {data: data, metadata: metadata[EXEC_MIME_TYPE]};\n    render(props, toinsert[0]);\n    element.append(toinsert);\n    return toinsert\n  }\n\n  events.on('output_added.OutputArea', handle_add_output);\n  events.on('output_updated.OutputArea', handle_update_output);\n  events.on('clear_output.CodeCell', handle_clear_output);\n  events.on('delete.Cell', handle_clear_output);\n  events.on('kernel_ready.Kernel', handle_kernel_cleanup);\n\n  OutputArea.prototype.register_mime_type(EXEC_MIME_TYPE, append_mime, {\n    safe: true,\n    index: 0\n  });\n}\n\nif (window.Jupyter !== undefined) {\n  try {\n    var events = require('base/js/events');\n    var OutputArea = require('notebook/js/outputarea').OutputArea;\n    if (OutputArea.prototype.mime_types().indexOf(EXEC_MIME_TYPE) == -1) {\n      register_renderer(events, OutputArea);\n    }\n  } catch(err) {\n  }\n}\n",
+      "application/vnd.holoviews_load.v0+json": ""
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<style>*[data-root-id],\n",
+       "*[data-root-id] > * {\n",
+       "  box-sizing: border-box;\n",
+       "  font-family: var(--jp-ui-font-family);\n",
+       "  font-size: var(--jp-ui-font-size1);\n",
+       "  color: var(--vscode-editor-foreground, var(--jp-ui-font-color1));\n",
+       "}\n",
+       "\n",
+       "/* Override VSCode background color */\n",
+       ".cell-output-ipywidget-background:has(\n",
+       "    > .cell-output-ipywidget-background > .lm-Widget > *[data-root-id]\n",
+       "  ),\n",
+       ".cell-output-ipywidget-background:has(> .lm-Widget > *[data-root-id]) {\n",
+       "  background-color: transparent !important;\n",
+       "}\n",
+       "</style>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.holoviews_exec.v0+json": "",
+      "text/html": [
+       "<div id='p1009'>\n",
+       "  <div id=\"d67e852e-e28d-4878-8115-bd419a4beeed\" data-root-id=\"p1009\" style=\"display: contents;\"></div>\n",
+       "</div>\n",
+       "<script type=\"application/javascript\">(function(root) {\n",
+       "  var docs_json = {\"4f2b357e-9572-411a-8046-8829ed981928\":{\"version\":\"3.4.1\",\"title\":\"Bokeh Application\",\"roots\":[{\"type\":\"object\",\"name\":\"panel.models.browser.BrowserInfo\",\"id\":\"p1009\"},{\"type\":\"object\",\"name\":\"panel.models.comm_manager.CommManager\",\"id\":\"p1010\",\"attributes\":{\"plot_id\":\"p1009\",\"comm_id\":\"042eeee4c7924effaf8a9818694c3bd7\",\"client_comm_id\":\"d1567d6b107648b1b073ded659433bbd\"}}],\"defs\":[{\"type\":\"model\",\"name\":\"ReactiveHTML1\"},{\"type\":\"model\",\"name\":\"FlexBox1\",\"properties\":[{\"name\":\"align_content\",\"kind\":\"Any\",\"default\":\"flex-start\"},{\"name\":\"align_items\",\"kind\":\"Any\",\"default\":\"flex-start\"},{\"name\":\"flex_direction\",\"kind\":\"Any\",\"default\":\"row\"},{\"name\":\"flex_wrap\",\"kind\":\"Any\",\"default\":\"wrap\"},{\"name\":\"gap\",\"kind\":\"Any\",\"default\":\"\"},{\"name\":\"justify_content\",\"kind\":\"Any\",\"default\":\"flex-start\"}]},{\"type\":\"model\",\"name\":\"FloatPanel1\",\"properties\":[{\"name\":\"config\",\"kind\":\"Any\",\"default\":{\"type\":\"map\"}},{\"name\":\"contained\",\"kind\":\"Any\",\"default\":true},{\"name\":\"position\",\"kind\":\"Any\",\"default\":\"right-top\"},{\"name\":\"offsetx\",\"kind\":\"Any\",\"default\":null},{\"name\":\"offsety\",\"kind\":\"Any\",\"default\":null},{\"name\":\"theme\",\"kind\":\"Any\",\"default\":\"primary\"},{\"name\":\"status\",\"kind\":\"Any\",\"default\":\"normalized\"}]},{\"type\":\"model\",\"name\":\"GridStack1\",\"properties\":[{\"name\":\"mode\",\"kind\":\"Any\",\"default\":\"warn\"},{\"name\":\"ncols\",\"kind\":\"Any\",\"default\":null},{\"name\":\"nrows\",\"kind\":\"Any\",\"default\":null},{\"name\":\"allow_resize\",\"kind\":\"Any\",\"default\":true},{\"name\":\"allow_drag\",\"kind\":\"Any\",\"default\":true},{\"name\":\"state\",\"kind\":\"Any\",\"default\":[]}]},{\"type\":\"model\",\"name\":\"drag1\",\"properties\":[{\"name\":\"slider_width\",\"kind\":\"Any\",\"default\":5},{\"name\":\"slider_color\",\"kind\":\"Any\",\"default\":\"black\"},{\"name\":\"value\",\"kind\":\"Any\",\"default\":50}]},{\"type\":\"model\",\"name\":\"click1\",\"properties\":[{\"name\":\"terminal_output\",\"kind\":\"Any\",\"default\":\"\"},{\"name\":\"debug_name\",\"kind\":\"Any\",\"default\":\"\"},{\"name\":\"clears\",\"kind\":\"Any\",\"default\":0}]},{\"type\":\"model\",\"name\":\"FastWrapper1\",\"properties\":[{\"name\":\"object\",\"kind\":\"Any\",\"default\":null},{\"name\":\"style\",\"kind\":\"Any\",\"default\":null}]},{\"type\":\"model\",\"name\":\"NotificationAreaBase1\",\"properties\":[{\"name\":\"js_events\",\"kind\":\"Any\",\"default\":{\"type\":\"map\"}},{\"name\":\"position\",\"kind\":\"Any\",\"default\":\"bottom-right\"},{\"name\":\"_clear\",\"kind\":\"Any\",\"default\":0}]},{\"type\":\"model\",\"name\":\"NotificationArea1\",\"properties\":[{\"name\":\"js_events\",\"kind\":\"Any\",\"default\":{\"type\":\"map\"}},{\"name\":\"notifications\",\"kind\":\"Any\",\"default\":[]},{\"name\":\"position\",\"kind\":\"Any\",\"default\":\"bottom-right\"},{\"name\":\"_clear\",\"kind\":\"Any\",\"default\":0},{\"name\":\"types\",\"kind\":\"Any\",\"default\":[{\"type\":\"map\",\"entries\":[[\"type\",\"warning\"],[\"background\",\"#ffc107\"],[\"icon\",{\"type\":\"map\",\"entries\":[[\"className\",\"fas fa-exclamation-triangle\"],[\"tagName\",\"i\"],[\"color\",\"white\"]]}]]},{\"type\":\"map\",\"entries\":[[\"type\",\"info\"],[\"background\",\"#007bff\"],[\"icon\",{\"type\":\"map\",\"entries\":[[\"className\",\"fas fa-info-circle\"],[\"tagName\",\"i\"],[\"color\",\"white\"]]}]]}]}]},{\"type\":\"model\",\"name\":\"Notification\",\"properties\":[{\"name\":\"background\",\"kind\":\"Any\",\"default\":null},{\"name\":\"duration\",\"kind\":\"Any\",\"default\":3000},{\"name\":\"icon\",\"kind\":\"Any\",\"default\":null},{\"name\":\"message\",\"kind\":\"Any\",\"default\":\"\"},{\"name\":\"notification_type\",\"kind\":\"Any\",\"default\":null},{\"name\":\"_destroyed\",\"kind\":\"Any\",\"default\":false}]},{\"type\":\"model\",\"name\":\"TemplateActions1\",\"properties\":[{\"name\":\"open_modal\",\"kind\":\"Any\",\"default\":0},{\"name\":\"close_modal\",\"kind\":\"Any\",\"default\":0}]},{\"type\":\"model\",\"name\":\"BootstrapTemplateActions1\",\"properties\":[{\"name\":\"open_modal\",\"kind\":\"Any\",\"default\":0},{\"name\":\"close_modal\",\"kind\":\"Any\",\"default\":0}]},{\"type\":\"model\",\"name\":\"TemplateEditor1\",\"properties\":[{\"name\":\"layout\",\"kind\":\"Any\",\"default\":[]}]},{\"type\":\"model\",\"name\":\"MaterialTemplateActions1\",\"properties\":[{\"name\":\"open_modal\",\"kind\":\"Any\",\"default\":0},{\"name\":\"close_modal\",\"kind\":\"Any\",\"default\":0}]},{\"type\":\"model\",\"name\":\"copy_to_clipboard1\",\"properties\":[{\"name\":\"fill\",\"kind\":\"Any\",\"default\":\"none\"},{\"name\":\"value\",\"kind\":\"Any\",\"default\":null}]}]}};\n",
+       "  var render_items = [{\"docid\":\"4f2b357e-9572-411a-8046-8829ed981928\",\"roots\":{\"p1009\":\"d67e852e-e28d-4878-8115-bd419a4beeed\"},\"root_ids\":[\"p1009\"]}];\n",
+       "  var docs = Object.values(docs_json)\n",
+       "  if (!docs) {\n",
+       "    return\n",
+       "  }\n",
+       "  const py_version = docs[0].version.replace('rc', '-rc.').replace('.dev', '-dev.')\n",
+       "  function embed_document(root) {\n",
+       "    var Bokeh = get_bokeh(root)\n",
+       "    Bokeh.embed.embed_items_notebook(docs_json, render_items);\n",
+       "    for (const render_item of render_items) {\n",
+       "      for (const root_id of render_item.root_ids) {\n",
+       "\tconst id_el = document.getElementById(root_id)\n",
+       "\tif (id_el.children.length && (id_el.children[0].className === 'bk-root')) {\n",
+       "\t  const root_el = id_el.children[0]\n",
+       "\t  root_el.id = root_el.id + '-rendered'\n",
+       "\t}\n",
+       "      }\n",
+       "    }\n",
+       "  }\n",
+       "  function get_bokeh(root) {\n",
+       "    if (root.Bokeh === undefined) {\n",
+       "      return null\n",
+       "    } else if (root.Bokeh.version !== py_version) {\n",
+       "      if (root.Bokeh.versions === undefined || !root.Bokeh.versions.has(py_version)) {\n",
+       "\treturn null\n",
+       "      }\n",
+       "      return root.Bokeh.versions.get(py_version);\n",
+       "    } else if (root.Bokeh.version === py_version) {\n",
+       "      return root.Bokeh\n",
+       "    }\n",
+       "    return null\n",
+       "  }\n",
+       "  function is_loaded(root) {\n",
+       "    var Bokeh = get_bokeh(root)\n",
+       "    return (Bokeh != null && Bokeh.Panel !== undefined)\n",
+       "  }\n",
+       "  if (is_loaded(root)) {\n",
+       "    embed_document(root);\n",
+       "  } else {\n",
+       "    var attempts = 0;\n",
+       "    var timer = setInterval(function(root) {\n",
+       "      if (is_loaded(root)) {\n",
+       "        clearInterval(timer);\n",
+       "        embed_document(root);\n",
+       "      } else if (document.readyState == \"complete\") {\n",
+       "        attempts++;\n",
+       "        if (attempts > 200) {\n",
+       "          clearInterval(timer);\n",
+       "\t  var Bokeh = get_bokeh(root)\n",
+       "\t  if (Bokeh == null || Bokeh.Panel == null) {\n",
+       "            console.warn(\"Panel: ERROR: Unable to run Panel code because Bokeh or Panel library is missing\");\n",
+       "\t  } else {\n",
+       "\t    console.warn(\"Panel: WARNING: Attempting to render but not all required libraries could be resolved.\")\n",
+       "\t    embed_document(root)\n",
+       "\t  }\n",
+       "        }\n",
+       "      }\n",
+       "    }, 25, root)\n",
+       "  }\n",
+       "})(window);</script>"
+      ]
+     },
+     "metadata": {
+      "application/vnd.holoviews_exec.v0+json": {
+       "id": "p1009"
+      }
+     },
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "<div class=\"logo-block\">\n",
+       "<img src='data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAEAAAABACAYAAACqaXHeAAAABHNCSVQICAgIfAhkiAAAAAlwSFlz\n",
+       "AAAB+wAAAfsBxc2miwAAABl0RVh0U29mdHdhcmUAd3d3Lmlua3NjYXBlLm9yZ5vuPBoAAA6zSURB\n",
+       "VHic7ZtpeFRVmsf/5966taWqUlUJ2UioBBJiIBAwCZtog9IOgjqACsogKtqirT2ttt069nQ/zDzt\n",
+       "tI4+CrJIREFaFgWhBXpUNhHZQoKBkIUASchWla1S+3ar7r1nPkDaCAnZKoQP/D7mnPOe9/xy76n3\n",
+       "nFSAW9ziFoPFNED2LLK5wcyBDObkb8ZkxuaoSYlI6ZcOKq1eWFdedqNzGHQBk9RMEwFAASkk0Xw3\n",
+       "ETacDNi2vtvc7L0ROdw0AjoSotQVkKSvHQz/wRO1lScGModBFbDMaNRN1A4tUBCS3lk7BWhQkgpD\n",
+       "lG4852/+7DWr1R3uHAZVQDsbh6ZPN7CyxUrCzJMRouusj0ipRwD2uKm0Zn5d2dFwzX1TCGhnmdGo\n",
+       "G62Nna+isiUqhkzuKrkQaJlPEv5mFl2fvGg2t/VnzkEV8F5ioioOEWkLG86fvbpthynjdhXYZziQ\n",
+       "x1hC9J2NFyi8vCTt91Fh04KGip0AaG9zuCk2wQCVyoNU3Hjezee9bq92duzzTmxsRJoy+jEZZZYo\n",
+       "GTKJ6SJngdJqAfRzpze0+jHreUtPc7gpBLQnIYK6BYp/uGhw9YK688eu7v95ysgshcg9qSLMo3JC\n",
+       "4jqLKQFBgdKDPoQ+Pltb8dUyQLpeDjeVgI6EgLIQFT5tEl3rn2losHVsexbZ3EyT9wE1uGdkIPcy\n",
+       "BGxn8QUq1QrA5nqW5i2tLqvrrM9NK6AdkVIvL9E9bZL/oyfMVd/jqvc8LylzRBKDJSzIExwhQzuL\n",
+       "QYGQj4rHfFTc8mUdu3E7yoLtbTe9gI4EqVgVkug2i5+uXGo919ixbRog+3fTbQ8qJe4ZOYNfMoTI\n",
+       "OoshUNosgO60AisX15aeI2PSIp5KiFLI9ubb1vV3Qb2ltwLakUCDAkWX7/nHKRmmGIl9VgYsUhJm\n",
+       "2NXjKYADtM1ygne9QQDIXlk49FBstMKx66D1v4+XuQr7vqTe0VcBHQlRWiOCbmmSYe2SqtL6q5rJ\n",
+       "zsTb7lKx3FKOYC4DoqyS/B5bvLPxvD9Qtf6saxYLQGJErmDOdOMr/zo96km1nElr8bmPOBwI9COv\n",
+       "HnFPRIwmkSOv9kcAS4heRsidOkpeWBgZM+UBrTFAXNYL5Vf2ii9c1trNzpYdaoVil3WIc+wdk+gQ\n",
+       "noie3ecCcxt9ITcLAPWt/laGEO/9U6PmzZkenTtsSMQ8uYywJVW+grCstAvCIaAdArAsIWkRDDs/\n",
+       "KzLm2YcjY1Lv0UdW73HabE9n6V66cxSzfEmuJssTpKGVp+0vHq73FwL46eOjpMpbRAnNmJFrGJNu\n",
+       "Ukf9Yrz+3rghiumCKNXXWPhLYcjxGsIpoCMsIRoFITkW8AuyM8jC1+/QLx4bozCEJIq38+1rtpR6\n",
+       "V/yzb8eBlRb3fo5l783N0CWolAzJHaVNzkrTzlEp2bQ2q3TC5gn6wpnoQAmwSiGh2GitnTmVMc5O\n",
+       "UyfKWUKCIsU7+fZDKwqdT6DDpvkzAX4/+AMFjk0tDp5GRXLpQ2MUmhgDp5gxQT8+Y7hyPsMi8uxF\n",
+       "71H0oebujHALECjFKaW9Lm68n18wXp2kVzIcABytD5iXFzg+WVXkegpAsOOYziqo0OkK76GyquC3\n",
+       "ltZAzMhhqlSNmmWTE5T6e3IN05ITFLM4GdN0vtZ3ob8Jh1NAKXFbm5PtLU/eqTSlGjkNAJjdgn/N\n",
+       "aedXa0tdi7+t9G0FIF49rtMSEgAs1kDLkTPO7ebm4IUWeyh1bKomXqlgMG6kJmHcSM0clYLJ8XtR\n",
+       "1GTnbV3F6I5wCGikAb402npp1h1s7LQUZZSMIfALFOuL3UUrfnS8+rez7v9qcold5tilgHbO1fjK\n",
+       "9ubb17u9oshxzMiUBKXWqJNxd+fqb0tLVs4lILFnK71H0Ind7uiPgACVcFJlrb0tV6DzxqqTIhUM\n",
+       "CwDf1/rrVhTa33/3pGPxJYdQ2l2cbgVcQSosdx8uqnDtbGjh9SlDVSMNWhlnilfqZk42Th2ZpLpf\n",
+       "xrHec5e815zrr0dfBZSwzkZfqsv+1FS1KUknUwPARVvItfKUY+cn57yP7qv07UE3p8B2uhUwLk09\n",
+       "e0SCOrK+hbdYHYLjRIl71wWzv9jpEoeOHhGRrJAzyEyNiJuUqX0g2sBN5kGK6y2Blp5M3lsB9Qh4\n",
+       "y2Ja6x6+i0ucmKgwMATwhSjdUu49tKrQ/pvN5d53ml2CGwCmJipmKjgmyuaXzNeL2a0AkQ01Th5j\n",
+       "2DktO3Jyk8f9vcOBQHV94OK+fPumJmvQHxJoWkaKWq9Vs+yUsbq0zGT1I4RgeH2b5wef7+c7bl8F\n",
+       "eKgoHVVZa8ZPEORzR6sT1BzDUAD/d9F78e2Tzv99v8D+fLVTqAKAsbGamKey1Mt9Ann4eH3gTXTz\n",
+       "idWtAJ8PQWOk7NzSeQn/OTHDuEikVF1R4z8BQCy+6D1aWRfY0tTGG2OM8rRoPaeIj5ZHzJxszElN\n",
+       "VM8K8JS5WOfv8mzRnQAKoEhmt8gyPM4lU9SmBK1MCQBnW4KONT86v1hZ1PbwSXPw4JWussVjtH9Y\n",
+       "NCoiL9UoH/6PSu8jFrfY2t36erQHXLIEakMi1SydmzB31h3GGXFDFNPaK8Rme9B79Ixrd0WN+1ij\n",
+       "NRQ/doRmuFLBkHSTOm5GruG+pFjFdAmorG4IXH1Qua6ASniclfFtDYt+oUjKipPrCQB7QBQ2lrgP\n",
+       "fFzm+9XWUtcqJ3/5vDLDpJ79XHZk3u8nGZ42qlj1+ydtbxysCezrydp6ugmipNJ7WBPB5tydY0jP\n",
+       "HaVNzs3QzeE4ZpTbI+ZbnSFPbVOw9vsfnVvqWnirPyCNGD08IlqtYkh2hjZ5dErEQzoNm+6ykyOt\n",
+       "Lt5/PQEuSRRKo22VkydK+vvS1XEKlhCJAnsqvcVvH7f/ZU2R67eXbMEGAMiIV5oWZWiWvz5Fv2xG\n",
+       "sjqNJQRvn3Rs2lji/lNP19VjAQDgD7FHhujZB9OGqYxRkZxixgRDVlqS6uEOFaJUVu0rPFzctrnF\n",
+       "JqijImVp8dEKVWyUXDk92zAuMZ6bFwpBU1HrOw6AdhQgUooChb0+ItMbWJitSo5Ws3IAOGEOtL53\n",
+       "0vHZih9sC4vtofZ7Qu6523V/fmGcds1TY3V36pUsBwAbSlxnVh2xLfAD/IAIMDf7XYIkNmXfpp2l\n",
+       "18rkAJAy9HKFaIr/qULkeQQKy9zf1JgDB2uaeFNGijo5QsUyacNUUTOnGO42xSnv4oOwpDi1zYkc\n",
+       "efUc3I5Gk6PhyTuVKaOGyLUAYPGIoY9Pu/atL/L92+4q9wbflRJ2Trpm/jPjdBtfnqB/dIThcl8A\n",
+       "KG7hbRuKnb8qsQsVvVlTrwQAQMUlf3kwJI24Z4JhPMtcfng5GcH49GsrxJpGvvHIaeem2ma+KSjQ\n",
+       "lIwUdYyCY8j4dE1KzijNnIP2llF2wcXNnsoapw9XxsgYAl6k+KzUXbi2yP3KR2ecf6z3BFsBICdW\n",
+       "nvnIaG3eHybqX7vbpEqUMT+9OL4Qpe8VON7dXuFd39v19FoAABRVePbGGuXTszO0P7tu6lghUonE\n",
+       "llRdrhArLvmKdh9u29jcFiRRkfLUxBiFNiqSU9icoZQHo5mYBI1MBgBH6wMNb+U7Pnw337H4gi1Y\n",
+       "ciWs+uks3Z9fztUvfzxTm9Ne8XXkvQLHNytOOZeiD4e0PgkAIAYCYknKUNUDSXEKzdWNpnil7r4p\n",
+       "xqkjTarZMtk/K8TQ6Qve78qqvXurGwIJqcOUKfUWHsm8KGvxSP68YudXq4pcj39X49uOK2X142O0\n",
+       "Tz5/u/7TVybqH0rSya6ZBwD21/gubbrgWdDgEOx9WUhfBaC2ibcEBYm7a7x+ukrBMNcEZggyR0TE\n",
+       "T8zUPjikQ4VosQZbTpS4vqizBKvqmvjsqnpfzaZyx9JPiz1/bfGKdgD45XB1zoIMzYbfTdS/NClB\n",
+       "Gct0USiY3YL/g0LHy/uq/Ef6uo5+n0R/vyhp17Klpge763f8rMu6YU/zrn2nml+2WtH+Z+5IAAFc\n",
+       "2bUTdTDOSNa9+cQY7YLsOIXhevEkCvzph7a8laecz/Un/z4/Ae04XeL3UQb57IwU9ZDr9UuKVajv\n",
+       "nxp1+1UVIo/LjztZkKH59fO3G/JemqCfmaCRqbqbd90ZZ8FfjtkfAyD0J/9+C2h1hDwsSxvGjNDc\n",
+       "b4zk5NfrSwiQblLHzZhg+Jf4aPlUwpDqkQqa9nimbt1/TDH8OitGMaQnj+RJS6B1fbF7SY1TqO5v\n",
+       "/v0WAADl1f7zokgS7s7VT2DZ7pegUjBM7mjtiDZbcN4j0YrHH0rXpCtY0qPX0cVL0rv5jv/ZXend\n",
+       "0u/EESYBAFBU4T4Qa5TflZOhTe7pmKpaP8kCVUVw1+yhXfJWvn1P3hnXi33JsTN6PnP3hHZ8Z3/h\n",
+       "aLHzmkNPuPj7Bc/F/Q38CwjTpSwQXgE4Vmwry9tpfq/ZFgqFMy4AVDtCvi8rvMvOmv0N4YwbVgEA\n",
+       "sPM72/KVnzfspmH7HQGCRLG2yL1+z8XwvPcdCbsAANh+xPzstgMtxeGKt+6MK3/tacfvwhWvIwMi\n",
+       "oKEBtm0H7W+UVfkc/Y1V0BhoPlDr/w1w/eu1vjIgAgDg22OtX6/eYfnEz/focrZTHAFR+PSs56/7\n",
+       "q32nwpjazxgwAQCwcU/T62t3WL7r6/jVRa6/byp1rei+Z98ZUAEAhEPHPc8fKnTU9nbgtnOe8h0l\n",
+       "9hcGIqmODLQAHCy2Xti6v/XNRivf43f4fFvIteu854+VHnR7q9tfBlwAAGz+pnndB9vM26UebAe8\n",
+       "SLHujPOTPVW+rwY+sxskAAC2HrA8t2Vvc7ffP1r9o+vwR2dcr92InIAbKKC1FZ5tB1tf+/G8p8sv\n",
+       "N/9Q5zd/XR34LYCwV5JdccMEAMDBk45DH243r/X4xGvqxFa/GNpS7n6rwOwNWwHVE26oAADYurf1\n",
+       "zx/utOzt+DMKYM0p17YtZZ5VNzqfsB2HewG1WXE8PoZ7gOclbTIvynZf9JV+fqZtfgs/8F/Nu5rB\n",
+       "EIBmJ+8QRMmpU7EzGRsf2FzuePqYRbzh/zE26EwdrT10f6r6o8HOYzCJB9Dpff8tbnGLG8L/A/WE\n",
+       "roTBs2RqAAAAAElFTkSuQmCC'\n",
+       "     style='height:25px; border-radius:12px; display: inline-block; float: left; vertical-align: middle'></img>\n",
+       "\n",
+       "\n",
+       "  <img src='data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACMAAAAjCAYAAAAe2bNZAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAAK6wAACusBgosNWgAAABx0RVh0U29mdHdhcmUAQWRvYmUgRmlyZXdvcmtzIENTNui8sowAAAf9SURBVFiFvZh7cFTVHcc/59y7793sJiFAwkvAYDRqFWwdraLVlj61diRYsDjqCFbFKrYo0CltlSq1tLaC2GprGIriGwqjFu10OlrGv8RiK/IICYECSWBDkt3s695zTv9IAtlHeOn0O7Mzu797z+/3Ob/z+p0VfBq9doNFljuABwAXw2PcvGHt6bgwxhz7Ls4YZNVXxxANLENwE2D1W9PAGmAhszZ0/X9gll5yCbHoOirLzmaQs0F6F8QMZq1v/8xgNm7DYwwjgXJLYL4witQ16+sv/U9HdDmV4WrKw6B06cZC/RMrM4MZ7xz61DAbtzEXmAvUAX4pMOVecg9/MFFu3j3Gz7gQBLygS2RGumBkL0cubiFRsR3LzVBV1UMk3IrW73PT9C2lYOwhQB4ClhX1AuKpjLcV27oEjyUpNUJCg1CvcejykWTCXyQgzic2HIIBjg3pS6+uRLKAhumZvD4U+tq0jTrgkVKQQtLekfTtxIPAkhTNF6G7kZm7aPp6M9myKVQEoaYaIhEQYvD781DML/RfBGNZXAl4irJiwBa07e/y7cQnBaJghIX6ENl2GR/fGCBoz6cm5qeyEqQA5ZYA5x5eeiV0Qph4gjFAUSwAr6QllQgcxS/Jm25Cr2Tmpsk03XI9NfI31FTZBEOgVOk51adqDBNPCNPSRlkiDXbBEwOU2WxH+I7itQZ62g56OjM33suq1YsZHVtGZSUI2QdyYgkgOthQNIF7BIGDnRAJgJSgj69cUx1gB8PkOGwL4E1gPrM27gIg7NlGKLQApc7BmEnAxP5g/rw4YqBrCDB5xHkw5rdR/1qTrN/hKNo6YUwVDNpFsnjYS8RbidBPcPXFP6R6yfExuOXmN4A3jv1+8ZUwgY9D2OWjUZE6lO88jDwHI8ZixGiMKSeYTBamCoDk6kDAb6y1OcH1a6KpD/fZesoFw5FlIXAVCIiH4PxrV+p2npVDToTBmtjY8t1swh2V61E9KqWiyuPEjM8dbfxuvfa49Zayf9R136Wr8mBSf/T7bNteA8zwaGEUbFpckWwq95n59dUIywKl2fbOIS5e8bWSu0tJ1a5redAYfqkdjesodFajcgaVNWhXo1C9SrkN3Usmv3UMJrc6/DDwkwEntkEJLe67tSLhvyzK8rHDQWleve5CGk4VZEB1r+5bg2E2si+Y0QatDK6jUVkX5eg2YYlp++ZM+rfMNYamAj8Y7MAVWFqaR1f/t2xzU4IHjybBtthzuiAASqv7jTF7jOqDMAakFHgDNsFyP+FhwZHBmH9F7cutIYkQCylYYv1AZSqsn1/+bX51OMMjPSl2nAnM7hnjOx2v53YgNWAzHM9Q/9l0lQWPSCBSyokAtOBC1Rj+w/1Xs+STDp4/E5g7Rs2zm2+oeVd7PUuHKDf6A4r5EsPT5K3gfCnBXNUYnvGzb+KcCczYYWOnLpy4eOXuG2oec0PBN8XQQAnpvS35AvAykr56rWhPBiV4MvtceGLxk5Mr6A1O8IfK7rl7xJ0r9kyumuP4fa0lMqTBLJIAJqEf1J3qE92lMBndlyfRD2YBghHC4hlny7ASqCeWo5zaoDdIWfnIefNGTb9fC73QDfhyBUCNOxrGPSUBfPem9us253YTV+3mcBbdkUYfzmHiLqZbYdIGHHON2ZlemXouaJUOO6TqtdHEQuXYY8Yt+EbDgmlS6RdzkaDTv2P9A3gICiq93sWhb5mc5wVhuU3Y7m5hOc3So7qFT3SLgOXHb/cyOfMn7xROegoC/PTcn3v8gbKPgDopJFk3R/uBPWQiwQ+2/GJevRMObLUzqe/saJjQUQTTftEVMW9tWxPgAocwcj9abNcZe7s+6t2R2xXZG7zyYLp8Q1PiRBBHym5bYuXi8Qt+/LvGu9f/5YDAxABsaRNPH6Xr4D4Sk87a897SOy9v/fKwjoF2eQel95yDESGEF6gEMwKhLwKus3wOVjTtes7qzgLdXTMnNCNoEpbcrtNuq6N7Xh/+eqcbj94xQkp7mdKpW5XbtbR8Z26kgMCAf2UU5YEovRUVRHbu2b3vK1UdDFkDCyMRQxbpdv8nhKAGIa7QaQedzT07fFPny53R738JoVYBdVrnsNx9XZ9v33UeGO+AA2MMUkgqQ5UcdDLZSFeVgONnXeHqSAC5Ew1BXwko0D1Zct3dT1duOjS3MzZnEUJtBuoQAq3SGOLR4ekjn9NC5nVOaYXf9lETrUkmOJy3pOz8OKIb2A1cWhJCCEzOxU2mUPror+2/L3yyM3pkM7jTjr1nBOgkGeyQ7erxpdJsMAS9wb2F9rzMxNY1K2PMU0WtZV82VU8Wp6vbKJVo9Lx/+4cydORdxCCQ/kDGTZCWsRpLu7VD7bfKqL8V2orKTp/PtzaXy42jr6TwAuisi+7JolUG4wY+8vyrISCMtRrLKWpvjAOqx/QGhp0rjRo5xD3x98CWQuOQN8qumRMmI7jKZPUEpzNVZsj4Zbaq1to5tZZsKIydLWojhIXrJnES79EaOzv3du2NytKuxzJKAA6wF8xqEE8s2jo/1wd/khslQGxd81Zg62Bbp31XBH+iETt7Y3ELA0iU6iGDlQ5mexe0VEx4a3x8V1AaYwFJgTiwaOsDmeK2J8nMUOqsnB1A+dcA04ucCYt0urkjmflk9iT2v30q/gZn5rQPvor4n9Ou634PeBzoznes/iot/7WnClKoM/+zCIjH5kwT8ChQjTHPIPTjFV3PpU/Hx+DM/A9U3IXI4SPCYAAAAABJRU5ErkJggg=='\n",
+       "       style='height:15px; border-radius:12px; display: inline-block; float: left'></img>\n",
+       "  \n",
+       "\n",
+       "\n",
+       "\n",
+       "\n",
+       "</div>\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "import clearwater_riverine as cwr"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "66bddd72-10d7-42f1-ad02-b8cc1e9a4cbf",
+   "metadata": {},
+   "source": [
+    "### Import ClearWater-Modules"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e56f2ee1-c9f6-4517-8f77-57d34c387b74",
+   "metadata": {},
+   "source": [
+    "We will also need to install Clearwater Modules' `Energy Budget` module. While this package is also still under development, the best way to install is with `conda develop`. You will need to clone the [ClearWater Modules](https://github.com/EcohydrologyTeam/ClearWater-modules) repository. Then, use conda develop pointing to the path of your `clearwater-modules` folder like below.\n",
+    "\n",
+    "NOTE: You will need to find this path yourself. Remember that if your path has any blank spaces, you must enclose the path with quotes."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "d081f53f-f7ef-4edb-81f2-e9cbcfcfabe6",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "path exists, skipping d:\\Clearwater\\ClearWater-riverine\\examples\\'\\Users\\aaufdenkampe\\Documents\\Python\\ClearWater-modules\\src'\n",
+      "completed operation for: d:\\Clearwater\\ClearWater-riverine\\examples\\'\\Users\\aaufdenkampe\\Documents\\Python\\ClearWater-modules\\src'\n"
+     ]
+    }
+   ],
+   "source": [
+    "!conda develop '/Users/aaufdenkampe/Documents/Python/ClearWater-modules/src'"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cd44e256",
+   "metadata": {},
+   "source": [
+    "You now need to restart the Python kernel for this notebook, if the path didn't already exist."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "ec258d25-c3b2-4b7e-a511-40f65c6058bc",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from clearwater_modules.nsm1.model import NutrientBudget"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fb9b46da-dde2-42ca-a156-4320b9b55ba3",
+   "metadata": {},
+   "source": [
+    "## Instantiate Models\n",
+    "### Clearwater-Riverine\n",
+    "\n",
+    "Ensure that you have followed the instructions in the Data Availability Section, and that you have all files downloaded in `examples/data_temp/sumwere_creek_coarse_p38`. For a more detailed explanation of all the steps in this process, please see [01_getting_started_riverine.ipynb](./01_getting_started_riverine.ipynb)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "ae2ef0cd-b448-405a-bfb7-ea69f4bd638f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "network_path = Path(r'W:\\2ERDC12 - Clearwater\\Clearwater_testing_NSM\\plan_48_simulation')\n",
+    "wetted_surface_area_path = network_path / \"wetted_surface_area.zarr\"\n",
+    "q_solar_path = network_path / 'cwr_boundary_conditions_q_solar_p28.csv'\n",
+    "air_temp_path = network_path / 'cwr_boundary_conditions_TairC_p28.csv'\n",
+    "config_file = network_path / 'demo_config.yml'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "c1f71478",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "True"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "#flow_field_fpath.exists()\n",
+    "config_file.exists()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "8a8eb193",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "0 172800\n"
+     ]
+    }
+   ],
+   "source": [
+    "start_index =  0 # int((8*60*60)/30)\n",
+    "end_index = 48*60*60\n",
+    "print(start_index, end_index)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "de6f3781",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Populating Model Mesh...\n",
+      "Calculating Required Parameters...\n",
+      "CPU times: total: 1.41 s\n",
+      "Wall time: 1.82 s\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%time\n",
+    "transport_model = cwr.ClearwaterRiverine(\n",
+    "    config_filepath=config_file,\n",
+    "    verbose=True,\n",
+    "    datetime_range= (start_index, end_index)\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "8fb5383b",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div><svg style=\"position: absolute; width: 0; height: 0; overflow: hidden\">\n",
+       "<defs>\n",
+       "<symbol id=\"icon-database\" viewBox=\"0 0 32 32\">\n",
+       "<path d=\"M16 0c-8.837 0-16 2.239-16 5v4c0 2.761 7.163 5 16 5s16-2.239 16-5v-4c0-2.761-7.163-5-16-5z\"></path>\n",
+       "<path d=\"M16 17c-8.837 0-16-2.239-16-5v6c0 2.761 7.163 5 16 5s16-2.239 16-5v-6c0 2.761-7.163 5-16 5z\"></path>\n",
+       "<path d=\"M16 26c-8.837 0-16-2.239-16-5v6c0 2.761 7.163 5 16 5s16-2.239 16-5v-6c0 2.761-7.163 5-16 5z\"></path>\n",
+       "</symbol>\n",
+       "<symbol id=\"icon-file-text2\" viewBox=\"0 0 32 32\">\n",
+       "<path d=\"M28.681 7.159c-0.694-0.947-1.662-2.053-2.724-3.116s-2.169-2.030-3.116-2.724c-1.612-1.182-2.393-1.319-2.841-1.319h-15.5c-1.378 0-2.5 1.121-2.5 2.5v27c0 1.378 1.122 2.5 2.5 2.5h23c1.378 0 2.5-1.122 2.5-2.5v-19.5c0-0.448-0.137-1.23-1.319-2.841zM24.543 5.457c0.959 0.959 1.712 1.825 2.268 2.543h-4.811v-4.811c0.718 0.556 1.584 1.309 2.543 2.268zM28 29.5c0 0.271-0.229 0.5-0.5 0.5h-23c-0.271 0-0.5-0.229-0.5-0.5v-27c0-0.271 0.229-0.5 0.5-0.5 0 0 15.499-0 15.5 0v7c0 0.552 0.448 1 1 1h7v19.5z\"></path>\n",
+       "<path d=\"M23 26h-14c-0.552 0-1-0.448-1-1s0.448-1 1-1h14c0.552 0 1 0.448 1 1s-0.448 1-1 1z\"></path>\n",
+       "<path d=\"M23 22h-14c-0.552 0-1-0.448-1-1s0.448-1 1-1h14c0.552 0 1 0.448 1 1s-0.448 1-1 1z\"></path>\n",
+       "<path d=\"M23 18h-14c-0.552 0-1-0.448-1-1s0.448-1 1-1h14c0.552 0 1 0.448 1 1s-0.448 1-1 1z\"></path>\n",
+       "</symbol>\n",
+       "</defs>\n",
+       "</svg>\n",
+       "<style>/* CSS stylesheet for displaying xarray objects in jupyterlab.\n",
+       " *\n",
+       " */\n",
+       "\n",
+       ":root {\n",
+       "  --xr-font-color0: var(--jp-content-font-color0, rgba(0, 0, 0, 1));\n",
+       "  --xr-font-color2: var(--jp-content-font-color2, rgba(0, 0, 0, 0.54));\n",
+       "  --xr-font-color3: var(--jp-content-font-color3, rgba(0, 0, 0, 0.38));\n",
+       "  --xr-border-color: var(--jp-border-color2, #e0e0e0);\n",
+       "  --xr-disabled-color: var(--jp-layout-color3, #bdbdbd);\n",
+       "  --xr-background-color: var(--jp-layout-color0, white);\n",
+       "  --xr-background-color-row-even: var(--jp-layout-color1, white);\n",
+       "  --xr-background-color-row-odd: var(--jp-layout-color2, #eeeeee);\n",
+       "}\n",
+       "\n",
+       "html[theme=dark],\n",
+       "body[data-theme=dark],\n",
+       "body.vscode-dark {\n",
+       "  --xr-font-color0: rgba(255, 255, 255, 1);\n",
+       "  --xr-font-color2: rgba(255, 255, 255, 0.54);\n",
+       "  --xr-font-color3: rgba(255, 255, 255, 0.38);\n",
+       "  --xr-border-color: #1F1F1F;\n",
+       "  --xr-disabled-color: #515151;\n",
+       "  --xr-background-color: #111111;\n",
+       "  --xr-background-color-row-even: #111111;\n",
+       "  --xr-background-color-row-odd: #313131;\n",
+       "}\n",
+       "\n",
+       ".xr-wrap {\n",
+       "  display: block !important;\n",
+       "  min-width: 300px;\n",
+       "  max-width: 700px;\n",
+       "}\n",
+       "\n",
+       ".xr-text-repr-fallback {\n",
+       "  /* fallback to plain text repr when CSS is not injected (untrusted notebook) */\n",
+       "  display: none;\n",
+       "}\n",
+       "\n",
+       ".xr-header {\n",
+       "  padding-top: 6px;\n",
+       "  padding-bottom: 6px;\n",
+       "  margin-bottom: 4px;\n",
+       "  border-bottom: solid 1px var(--xr-border-color);\n",
+       "}\n",
+       "\n",
+       ".xr-header > div,\n",
+       ".xr-header > ul {\n",
+       "  display: inline;\n",
+       "  margin-top: 0;\n",
+       "  margin-bottom: 0;\n",
+       "}\n",
+       "\n",
+       ".xr-obj-type,\n",
+       ".xr-array-name {\n",
+       "  margin-left: 2px;\n",
+       "  margin-right: 10px;\n",
+       "}\n",
+       "\n",
+       ".xr-obj-type {\n",
+       "  color: var(--xr-font-color2);\n",
+       "}\n",
+       "\n",
+       ".xr-sections {\n",
+       "  padding-left: 0 !important;\n",
+       "  display: grid;\n",
+       "  grid-template-columns: 150px auto auto 1fr 20px 20px;\n",
+       "}\n",
+       "\n",
+       ".xr-section-item {\n",
+       "  display: contents;\n",
+       "}\n",
+       "\n",
+       ".xr-section-item input {\n",
+       "  display: none;\n",
+       "}\n",
+       "\n",
+       ".xr-section-item input + label {\n",
+       "  color: var(--xr-disabled-color);\n",
+       "}\n",
+       "\n",
+       ".xr-section-item input:enabled + label {\n",
+       "  cursor: pointer;\n",
+       "  color: var(--xr-font-color2);\n",
+       "}\n",
+       "\n",
+       ".xr-section-item input:enabled + label:hover {\n",
+       "  color: var(--xr-font-color0);\n",
+       "}\n",
+       "\n",
+       ".xr-section-summary {\n",
+       "  grid-column: 1;\n",
+       "  color: var(--xr-font-color2);\n",
+       "  font-weight: 500;\n",
+       "}\n",
+       "\n",
+       ".xr-section-summary > span {\n",
+       "  display: inline-block;\n",
+       "  padding-left: 0.5em;\n",
+       "}\n",
+       "\n",
+       ".xr-section-summary-in:disabled + label {\n",
+       "  color: var(--xr-font-color2);\n",
+       "}\n",
+       "\n",
+       ".xr-section-summary-in + label:before {\n",
+       "  display: inline-block;\n",
+       "  content: '►';\n",
+       "  font-size: 11px;\n",
+       "  width: 15px;\n",
+       "  text-align: center;\n",
+       "}\n",
+       "\n",
+       ".xr-section-summary-in:disabled + label:before {\n",
+       "  color: var(--xr-disabled-color);\n",
+       "}\n",
+       "\n",
+       ".xr-section-summary-in:checked + label:before {\n",
+       "  content: '▼';\n",
+       "}\n",
+       "\n",
+       ".xr-section-summary-in:checked + label > span {\n",
+       "  display: none;\n",
+       "}\n",
+       "\n",
+       ".xr-section-summary,\n",
+       ".xr-section-inline-details {\n",
+       "  padding-top: 4px;\n",
+       "  padding-bottom: 4px;\n",
+       "}\n",
+       "\n",
+       ".xr-section-inline-details {\n",
+       "  grid-column: 2 / -1;\n",
+       "}\n",
+       "\n",
+       ".xr-section-details {\n",
+       "  display: none;\n",
+       "  grid-column: 1 / -1;\n",
+       "  margin-bottom: 5px;\n",
+       "}\n",
+       "\n",
+       ".xr-section-summary-in:checked ~ .xr-section-details {\n",
+       "  display: contents;\n",
+       "}\n",
+       "\n",
+       ".xr-array-wrap {\n",
+       "  grid-column: 1 / -1;\n",
+       "  display: grid;\n",
+       "  grid-template-columns: 20px auto;\n",
+       "}\n",
+       "\n",
+       ".xr-array-wrap > label {\n",
+       "  grid-column: 1;\n",
+       "  vertical-align: top;\n",
+       "}\n",
+       "\n",
+       ".xr-preview {\n",
+       "  color: var(--xr-font-color3);\n",
+       "}\n",
+       "\n",
+       ".xr-array-preview,\n",
+       ".xr-array-data {\n",
+       "  padding: 0 5px !important;\n",
+       "  grid-column: 2;\n",
+       "}\n",
+       "\n",
+       ".xr-array-data,\n",
+       ".xr-array-in:checked ~ .xr-array-preview {\n",
+       "  display: none;\n",
+       "}\n",
+       "\n",
+       ".xr-array-in:checked ~ .xr-array-data,\n",
+       ".xr-array-preview {\n",
+       "  display: inline-block;\n",
+       "}\n",
+       "\n",
+       ".xr-dim-list {\n",
+       "  display: inline-block !important;\n",
+       "  list-style: none;\n",
+       "  padding: 0 !important;\n",
+       "  margin: 0;\n",
+       "}\n",
+       "\n",
+       ".xr-dim-list li {\n",
+       "  display: inline-block;\n",
+       "  padding: 0;\n",
+       "  margin: 0;\n",
+       "}\n",
+       "\n",
+       ".xr-dim-list:before {\n",
+       "  content: '(';\n",
+       "}\n",
+       "\n",
+       ".xr-dim-list:after {\n",
+       "  content: ')';\n",
+       "}\n",
+       "\n",
+       ".xr-dim-list li:not(:last-child):after {\n",
+       "  content: ',';\n",
+       "  padding-right: 5px;\n",
+       "}\n",
+       "\n",
+       ".xr-has-index {\n",
+       "  font-weight: bold;\n",
+       "}\n",
+       "\n",
+       ".xr-var-list,\n",
+       ".xr-var-item {\n",
+       "  display: contents;\n",
+       "}\n",
+       "\n",
+       ".xr-var-item > div,\n",
+       ".xr-var-item label,\n",
+       ".xr-var-item > .xr-var-name span {\n",
+       "  background-color: var(--xr-background-color-row-even);\n",
+       "  margin-bottom: 0;\n",
+       "}\n",
+       "\n",
+       ".xr-var-item > .xr-var-name:hover span {\n",
+       "  padding-right: 5px;\n",
+       "}\n",
+       "\n",
+       ".xr-var-list > li:nth-child(odd) > div,\n",
+       ".xr-var-list > li:nth-child(odd) > label,\n",
+       ".xr-var-list > li:nth-child(odd) > .xr-var-name span {\n",
+       "  background-color: var(--xr-background-color-row-odd);\n",
+       "}\n",
+       "\n",
+       ".xr-var-name {\n",
+       "  grid-column: 1;\n",
+       "}\n",
+       "\n",
+       ".xr-var-dims {\n",
+       "  grid-column: 2;\n",
+       "}\n",
+       "\n",
+       ".xr-var-dtype {\n",
+       "  grid-column: 3;\n",
+       "  text-align: right;\n",
+       "  color: var(--xr-font-color2);\n",
+       "}\n",
+       "\n",
+       ".xr-var-preview {\n",
+       "  grid-column: 4;\n",
+       "}\n",
+       "\n",
+       ".xr-index-preview {\n",
+       "  grid-column: 2 / 5;\n",
+       "  color: var(--xr-font-color2);\n",
+       "}\n",
+       "\n",
+       ".xr-var-name,\n",
+       ".xr-var-dims,\n",
+       ".xr-var-dtype,\n",
+       ".xr-preview,\n",
+       ".xr-attrs dt {\n",
+       "  white-space: nowrap;\n",
+       "  overflow: hidden;\n",
+       "  text-overflow: ellipsis;\n",
+       "  padding-right: 10px;\n",
+       "}\n",
+       "\n",
+       ".xr-var-name:hover,\n",
+       ".xr-var-dims:hover,\n",
+       ".xr-var-dtype:hover,\n",
+       ".xr-attrs dt:hover {\n",
+       "  overflow: visible;\n",
+       "  width: auto;\n",
+       "  z-index: 1;\n",
+       "}\n",
+       "\n",
+       ".xr-var-attrs,\n",
+       ".xr-var-data,\n",
+       ".xr-index-data {\n",
+       "  display: none;\n",
+       "  background-color: var(--xr-background-color) !important;\n",
+       "  padding-bottom: 5px !important;\n",
+       "}\n",
+       "\n",
+       ".xr-var-attrs-in:checked ~ .xr-var-attrs,\n",
+       ".xr-var-data-in:checked ~ .xr-var-data,\n",
+       ".xr-index-data-in:checked ~ .xr-index-data {\n",
+       "  display: block;\n",
+       "}\n",
+       "\n",
+       ".xr-var-data > table {\n",
+       "  float: right;\n",
+       "}\n",
+       "\n",
+       ".xr-var-name span,\n",
+       ".xr-var-data,\n",
+       ".xr-index-name div,\n",
+       ".xr-index-data,\n",
+       ".xr-attrs {\n",
+       "  padding-left: 25px !important;\n",
+       "}\n",
+       "\n",
+       ".xr-attrs,\n",
+       ".xr-var-attrs,\n",
+       ".xr-var-data,\n",
+       ".xr-index-data {\n",
+       "  grid-column: 1 / -1;\n",
+       "}\n",
+       "\n",
+       "dl.xr-attrs {\n",
+       "  padding: 0;\n",
+       "  margin: 0;\n",
+       "  display: grid;\n",
+       "  grid-template-columns: 125px auto;\n",
+       "}\n",
+       "\n",
+       ".xr-attrs dt,\n",
+       ".xr-attrs dd {\n",
+       "  padding: 0;\n",
+       "  margin: 0;\n",
+       "  float: left;\n",
+       "  padding-right: 10px;\n",
+       "  width: auto;\n",
+       "}\n",
+       "\n",
+       ".xr-attrs dt {\n",
+       "  font-weight: normal;\n",
+       "  grid-column: 1;\n",
+       "}\n",
+       "\n",
+       ".xr-attrs dt:hover span {\n",
+       "  display: inline-block;\n",
+       "  background: var(--xr-background-color);\n",
+       "  padding-right: 10px;\n",
+       "}\n",
+       "\n",
+       ".xr-attrs dd {\n",
+       "  grid-column: 2;\n",
+       "  white-space: pre-wrap;\n",
+       "  word-break: break-all;\n",
+       "}\n",
+       "\n",
+       ".xr-icon-database,\n",
+       ".xr-icon-file-text2,\n",
+       ".xr-no-icon {\n",
+       "  display: inline-block;\n",
+       "  vertical-align: middle;\n",
+       "  width: 1em;\n",
+       "  height: 1.5em !important;\n",
+       "  stroke-width: 0;\n",
+       "  stroke: currentColor;\n",
+       "  fill: currentColor;\n",
+       "}\n",
+       "</style><pre class='xr-text-repr-fallback'>&lt;xarray.Dataset&gt; Size: 495MB\n",
+       "Dimensions:                 (node: 549, time: 5761, nface: 444, nmax_face: 8,\n",
+       "                             nedge: 915, 2: 2)\n",
+       "Coordinates:\n",
+       "    node_x                  (node) float64 4kB 5.004e+05 5.005e+05 ... 5.024e+05\n",
+       "    node_y                  (node) float64 4kB 2.381e+03 2.376e+03 ... 500.0\n",
+       "  * time                    (time) datetime64[ns] 46kB 2022-05-13 ... 2022-05-15\n",
+       "    face_x                  (nface) float64 4kB 5.005e+05 ... 5.024e+05\n",
+       "    face_y                  (nface) float64 4kB 2.45e+03 2.45e+03 ... 564.4\n",
+       "Dimensions without coordinates: node, nface, nmax_face, nedge, 2\n",
+       "Data variables: (12/34)\n",
+       "    mesh2d                  int32 4B 0\n",
+       "    face_nodes              (nface, nmax_face) int32 14kB 0 1 2 3 ... -1 -1 -1\n",
+       "    edge_nodes              (nedge, 2) int32 7kB 0 1 1 2 2 ... 547 418 548 519\n",
+       "    edge_face_connectivity  (nedge, 2) int32 7kB 0 207 0 208 ... 194 442 329 443\n",
+       "    edges_face1             (nedge) int32 4kB 0 0 0 0 207 ... 366 0 19 194 329\n",
+       "    edges_face2             (nedge) int32 4kB 207 208 1 367 ... 440 441 442 443\n",
+       "    ...                      ...\n",
+       "    DOC                     (time, nface) float64 20MB 1.0 1.0 1.0 ... nan nan\n",
+       "    DIC                     (time, nface) float64 20MB 1.0 1.0 1.0 ... nan nan\n",
+       "    POM                     (time, nface) float64 20MB 1.0 1.0 1.0 ... nan nan\n",
+       "    CBOD                    (time, nface) float64 20MB 1.0 1.0 1.0 ... nan nan\n",
+       "    PX                      (time, nface) float64 20MB 1.0 1.0 1.0 ... nan nan\n",
+       "    Alk                     (time, nface) float64 20MB 1.0 1.0 1.0 ... nan nan\n",
+       "Attributes: (12/13)\n",
+       "    Conventions:                       CF-1.8 UGRID-1.0 Deltares-0.10\n",
+       "    diffusion_coefficient:             0.1\n",
+       "    volume_calculation_required:       False\n",
+       "    face_area_calculation_required:    False\n",
+       "    face_area_elevation_info:          Empty DataFrame\\nColumns: []\\nIndex: []\n",
+       "    face_area_elevation_values:        Empty DataFrame\\nColumns: []\\nIndex: []\n",
+       "    ...                                ...\n",
+       "    face_cell_indexes_df:              Empty DataFrame\\nColumns: []\\nIndex: []\n",
+       "    face_volume_elevation_info:        Empty DataFrame\\nColumns: []\\nIndex: []\n",
+       "    face_volume_elevation_values:      Empty DataFrame\\nColumns: []\\nIndex: []\n",
+       "    boundary_data:                     Empty DataFrame\\nColumns: []\\nIndex: []\n",
+       "    units:                             Metric\n",
+       "    nreal:                             366</pre><div class='xr-wrap' style='display:none'><div class='xr-header'><div class='xr-obj-type'>xarray.Dataset</div></div><ul class='xr-sections'><li class='xr-section-item'><input id='section-67055452-6e94-43cd-b703-1a99380021b9' class='xr-section-summary-in' type='checkbox' disabled ><label for='section-67055452-6e94-43cd-b703-1a99380021b9' class='xr-section-summary'  title='Expand/collapse section'>Dimensions:</label><div class='xr-section-inline-details'><ul class='xr-dim-list'><li><span>node</span>: 549</li><li><span class='xr-has-index'>time</span>: 5761</li><li><span>nface</span>: 444</li><li><span>nmax_face</span>: 8</li><li><span>nedge</span>: 915</li><li><span>2</span>: 2</li></ul></div><div class='xr-section-details'></div></li><li class='xr-section-item'><input id='section-85ab7f53-b664-4f84-ae8f-c77a5d973e29' class='xr-section-summary-in' type='checkbox'  checked><label for='section-85ab7f53-b664-4f84-ae8f-c77a5d973e29' class='xr-section-summary' >Coordinates: <span>(5)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span>node_x</span></div><div class='xr-var-dims'>(node)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>5.004e+05 5.005e+05 ... 5.024e+05</div><input id='attrs-837de581-336c-4942-a3a8-282a65f2dab5' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-837de581-336c-4942-a3a8-282a65f2dab5' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-1064c606-d508-4efd-9e05-2d1d94b09521' class='xr-var-data-in' type='checkbox'><label for='data-1064c606-d508-4efd-9e05-2d1d94b09521' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array([500400.00000001, 500485.77497549, 500500.00000001, 500500.00000001,\n",
+       "       500588.70786068, 500600.00000001, 500600.00000001, 500691.21118046,\n",
+       "       500700.00000001, 500700.00000001, 500800.00000001, 500800.00000001,\n",
+       "       500793.47107692, 500900.00000001, 500900.00000001, 501000.00000001,\n",
+       "       501000.00000001, 501100.00000001, 501100.00000001, 501200.00000001,\n",
+       "       501200.00000001, 501300.00000001, 501300.00000001, 501400.00000001,\n",
+       "       501400.00000001, 501500.00000001, 501500.00000001, 501569.52150026,\n",
+       "       501600.00000001, 501600.00000001, 501700.00000001, 501700.00000001,\n",
+       "       501800.00000001, 501800.00000001, 501900.00000001, 501900.00000001,\n",
+       "       502000.00000001, 502000.00000001, 502100.00000001, 502100.00000001,\n",
+       "       502200.00000001, 502200.00000001, 502300.00000001, 502300.00000001,\n",
+       "       502400.        , 501700.00000001, 501602.19164361, 501706.52881355,\n",
+       "       501800.00000001, 501810.06547903, 501900.00000001, 501910.9511348 ,\n",
+       "       501967.38330336, 502000.00000001, 502100.00000001, 502200.00000001,\n",
+       "       502300.00000001, 502400.        , 502001.40752427, 502100.00000001,\n",
+       "       502166.30287737, 502200.00000001, 502116.51457194, 502300.00000001,\n",
+       "       502400.        , 500700.00000001, 500700.00000001, 500604.03141216,\n",
+       "       500565.8370389 , 500600.00000001, 500800.00000001, 500800.00000001,\n",
+       "       500839.59417791, 500900.00000001, 500900.00000001, 500895.27352363,\n",
+       "       501000.00000001, 501000.00000001, 500993.46557737, 500967.47405019,\n",
+       "...\n",
+       "       501433.01538715, 501370.76144742, 501324.47264009, 501420.97411405,\n",
+       "       501286.17253587, 501215.1010291 , 501145.24499223, 501060.47697569,\n",
+       "       500965.65553841, 500869.92689859, 500785.19488662, 500708.43792557,\n",
+       "       500639.76098268, 500732.03806137, 500589.28674574, 500627.49956643,\n",
+       "       500729.18077917, 500821.63647053, 500915.63945653, 501010.210723  ,\n",
+       "       501104.78235716, 501199.01018726, 501292.48977967, 501310.81525422,\n",
+       "       501384.7747243 , 501407.32523181, 501373.39975232, 501474.84730718,\n",
+       "       501507.21324787, 501451.16145605, 501561.83423686, 501612.7973118 ,\n",
+       "       501527.00650264, 501641.59887177, 501707.62190871, 501853.98648974,\n",
+       "       501756.61238209, 501802.6867799 , 501899.14757467, 501906.20985598,\n",
+       "       501858.88538519, 501955.77854696, 501932.49255572, 502016.22338546,\n",
+       "       502107.15793419, 502202.77367074, 502300.86497163, 502400.        ,\n",
+       "       501669.735584  , 501669.08400404, 501718.80521364, 502170.55268771,\n",
+       "       502286.8767108 , 501391.83310031, 501472.31019726, 501552.78729421,\n",
+       "       500914.35228762, 500953.79804404, 500982.5929238 , 501068.40430883,\n",
+       "       501154.21569386, 501240.02707889, 501325.83846392, 501411.64984895,\n",
+       "       501497.46123398, 501583.27261901, 501126.9083414 , 501987.79523573,\n",
+       "       502069.38061548, 502150.96599523, 502232.55137497, 502314.13675472,\n",
+       "       502400.        , 500400.00000001, 502400.        , 500400.00000001,\n",
+       "       502400.        ])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>node_y</span></div><div class='xr-var-dims'>(node)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>2.381e+03 2.376e+03 ... 500.0 500.0</div><input id='attrs-f75f86b0-c9cd-46cc-b4f8-6df327ae617e' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-f75f86b0-c9cd-46cc-b4f8-6df327ae617e' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-95c2d029-2510-4668-885c-a4f386d2ff7c' class='xr-var-data-in' type='checkbox'><label for='data-95c2d029-2510-4668-885c-a4f386d2ff7c' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array([2380.90844004, 2376.4242409 , 2386.5131813 , 2500.00000004,\n",
+       "       2382.05515883, 2390.58648094, 2500.00000004, 2385.78843387,\n",
+       "       2392.78377471, 2500.00000004, 2393.79033837, 2500.00000004,\n",
+       "       2388.48706572, 2389.30550178, 2500.00000004, 2389.53976159,\n",
+       "       2500.00000004, 2388.93368814, 2500.00000004, 2387.87016137,\n",
+       "       2500.00000004, 2385.0111151 , 2500.00000004, 2380.82980762,\n",
+       "       2500.00000004, 2375.58197869, 2500.00000004, 2369.52150028,\n",
+       "       2400.00000004, 2500.00000004, 2400.00000004, 2500.00000004,\n",
+       "       2400.00000004, 2500.00000004, 2400.00000004, 2500.00000004,\n",
+       "       2400.00000004, 2500.00000004, 2400.00000004, 2500.00000004,\n",
+       "       2400.00000004, 2500.00000004, 2400.00000004, 2500.00000004,\n",
+       "       2400.00000004, 2308.32143068, 2313.00784877, 2299.67952535,\n",
+       "       2296.40094488, 2286.32871568, 2280.68585708, 2271.69203231,\n",
+       "       2267.38330338, 2300.00000004, 2300.00000004, 2300.00000004,\n",
+       "       2300.00000004, 2300.00000004, 2205.36938753, 2191.56219523,\n",
+       "       2166.30287739, 2200.00000004, 2172.88097567, 2200.00000004,\n",
+       "       2200.00000004, 2100.00000004, 2188.06534731, 2188.4064972 ,\n",
+       "       2134.16296114, 2100.00000004, 2100.00000004, 2192.16172881,\n",
+       "       2060.40582214, 2082.7151293 , 2188.63954438, 2193.97381478,\n",
+       "       2079.24689484, 2187.54699109, 2194.92339133, 2062.92553287,\n",
+       "...\n",
+       "       1574.46604825, 1692.87334217, 1602.11401753, 1569.28369981,\n",
+       "       1744.62609645, 1813.65814182, 1883.95778688, 1935.07168374,\n",
+       "       1962.5094257 , 1938.57242587, 1887.49633686, 1824.6640322 ,\n",
+       "       1753.75463832, 1682.71480012, 1670.30219739, 1601.70789602,\n",
+       "       1543.91149935, 1507.76082915, 1475.7046162 , 1445.3451056 ,\n",
+       "       1414.98547697, 1383.58375943, 1350.04347939, 1398.53743517,\n",
+       "       1313.38515965, 1365.8348983 , 1418.68019888, 1271.64040499,\n",
+       "       1335.65219895, 1384.66220145, 1223.8612233 , 1303.49585367,\n",
+       "       1344.57674956, 1164.93432734, 1091.03052452, 1057.94121482,\n",
+       "       1004.77647748,  916.90101601,  975.08016656, 1029.36431669,\n",
+       "        835.22140621,  920.16789682,  768.82181313,  715.64764977,\n",
+       "        675.95857263,  649.38625771,  634.18044155,  628.82701829,\n",
+       "        957.34218027,  913.14917144,  866.29825148,  500.        ,\n",
+       "        500.        , 1477.0336195 , 1451.61159081, 1426.18956212,\n",
+       "        500.        ,  500.        ,  577.88608574,  619.79397145,\n",
+       "        661.70185716,  703.60974288,  745.51762859,  787.4255143 ,\n",
+       "        829.33340001,  871.24128573,  500.        , 1069.2765888 ,\n",
+       "       1109.18886091, 1149.10113301, 1189.01340512, 1228.92567723,\n",
+       "       1204.01423819, 2500.00000004, 2500.00000004,  500.        ,\n",
+       "        500.        ])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>time</span></div><div class='xr-var-dims'>(time)</div><div class='xr-var-dtype'>datetime64[ns]</div><div class='xr-var-preview xr-preview'>2022-05-13 ... 2022-05-15</div><input id='attrs-5cb252a2-0621-44de-81ac-8222cdf20ff9' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-5cb252a2-0621-44de-81ac-8222cdf20ff9' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-85400a91-54a1-4479-bb7e-c94580f16637' class='xr-var-data-in' type='checkbox'><label for='data-85400a91-54a1-4479-bb7e-c94580f16637' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array([&#x27;2022-05-13T00:00:00.000000000&#x27;, &#x27;2022-05-13T00:00:30.000000000&#x27;,\n",
+       "       &#x27;2022-05-13T00:01:00.000000000&#x27;, ..., &#x27;2022-05-14T23:59:00.000000000&#x27;,\n",
+       "       &#x27;2022-05-14T23:59:30.000000000&#x27;, &#x27;2022-05-15T00:00:00.000000000&#x27;],\n",
+       "      dtype=&#x27;datetime64[ns]&#x27;)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>face_x</span></div><div class='xr-var-dims'>(nface)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>5.005e+05 5.006e+05 ... 5.024e+05</div><input id='attrs-2fbe8a14-cabb-4d8e-a1a3-bbc84a6962f5' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-2fbe8a14-cabb-4d8e-a1a3-bbc84a6962f5' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-222752a6-7dc4-4394-bd2e-a14171a44fa0' class='xr-var-data-in' type='checkbox'><label for='data-222752a6-7dc4-4394-bd2e-a14171a44fa0' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array([500450.00000001, 500550.00000001, 500650.00000001, 500750.00000001,\n",
+       "       500850.00000001, 500950.00000001, 501050.00000001, 501150.00000001,\n",
+       "       501250.00000001, 501350.00000001, 501450.00000001, 501550.00000001,\n",
+       "       501650.00000001, 501750.00000001, 501850.00000001, 501950.00000001,\n",
+       "       502050.00000001, 502150.00000001, 502250.00000001, 502350.00000001,\n",
+       "       501650.00000001, 501750.00000001, 501850.00000001, 501950.00000001,\n",
+       "       502050.00000001, 502150.00000001, 502250.00000001, 502350.00000001,\n",
+       "       502050.00000001, 502150.00000001, 502250.00000001, 502350.00000001,\n",
+       "       500650.00000001, 500750.00000001, 500850.00000001, 500950.00000001,\n",
+       "       501050.00000001, 501150.00000001, 502250.00000001, 502350.00000001,\n",
+       "       500450.00000001, 500550.00000001, 500650.00000001, 500750.00000001,\n",
+       "       501150.00000001, 501250.00000001, 501350.00000001, 501450.00000001,\n",
+       "       501550.00000001, 501650.00000001, 501750.00000001, 502350.00000001,\n",
+       "       500450.00000001, 500550.00000001, 500650.00000001, 501350.00000001,\n",
+       "       501450.00000001, 501550.00000001, 501650.00000001, 501750.00000001,\n",
+       "       501850.00000001, 501950.00000001, 502350.00000001, 500450.00000001,\n",
+       "       500550.00000001, 501450.00000001, 501550.00000001, 501650.00000001,\n",
+       "       501750.00000001, 501850.00000001, 501950.00000001, 502050.00000001,\n",
+       "       502350.00000001, 500450.00000001, 500850.00000001, 500950.00000001,\n",
+       "       501050.00000001, 501650.00000001, 501750.00000001, 501850.00000001,\n",
+       "...\n",
+       "       502132.14540178, 502213.73078153, 502295.31616128, 500450.00000001,\n",
+       "       500400.00000001, 500850.00000001, 500950.00000001, 502400.        ,\n",
+       "       500550.00000001, 500750.00000001, 500650.00000001, 501050.00000001,\n",
+       "       501150.00000001, 501250.00000001, 501350.00000001, 501450.00000001,\n",
+       "       501550.00000001, 501650.00000001, 501750.00000001, 501850.00000001,\n",
+       "       501950.00000001, 502050.00000001, 502150.00000001, 502250.00000001,\n",
+       "       502400.        , 502400.        , 502400.        , 502400.        ,\n",
+       "       502400.        , 502400.        , 502400.        , 502400.        ,\n",
+       "       500400.00000001, 500400.00000001, 500400.00000001, 502400.        ,\n",
+       "       500400.00000001, 500400.00000001, 502400.        , 500400.00000001,\n",
+       "       500400.00000001, 500400.00000001, 500400.00000001, 502400.        ,\n",
+       "       502400.        , 500400.00000001, 502400.        , 500400.00000001,\n",
+       "       500400.00000001, 500400.00000001, 502343.4383554 , 500400.00000001,\n",
+       "       502400.        , 500400.00000001, 501850.00000001, 500400.00000001,\n",
+       "       500550.00000001, 500748.8225405 , 500855.9986843 , 501231.5056931 ,\n",
+       "       501350.00000001, 500934.07516583, 500650.00000001, 500400.00000001,\n",
+       "       501450.00000001, 501950.00000001, 501550.00000001, 501650.00000001,\n",
+       "       501750.00000001, 501040.35319272, 502162.13636585, 502228.71469925,\n",
+       "       502076.860022  , 502400.        , 501144.9598638 , 502400.        ,\n",
+       "       500400.00000001, 502350.00000001, 500450.00000001, 502400.        ])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>face_y</span></div><div class='xr-var-dims'>(nface)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>2.45e+03 2.45e+03 ... 500.0 564.4</div><input id='attrs-4e6687fc-f6e6-4be1-9419-1f2bd190dd46' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-4e6687fc-f6e6-4be1-9419-1f2bd190dd46' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-22dab49b-77fc-4158-84a2-89a730217e1b' class='xr-var-data-in' type='checkbox'><label for='data-22dab49b-77fc-4158-84a2-89a730217e1b' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array([2450.00000004, 2450.00000004, 2450.00000004, 2450.00000004,\n",
+       "       2450.00000004, 2450.00000004, 2450.00000004, 2450.00000004,\n",
+       "       2450.00000004, 2450.00000004, 2450.00000004, 2450.00000004,\n",
+       "       2450.00000004, 2450.00000004, 2450.00000004, 2450.00000004,\n",
+       "       2450.00000004, 2450.00000004, 2450.00000004, 2450.00000004,\n",
+       "       2350.00000004, 2350.00000004, 2350.00000004, 2350.00000004,\n",
+       "       2350.00000004, 2350.00000004, 2350.00000004, 2350.00000004,\n",
+       "       2250.00000004, 2250.00000004, 2250.00000004, 2250.00000004,\n",
+       "       2150.00000004, 2150.00000004, 2150.00000004, 2150.00000004,\n",
+       "       2150.00000004, 2150.00000004, 2150.00000004, 2150.00000004,\n",
+       "       2050.00000004, 2050.00000004, 2050.00000004, 2050.00000004,\n",
+       "       2050.00000004, 2050.00000004, 2050.00000004, 2050.00000004,\n",
+       "       2050.00000004, 2050.00000004, 2050.00000004, 2050.00000004,\n",
+       "       1950.00000004, 1950.00000004, 1950.00000004, 1950.00000004,\n",
+       "       1950.00000004, 1950.00000004, 1950.00000004, 1950.00000004,\n",
+       "       1950.00000004, 1950.00000004, 1950.00000004, 1850.00000004,\n",
+       "       1850.00000004, 1850.00000004, 1850.00000004, 1850.00000004,\n",
+       "       1850.00000004, 1850.00000004, 1850.00000004, 1850.00000004,\n",
+       "       1850.00000004, 1750.00000004, 1750.00000004, 1750.00000004,\n",
+       "       1750.00000004, 1750.00000004, 1750.00000004, 1750.00000004,\n",
+       "...\n",
+       "       1084.23144691, 1124.14371901, 1164.05599112, 2500.00000004,\n",
+       "       2315.84861428, 2500.00000004, 2500.00000004, 2450.00000004,\n",
+       "       2500.00000004, 2500.00000004, 2500.00000004, 2500.00000004,\n",
+       "       2500.00000004, 2500.00000004, 2500.00000004, 2500.00000004,\n",
+       "       2500.00000004, 2500.00000004, 2500.00000004, 2500.00000004,\n",
+       "       2500.00000004, 2500.00000004, 2500.00000004, 2500.00000004,\n",
+       "       2350.00000004, 2250.00000004, 2150.00000004, 1750.00000004,\n",
+       "       1850.00000004, 2050.00000004, 1550.00000004, 1432.75636654,\n",
+       "       2190.85252633, 2065.45813209, 1950.00000004, 1950.00000004,\n",
+       "       1850.00000004, 1750.00000004, 1650.00000004, 1650.00000004,\n",
+       "       1550.00000004, 1450.00000004, 1350.00000004, 1072.05468561,\n",
+       "       1284.76348562, 1250.00000004,  950.00000004, 1150.00000004,\n",
+       "       1050.00000004,  950.00000004,  500.        ,  850.00000004,\n",
+       "        833.3069116 ,  750.00000004,  500.        ,  650.00000004,\n",
+       "        500.        ,  500.        ,  500.        ,  500.        ,\n",
+       "        500.        ,  500.        ,  500.        ,  550.00000002,\n",
+       "        500.        ,  500.        ,  500.        ,  500.        ,\n",
+       "        500.        ,  500.        ,  500.        ,  500.        ,\n",
+       "        500.        ,  697.72042073,  500.        , 1174.06180468,\n",
+       "       2440.45422004, 2500.00000004,  500.        ,  564.41350915])</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-9bf77c8a-5e5c-4d50-ac98-5e5850a52f9f' class='xr-section-summary-in' type='checkbox'  ><label for='section-9bf77c8a-5e5c-4d50-ac98-5e5850a52f9f' class='xr-section-summary' >Data variables: <span>(34)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span>mesh2d</span></div><div class='xr-var-dims'>()</div><div class='xr-var-dtype'>int32</div><div class='xr-var-preview xr-preview'>0</div><input id='attrs-f22b616e-6be6-41fa-813d-fe284cf7f158' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-f22b616e-6be6-41fa-813d-fe284cf7f158' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-71d75a34-f9fa-43e2-9067-2a20c48128e6' class='xr-var-data-in' type='checkbox'><label for='data-71d75a34-f9fa-43e2-9067-2a20c48128e6' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>cf_role :</span></dt><dd>mesh_topology</dd><dt><span>long_name :</span></dt><dd>Topology data of 2D mesh</dd><dt><span>topology_dimension :</span></dt><dd>2</dd><dt><span>node_coordinates :</span></dt><dd>node_x node_y</dd><dt><span>face_node_connectivity :</span></dt><dd>face_nodes</dd><dt><span>face_dimension :</span></dt><dd>face</dd><dt><span>edge_node_connectivity :</span></dt><dd>edge_nodes</dd><dt><span>edge_dimension :</span></dt><dd>edge</dd><dt><span>face_edge_connectivity :</span></dt><dd>face_edges</dd><dt><span>face_face_connectivity :</span></dt><dd>face_face_connectivity</dd><dt><span>edge_face_connectivity :</span></dt><dd>edge_face_connectivity</dd><dt><span>boundary_node_connectivity :</span></dt><dd>boundary_node_connectivity</dd><dt><span>face_coordinates :</span></dt><dd>face x face_y</dd><dt><span>edge_coordinates :</span></dt><dd>edge_x edge_y</dd></dl></div><div class='xr-var-data'><pre>array(0)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>face_nodes</span></div><div class='xr-var-dims'>(nface, nmax_face)</div><div class='xr-var-dtype'>int32</div><div class='xr-var-preview xr-preview'>0 1 2 3 545 -1 ... -1 -1 -1 -1 -1</div><input id='attrs-4b4431de-c5d6-4744-871b-f45e0d7fd255' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-4b4431de-c5d6-4744-871b-f45e0d7fd255' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-99109697-8f0e-4779-92ce-ad695d91c7fc' class='xr-var-data-in' type='checkbox'><label for='data-99109697-8f0e-4779-92ce-ad695d91c7fc' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>cf_role :</span></dt><dd>face_node_connectivity</dd><dt><span>long_name :</span></dt><dd>Vertex nodes of mesh faces (counterclockwise)</dd><dt><span>start_index :</span></dt><dd>0</dd><dt><span>_FillValue :</span></dt><dd>-1</dd></dl></div><div class='xr-var-data'><pre>array([[  0,   1,   2, ...,  -1,  -1,  -1],\n",
+       "       [  3,   2,   4, ...,  -1,  -1,  -1],\n",
+       "       [  6,   5,   7, ...,  -1,  -1,  -1],\n",
+       "       ...,\n",
+       "       [546,  43,  -1, ...,  -1,  -1,  -1],\n",
+       "       [547, 418,  -1, ...,  -1,  -1,  -1],\n",
+       "       [548, 519,  -1, ...,  -1,  -1,  -1]])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>edge_nodes</span></div><div class='xr-var-dims'>(nedge, 2)</div><div class='xr-var-dtype'>int32</div><div class='xr-var-preview xr-preview'>0 1 1 2 2 3 ... 43 547 418 548 519</div><input id='attrs-c16d685c-cb4f-490f-8c0f-7adfd94b3fa0' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-c16d685c-cb4f-490f-8c0f-7adfd94b3fa0' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-374826d1-190b-4c51-8438-daa49da766d7' class='xr-var-data-in' type='checkbox'><label for='data-374826d1-190b-4c51-8438-daa49da766d7' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>cf_role :</span></dt><dd>edge_node_connectivity</dd><dt><span>long_name :</span></dt><dd>Vertex nodes of mesh edges</dd><dt><span>start_index :</span></dt><dd>0</dd></dl></div><div class='xr-var-data'><pre>array([[  0,   1],\n",
+       "       [  1,   2],\n",
+       "       [  2,   3],\n",
+       "       ...,\n",
+       "       [546,  43],\n",
+       "       [547, 418],\n",
+       "       [548, 519]])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>edge_face_connectivity</span></div><div class='xr-var-dims'>(nedge, 2)</div><div class='xr-var-dtype'>int32</div><div class='xr-var-preview xr-preview'>0 207 0 208 0 ... 194 442 329 443</div><input id='attrs-5a338519-9c15-4e86-b181-f6359c35111b' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-5a338519-9c15-4e86-b181-f6359c35111b' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-1426275a-7d28-41ba-9417-eae1a3e3b2be' class='xr-var-data-in' type='checkbox'><label for='data-1426275a-7d28-41ba-9417-eae1a3e3b2be' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>cf_role :</span></dt><dd>edge_face_connectivity</dd><dt><span>long_name :</span></dt><dd>neighbor faces for edges</dd><dt><span>start_index :</span></dt><dd>0</dd></dl></div><div class='xr-var-data'><pre>array([[  0, 207],\n",
+       "       [  0, 208],\n",
+       "       [  0,   1],\n",
+       "       ...,\n",
+       "       [ 19, 441],\n",
+       "       [194, 442],\n",
+       "       [329, 443]])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>edges_face1</span></div><div class='xr-var-dims'>(nedge)</div><div class='xr-var-dtype'>int32</div><div class='xr-var-preview xr-preview'>0 0 0 0 207 ... 366 0 19 194 329</div><input id='attrs-37c9b577-580f-4e20-8bde-1882f950910d' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-37c9b577-580f-4e20-8bde-1882f950910d' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-265a8330-641c-427a-9fd0-dc4551549bfd' class='xr-var-data-in' type='checkbox'><label for='data-265a8330-641c-427a-9fd0-dc4551549bfd' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>Units :</span></dt><dd></dd></dl></div><div class='xr-var-data'><pre>array([  0,   0,   0,   0, 207, 207, 207, 208, 208, 208,  30,  30,  30,\n",
+       "        30,  29,  29,  29,  29,  29,  38,  38,  38,  38,   4,   4,   4,\n",
+       "         4,   5,   5,   5, 254, 254, 254, 254, 254, 253, 253, 253, 253,\n",
+       "       316, 316, 316, 316, 217, 217, 217, 217, 216, 216, 216, 278, 278,\n",
+       "       278, 278,  19,  19,  19, 212, 212, 212, 213, 213, 213,   1,   1,\n",
+       "         1,   3,   3,   3,   3,   2,   2,   2, 209, 209, 210, 210,   6,\n",
+       "         6, 211,   7,   7,   7,   8,   8,   8,   9,   9,  10,  10,  11,\n",
+       "        11,  11,  11, 275, 275, 275, 275, 275,  37,  37,  37,  37, 276,\n",
+       "       276, 276,  12,  12,  12,  13,  13,  13,  14,  14,  14,  20,  20,\n",
+       "        20,  21,  21,  21,  15,  15,  15,  22,  22,  22,  16,  16,  16,\n",
+       "        17,  17,  17,  23,  23,  23,  23,  18,  18,  24,  24,  25, 214,\n",
+       "        44,  44,  44,  44,  45,  45,  45,  45,  45,  26,  60,  60,  60,\n",
+       "        60,  60,  61,  61,  61,  61,  61, 283, 283, 283,  27,  27,  31,\n",
+       "        31,  28,  28, 223, 223, 223,  39,  39,  81,  81,  81,  81,  72,\n",
+       "        72,  72,  72, 227, 227, 227,  33,  33,  33,  33,  32,  32,  32,\n",
+       "        32,  43,  43,  43,  43,  43,  41,  41,  41,  41,  41,  42, 277,\n",
+       "       220, 220, 220,  75,  75,  75,  75,  75,  75, 241, 241, 241, 241,\n",
+       "       242, 242,  51,  51,  51,  92,  92,  92,  92,  91,  91,  91,  91,\n",
+       "        91,  99,  99,  99,  99, 268, 268, 268,  40,  40,  53,  53,  53,\n",
+       "        34,  34,  34,  34,  52,  52, 303, 303, 303, 304, 304,  54,  54,\n",
+       "...\n",
+       "       364, 364, 364, 155, 155, 155, 154, 154, 170, 170, 170, 170, 170,\n",
+       "       149, 149, 149, 138, 148, 148, 156, 150, 150, 151, 151, 152, 152,\n",
+       "       153, 259, 259, 259, 356, 356, 363, 363, 363, 146, 146, 146, 146,\n",
+       "       160, 160, 160, 161, 329, 329, 329, 168, 168, 168, 167, 167, 181,\n",
+       "       181, 181, 181, 164, 164, 164, 163, 163, 171, 171, 165, 165, 166,\n",
+       "       169, 362, 362, 362, 362, 343, 343, 343, 344, 344, 183, 183, 183,\n",
+       "       183, 183, 191, 191, 191, 192, 192, 192, 174, 174, 174, 174, 175,\n",
+       "       175, 175, 261, 261, 261, 260, 322, 322, 322, 322, 173, 173, 173,\n",
+       "       179, 179, 179, 178, 178, 188, 188, 188, 188, 177, 177, 176, 176,\n",
+       "       182, 182, 182, 345, 345, 346, 346, 180, 172, 172, 172, 172, 159,\n",
+       "       262, 262, 184, 184, 184, 184, 265, 265, 265, 193, 193, 193, 193,\n",
+       "       204, 204, 204, 324, 324, 325, 325, 325, 186, 186, 186, 185, 185,\n",
+       "       195, 195, 195, 197, 197, 197, 338, 338, 187, 198, 198, 198, 198,\n",
+       "       198, 199, 199, 199, 199, 351, 351, 351, 339, 339, 339, 353, 353,\n",
+       "       353, 353, 263, 196, 194, 189, 189, 189, 200, 200, 190, 190, 342,\n",
+       "       342, 205, 205, 205, 201, 201, 202, 202, 264, 203, 341, 341, 348,\n",
+       "       348, 348, 326, 326, 327, 327, 327, 266, 266, 328, 206, 270, 270,\n",
+       "       271, 273, 273, 273,  35, 218, 279, 289, 290, 292, 298, 299, 315,\n",
+       "       313, 257, 257, 319, 320, 321, 347, 355, 355, 267, 350, 349, 365,\n",
+       "       366,   0,  19, 194, 329])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>edges_face2</span></div><div class='xr-var-dims'>(nedge)</div><div class='xr-var-dtype'>int32</div><div class='xr-var-preview xr-preview'>207 208 1 367 ... 440 441 442 443</div><input id='attrs-d151ca86-b33c-45df-be35-03835fbe6c59' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-d151ca86-b33c-45df-be35-03835fbe6c59' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-866ba51e-f524-415d-9fcd-fa0b4693d1ad' class='xr-var-data-in' type='checkbox'><label for='data-866ba51e-f524-415d-9fcd-fa0b4693d1ad' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>Units :</span></dt><dd></dd></dl></div><div class='xr-var-data'><pre>array([207, 208,   1, 367, 208, 368, 268, 269, 209,   1,  29,  38,  31,\n",
+       "        26,  38,  25,  28, 223, 224, 224, 225,  51,  39,   5, 369,   3,\n",
+       "       211, 212,   6, 370, 253, 316, 255, 335, 334, 334,  90, 252, 315,\n",
+       "       315, 131, 132, 317, 216, 278, 218,  10,   9, 215, 277, 277,  46,\n",
+       "        47, 279,  18,  27, 371, 213, 211, 273, 274, 214,   6, 209,   2,\n",
+       "       372, 373,   2, 210, 211, 209, 210, 374, 270, 210, 271, 211,   7,\n",
+       "       375, 272, 214,   8, 376, 215,   9, 377,  10, 378,  11, 379, 218,\n",
+       "        20,  12, 380,  37, 276, 214, 274,  36, 276,  36,  44,  45,  45,\n",
+       "       277, 215,  20,  13, 381,  21,  14, 382,  22,  15, 383,  21, 218,\n",
+       "       219, 219, 220,  22,  23,  16, 384, 220, 221,  23,  24,  17, 385,\n",
+       "        25,  18, 386, 221, 222,  28,  24,  26, 387,  28,  25,  26, 215,\n",
+       "        45,  36, 302, 301, 301, 300,  55,  46, 277,  27,  61, 283,  50,\n",
+       "        59,  69, 283,  70,  71, 285, 284, 284, 222, 282,  31, 388,  39,\n",
+       "       389, 222, 223, 222, 284, 224,  51, 390,  72, 227,  87, 391, 227,\n",
+       "       392,  62, 226, 226, 288, 228,  32,  43,  34, 271, 270, 269,  41,\n",
+       "        42,  42,  54, 304, 303,  34,  42, 269, 268,  40,  53,  54,  46,\n",
+       "       219, 281, 221, 241, 242, 243,  74,  84,  76, 242,  76, 240, 302,\n",
+       "       303, 243, 225,  62, 393,  91,  99, 394,  87,  87, 228, 229,  97,\n",
+       "        98,  98, 110, 361, 395, 396,  40, 269, 397,  52,  52,  64,  54,\n",
+       "       303,  35, 273, 272, 398,  63, 304, 302,  35, 305, 243,  64, 306,\n",
+       "...\n",
+       "       160, 146, 365, 154, 170, 156, 153, 169, 169, 182, 342, 343, 171,\n",
+       "       148, 164, 150, 152, 413, 163, 171, 165, 151, 166, 152, 167, 153,\n",
+       "       168, 356, 321, 260, 260, 362, 362, 159, 160, 160, 161, 366, 365,\n",
+       "       161, 159, 173, 174, 267, 328, 414, 167, 181, 169, 166, 180, 180,\n",
+       "       339, 340, 182, 163, 177, 165, 415, 176, 343, 344, 178, 166, 179,\n",
+       "       182, 260, 261, 262, 159, 344, 342, 351, 352, 345, 191, 184, 355,\n",
+       "       354, 190, 192, 190, 202, 203, 193, 184, 173, 265, 266, 175, 266,\n",
+       "       267, 416, 260, 323, 262, 322, 321, 347, 355, 323, 172, 264, 265,\n",
+       "       178, 188, 180, 177, 187, 187, 197, 338, 180, 176, 186, 417, 185,\n",
+       "       340, 341, 342, 346, 353, 354, 347, 339, 159, 262, 263, 264, 262,\n",
+       "       324, 263, 193, 324, 323, 355, 264, 327, 266, 204, 205, 325, 324,\n",
+       "       203, 418, 205, 325, 323, 205, 326, 263, 185, 195, 187, 419, 194,\n",
+       "       194, 420, 196, 338, 196, 421, 422, 339, 196, 199, 351, 350, 349,\n",
+       "       423, 351, 424, 200, 189, 189, 352, 350, 425, 348, 340, 352, 189,\n",
+       "       190, 354, 264, 426, 427, 200, 190, 352, 428, 201, 201, 354, 341,\n",
+       "       350, 429, 206, 326, 202, 430, 431, 203, 326, 432, 340, 349, 433,\n",
+       "       349, 340, 327, 206, 206, 434, 328, 328, 267, 435, 436, 269, 271,\n",
+       "       272, 272,  35, 274, 274, 279, 280, 290, 291, 291, 299, 300, 314,\n",
+       "       314, 256, 319, 320, 321, 347, 355, 323, 354, 437, 349, 438, 366,\n",
+       "       439, 440, 441, 442, 443])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>faces_surface_area</span></div><div class='xr-var-dims'>(nface)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>1.209e+04 1.155e+04 ... 0.0 0.0</div><input id='attrs-62df9e49-d671-4a50-8414-f13d06cd5346' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-62df9e49-d671-4a50-8414-f13d06cd5346' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-99b1805f-c324-4b89-b755-b1ab1595dc5b' class='xr-var-data-in' type='checkbox'><label for='data-99b1805f-c324-4b89-b755-b1ab1595dc5b' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>Can Plot :</span></dt><dd>False</dd><dt><span>Column :</span></dt><dd>[&#x27;Surface Area&#x27;]</dd><dt><span>Row :</span></dt><dd>Cell</dd></dl></div><div class='xr-var-data'><pre>array([12093.502 , 11548.585 , 11171.599 , 10933.172 , 10845.208 ,\n",
+       "       11057.737 , 11076.327 , 11159.808 , 11355.937 , 11707.954 ,\n",
+       "       12179.411 , 12372.714 , 10000.    , 10000.    , 10000.    ,\n",
+       "       10000.    , 10000.    , 10000.    , 10000.    , 10000.    ,\n",
+       "       10192.167 , 10157.063 , 11570.182 , 12511.738 , 10000.    ,\n",
+       "       10000.    , 10000.    , 10000.    , 11643.33  , 12375.317 ,\n",
+       "       10000.    , 10000.    , 10225.055 ,  9011.354 , 11800.216 ,\n",
+       "       11948.948 , 11381.768 , 10379.308 , 13925.537 , 10000.    ,\n",
+       "       12904.911 , 12812.023 , 10000.    , 12647.637 , 11685.764 ,\n",
+       "       15638.24  , 13152.936 , 12571.16  , 11801.007 , 10739.222 ,\n",
+       "       10746.115 , 12266.823 , 10000.    , 10000.    , 10505.016 ,\n",
+       "       14465.06  , 10000.    , 10000.    , 10000.    , 10000.    ,\n",
+       "       12278.9795, 12606.872 , 11669.523 , 10000.    , 10422.424 ,\n",
+       "       13378.265 , 12460.002 , 10000.    , 10000.    , 10000.    ,\n",
+       "       10000.    , 11893.997 , 10883.659 , 11015.559 , 11371.164 ,\n",
+       "       12317.797 , 12140.093 , 11477.414 , 10786.679 , 11399.253 ,\n",
+       "       12984.431 , 11392.88  , 11576.466 , 11528.987 , 11435.215 ,\n",
+       "       12482.378 , 12737.938 , 12552.909 , 11622.415 , 11061.124 ,\n",
+       "       14263.398 , 13467.075 , 10000.    , 10000.    , 13848.663 ,\n",
+       "       12374.09  , 11786.802 , 11719.413 , 10000.    , 12591.233 ,\n",
+       "...\n",
+       "        9677.272 ,  9377.417 , 11661.28  , 13107.175 , 12163.041 ,\n",
+       "        9246.305 , 11232.672 ,  9340.985 , 10520.21  , 10267.455 ,\n",
+       "       11053.815 , 10812.306 , 10158.613 ,  8401.925 , 10414.027 ,\n",
+       "        9197.689 , 15348.971 , 11569.981 ,  9116.009 , 10310.002 ,\n",
+       "        8289.561 , 14907.459 ,     0.    ,     0.    ,     0.    ,\n",
+       "           0.    ,     0.    ,     0.    ,     0.    ,     0.    ,\n",
+       "           0.    ,     0.    ,     0.    ,     0.    ,     0.    ,\n",
+       "           0.    ,     0.    ,     0.    ,     0.    ,     0.    ,\n",
+       "           0.    ,     0.    ,     0.    ,     0.    ,     0.    ,\n",
+       "           0.    ,     0.    ,     0.    ,     0.    ,     0.    ,\n",
+       "           0.    ,     0.    ,     0.    ,     0.    ,     0.    ,\n",
+       "           0.    ,     0.    ,     0.    ,     0.    ,     0.    ,\n",
+       "           0.    ,     0.    ,     0.    ,     0.    ,     0.    ,\n",
+       "           0.    ,     0.    ,     0.    ,     0.    ,     0.    ,\n",
+       "           0.    ,     0.    ,     0.    ,     0.    ,     0.    ,\n",
+       "           0.    ,     0.    ,     0.    ,     0.    ,     0.    ,\n",
+       "           0.    ,     0.    ,     0.    ,     0.    ,     0.    ,\n",
+       "           0.    ,     0.    ,     0.    ,     0.    ,     0.    ,\n",
+       "           0.    ,     0.    ,     0.    ,     0.    ,     0.    ,\n",
+       "           0.    ,     0.    ,     0.    ,     0.    ], dtype=float32)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>edge_velocity</span></div><div class='xr-var-dims'>(time, nedge)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>0.0 0.0 0.0 0.0 ... 0.0 0.0 0.5212</div><input id='attrs-b8bbcdb4-1b6e-4364-97d4-4831625d3d70' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-b8bbcdb4-1b6e-4364-97d4-4831625d3d70' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-e1978c75-a3fa-4236-b5ba-7ba0e6e52dfa' class='xr-var-data-in' type='checkbox'><label for='data-e1978c75-a3fa-4236-b5ba-7ba0e6e52dfa' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>Can Interpolate :</span></dt><dd>True</dd><dt><span>Can Plot :</span></dt><dd>True</dd><dt><span>Columns :</span></dt><dd>Faces</dd><dt><span>Coverage :</span></dt><dd>Wet</dd><dt><span>Location :</span></dt><dd>Faces</dd><dt><span>Maximum Value of Data Set :</span></dt><dd>nan</dd><dt><span>Name :</span></dt><dd>Velocity</dd><dt><span>Orientation :</span></dt><dd>Normal</dd><dt><span>Rows :</span></dt><dd>Times</dd><dt><span>Units :</span></dt><dd>m/s</dd></dl></div><div class='xr-var-data'><pre>array([[0.        , 0.        , 0.        , ..., 0.        , 0.        ,\n",
+       "        0.        ],\n",
+       "       [0.        , 0.        , 0.        , ..., 0.        , 0.        ,\n",
+       "        0.        ],\n",
+       "       [0.        , 0.        , 0.        , ..., 0.        , 0.        ,\n",
+       "        0.        ],\n",
+       "       ...,\n",
+       "       [0.        , 0.        , 0.        , ..., 0.        , 0.        ,\n",
+       "        0.52121276],\n",
+       "       [0.        , 0.        , 0.        , ..., 0.        , 0.        ,\n",
+       "        0.52121276],\n",
+       "       [0.        , 0.        , 0.        , ..., 0.        , 0.        ,\n",
+       "        0.52121276]], dtype=float32)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>edge_length</span></div><div class='xr-var-dims'>(nedge)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>85.89 17.44 113.5 ... 100.0 128.8</div><input id='attrs-f30bff56-4c4c-48f7-9e59-364866a57519' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-f30bff56-4c4c-48f7-9e59-364866a57519' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-af9e9dd8-b0fa-404d-9723-b5f25f63b06c' class='xr-var-data-in' type='checkbox'><label for='data-af9e9dd8-b0fa-404d-9723-b5f25f63b06c' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>Units :</span></dt><dd>ft</dd></dl></div><div class='xr-var-data'><pre>array([ 85.89211 ,  17.439554, 113.48682 , 100.      , 113.06435 ,\n",
+       "       130.11964 ,  99.31437 ,  99.31749 , 109.39354 ,  88.81981 ,\n",
+       "       100.      , 100.      , 100.      , 100.      ,  47.654926,\n",
+       "       100.      , 108.437805,  24.934294,  50.220978,  93.907425,\n",
+       "        58.96602 ,  50.471256, 100.      , 110.694496, 100.      ,\n",
+       "       106.20966 , 100.10052 , 100.000275, 110.460236, 100.      ,\n",
+       "        51.840977,  99.29926 ,  57.092033,  62.797802,  65.7461  ,\n",
+       "        91.43993 ,  46.153507, 101.7107  ,  99.314575, 121.785515,\n",
+       "        56.962395,  45.561947, 101.98182 , 120.9206  ,  99.31481 ,\n",
+       "       127.53077 , 100.1376  , 100.08738 , 115.67217 ,  99.3232  ,\n",
+       "       125.6258  ,  25.746962,  73.28819 , 119.10959 , 100.      ,\n",
+       "       100.      , 100.      , 106.35971 , 105.50783 ,  99.32356 ,\n",
+       "        99.31784 , 107.15623 , 100.00184 ,  14.152593, 109.41352 ,\n",
+       "       100.      , 100.      , 107.216225,  93.56978 ,   8.411393,\n",
+       "        91.33729 ,  11.232904, 100.      ,  99.315   , 106.179   ,\n",
+       "        99.31781 , 105.758255, 111.066315, 100.      ,  99.32246 ,\n",
+       "       100.00565 , 112.12984 , 100.      , 100.04086 , 114.988884,\n",
+       "       100.      , 119.17019 , 100.      , 124.41802 , 100.      ,\n",
+       "        69.78516 ,  43.103107, 100.      , 100.      ,  88.287224,\n",
+       "        82.55536 ,  99.30882 ,  87.09727 ,  13.797156,  75.98283 ,\n",
+       "...\n",
+       "       100.      , 100.      , 100.73506 , 100.      ,  97.64508 ,\n",
+       "       116.70721 , 172.67032 , 100.      , 105.26687 ,  16.351381,\n",
+       "        96.13597 ,  85.58452 , 136.98862 ,  74.40756 , 100.      ,\n",
+       "       100.      ,  42.041985,  17.8536  , 109.39284 , 102.350555,\n",
+       "        39.445755,  83.03847 , 108.884384,  86.23403 ,  51.86689 ,\n",
+       "        55.69457 , 112.298965,  88.05103 , 100.      , 100.      ,\n",
+       "       100.      ,  98.142006,  98.26594 , 100.      , 100.      ,\n",
+       "       100.      ,  27.054056,  92.423836,  95.497986, 100.      ,\n",
+       "        96.17716 ,  43.140568, 100.      , 100.      , 100.      ,\n",
+       "       100.      ,  99.21852 , 100.      ,  83.33201 ,  95.497986,\n",
+       "       173.11029 , 133.3166  ,  95.497986,  77.49693 ,  81.49823 ,\n",
+       "       125.902985,  16.832644, 152.82161 ,  99.262886, 131.5571  ,\n",
+       "       116.32402 , 153.72005 ,  84.86046 ,  91.74184 ,  90.69268 ,\n",
+       "        89.94224 ,  93.676575,  88.41198 ,   9.854439,  99.29854 ,\n",
+       "       110.2637  , 125.302925, 114.64001 , 115.68813 , 128.34367 ,\n",
+       "       112.596176,  83.31521 , 102.19095 ,  94.54581 ,  99.17044 ,\n",
+       "        90.623886, 111.21425 ,  77.387024,  95.497986,  46.834377,\n",
+       "        81.45024 , 137.7868  ,  91.29342 ,  36.103046,  91.270935,\n",
+       "        59.904865, 119.09156 , 100.      , 100.      , 128.82701 ],\n",
+       "      dtype=float32)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>water_surface_elev</span></div><div class='xr-var-dims'>(time, nface)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>22.24 22.22 22.26 ... 24.0 20.75</div><input id='attrs-2e76211c-94a5-42d5-9090-4090e9b3913f' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-2e76211c-94a5-42d5-9090-4090e9b3913f' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-39625c1a-7f3f-44f9-9d9b-64c58771a366' class='xr-var-data-in' type='checkbox'><label for='data-39625c1a-7f3f-44f9-9d9b-64c58771a366' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>Can Interpolate :</span></dt><dd>True</dd><dt><span>Can Plot :</span></dt><dd>True</dd><dt><span>Columns :</span></dt><dd>Cells</dd><dt><span>Coverage :</span></dt><dd>Wet</dd><dt><span>Location :</span></dt><dd>Cells</dd><dt><span>Maximum Value of Data Set :</span></dt><dd>21.932491</dd><dt><span>Minimum Value of Data Set :</span></dt><dd>20.750002</dd><dt><span>Name :</span></dt><dd>Water Surface</dd><dt><span>Orientation :</span></dt><dd>Scalar</dd><dt><span>Rows :</span></dt><dd>Times</dd><dt><span>Units :</span></dt><dd>m</dd></dl></div><div class='xr-var-data'><pre>array([[22.243147, 22.22242 , 22.258389, ..., 24.      , 24.      ,\n",
+       "        20.      ],\n",
+       "       [22.243147, 22.22242 , 22.258389, ..., 24.      , 24.      ,\n",
+       "        20.750002],\n",
+       "       [22.243147, 22.22242 , 22.258389, ..., 24.      , 24.      ,\n",
+       "        20.750002],\n",
+       "       ...,\n",
+       "       [22.243147, 22.22242 , 22.258389, ..., 24.      , 24.      ,\n",
+       "        20.750002],\n",
+       "       [22.243147, 22.22242 , 22.258389, ..., 24.      , 24.      ,\n",
+       "        20.750002],\n",
+       "       [22.243147, 22.22242 , 22.258389, ..., 24.      , 24.      ,\n",
+       "        20.750002]], dtype=float32)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>volume</span></div><div class='xr-var-dims'>(time, nface)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>0.0 0.0 0.0 0.0 ... 0.0 0.0 0.5214</div><input id='attrs-f5498300-e9dd-4a2c-b10e-7d3901dd29af' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-f5498300-e9dd-4a2c-b10e-7d3901dd29af' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-056fe325-b8e2-4ec7-b132-37521ef978b1' class='xr-var-data-in' type='checkbox'><label for='data-056fe325-b8e2-4ec7-b132-37521ef978b1' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>Can Interpolate :</span></dt><dd>True</dd><dt><span>Can Plot :</span></dt><dd>True</dd><dt><span>Columns :</span></dt><dd>Cells</dd><dt><span>Coverage :</span></dt><dd>Wet</dd><dt><span>Location :</span></dt><dd>Cells</dd><dt><span>Maximum Value of Data Set :</span></dt><dd>16477.807</dd><dt><span>Name :</span></dt><dd>Volume</dd><dt><span>Orientation :</span></dt><dd>Scalar</dd><dt><span>Rows :</span></dt><dd>Times</dd><dt><span>Units :</span></dt><dd>ft^3</dd></dl></div><div class='xr-var-data'><pre>array([[0.        , 0.        , 0.        , ..., 0.        , 0.        ,\n",
+       "        0.07465479],\n",
+       "       [0.        , 0.        , 0.        , ..., 0.        , 0.        ,\n",
+       "        0.5653213 ],\n",
+       "       [0.        , 0.        , 0.        , ..., 0.        , 0.        ,\n",
+       "        0.5653213 ],\n",
+       "       ...,\n",
+       "       [0.        , 0.        , 0.        , ..., 0.        , 0.        ,\n",
+       "        0.52144784],\n",
+       "       [0.        , 0.        , 0.        , ..., 0.        , 0.        ,\n",
+       "        0.52144784],\n",
+       "       [0.        , 0.        , 0.        , ..., 0.        , 0.        ,\n",
+       "        0.52144784]], dtype=float32)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>face_flow</span></div><div class='xr-var-dims'>(time, nedge)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>0.0 0.0 0.0 0.0 ... 0.0 0.0 14.48</div><input id='attrs-5ca53062-fc69-4014-b378-9b9554afa9e6' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-5ca53062-fc69-4014-b378-9b9554afa9e6' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-60206c15-7312-4f6b-9f5e-04a00de43bbd' class='xr-var-data-in' type='checkbox'><label for='data-60206c15-7312-4f6b-9f5e-04a00de43bbd' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>Can Interpolate :</span></dt><dd>True</dd><dt><span>Can Plot :</span></dt><dd>True</dd><dt><span>Columns :</span></dt><dd>Faces</dd><dt><span>Coverage :</span></dt><dd>Wet</dd><dt><span>Location :</span></dt><dd>Faces</dd><dt><span>Maximum Value of Data Set :</span></dt><dd>nan</dd><dt><span>Name :</span></dt><dd>Flow</dd><dt><span>Orientation :</span></dt><dd>Normal</dd><dt><span>Rows :</span></dt><dd>Times</dd><dt><span>Units :</span></dt><dd>m^3/s</dd></dl></div><div class='xr-var-data'><pre>array([[ 0.      ,  0.      ,  0.      , ...,  0.      ,  0.      ,\n",
+       "         0.      ],\n",
+       "       [ 0.      ,  0.      ,  0.      , ...,  0.      ,  0.      ,\n",
+       "         0.      ],\n",
+       "       [ 0.      ,  0.      ,  0.      , ...,  0.      ,  0.      ,\n",
+       "         0.      ],\n",
+       "       ...,\n",
+       "       [ 0.      ,  0.      ,  0.      , ...,  0.      ,  0.      ,\n",
+       "        14.482463],\n",
+       "       [ 0.      ,  0.      ,  0.      , ...,  0.      ,  0.      ,\n",
+       "        14.482463],\n",
+       "       [ 0.      ,  0.      ,  0.      , ...,  0.      ,  0.      ,\n",
+       "        14.482463]], dtype=float32)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>advection_coeff</span></div><div class='xr-var-dims'>(time, nedge)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>0.0 0.0 0.0 0.0 ... 0.0 0.0 14.48</div><input id='attrs-676ca099-f2fa-4276-a673-15e63a622edf' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-676ca099-f2fa-4276-a673-15e63a622edf' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-d83c93d5-f3db-4f28-b20b-53b7ada08a2a' class='xr-var-data-in' type='checkbox'><label for='data-d83c93d5-f3db-4f28-b20b-53b7ada08a2a' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>Units :</span></dt><dd>m3/s</dd></dl></div><div class='xr-var-data'><pre>array([[ 0.      ,  0.      ,  0.      , ...,  0.      ,  0.      ,\n",
+       "         0.      ],\n",
+       "       [ 0.      ,  0.      ,  0.      , ...,  0.      ,  0.      ,\n",
+       "         0.      ],\n",
+       "       [ 0.      ,  0.      ,  0.      , ...,  0.      ,  0.      ,\n",
+       "         0.      ],\n",
+       "       ...,\n",
+       "       [ 0.      ,  0.      ,  0.      , ...,  0.      ,  0.      ,\n",
+       "        14.482463],\n",
+       "       [ 0.      ,  0.      ,  0.      , ...,  0.      ,  0.      ,\n",
+       "        14.482463],\n",
+       "       [ 0.      ,  0.      ,  0.      , ...,  0.      ,  0.      ,\n",
+       "        14.482463]], dtype=float32)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>edge_vertical_area</span></div><div class='xr-var-dims'>(time, nedge)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>0.0 0.0 0.0 0.0 ... 0.0 0.0 27.79</div><input id='attrs-ac2967bb-1bdc-459e-aa83-91b3ff540a6d' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-ac2967bb-1bdc-459e-aa83-91b3ff540a6d' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-9351e2ec-41b1-4fd3-92cf-2c87733e2dba' class='xr-var-data-in' type='checkbox'><label for='data-9351e2ec-41b1-4fd3-92cf-2c87733e2dba' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>Units :</span></dt><dd>m2</dd></dl></div><div class='xr-var-data'><pre>array([[ 0.      ,  0.      ,  0.      , ...,  0.      ,  0.      ,\n",
+       "         0.      ],\n",
+       "       [ 0.      ,  0.      ,  0.      , ...,  0.      ,  0.      ,\n",
+       "         0.      ],\n",
+       "       [ 0.      ,  0.      ,  0.      , ...,  0.      ,  0.      ,\n",
+       "         0.      ],\n",
+       "       ...,\n",
+       "       [ 0.      ,  0.      ,  0.      , ...,  0.      ,  0.      ,\n",
+       "        27.786087],\n",
+       "       [ 0.      ,  0.      ,  0.      , ...,  0.      ,  0.      ,\n",
+       "        27.786087],\n",
+       "       [ 0.      ,  0.      ,  0.      , ...,  0.      ,  0.      ,\n",
+       "        27.786087]], dtype=float32)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>face_to_face_dist</span></div><div class='xr-var-dims'>(nedge)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>143.2 161.4 100.0 ... 50.0 55.01</div><input id='attrs-58e2798e-f727-417e-896c-f7cc055b8a5b' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-58e2798e-f727-417e-896c-f7cc055b8a5b' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-acc4b5ef-1cdd-4ea4-b552-377bd5fb57b6' class='xr-var-data-in' type='checkbox'><label for='data-acc4b5ef-1cdd-4ea4-b552-377bd5fb57b6' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>Units :</span></dt><dd>m</dd></dl></div><div class='xr-var-data'><pre>array([143.21540974, 161.42024958, 100.        ,  50.        ,\n",
+       "       101.49697922,  43.43809912, 100.        , 100.        ,\n",
+       "       100.42040736, 131.83277573, 100.        , 100.        ,\n",
+       "       100.        , 100.        , 141.42135624, 100.        ,\n",
+       "       100.        , 152.33126379, 161.68127564, 135.34648695,\n",
+       "       154.58009105, 141.42135624, 100.        , 100.        ,\n",
+       "        50.        , 100.        , 116.78676788, 116.48627536,\n",
+       "       100.        ,  50.        , 100.97619201, 100.        ,\n",
+       "       102.04391921,  71.19936701,  67.1136868 ,  79.090229  ,\n",
+       "       136.71038729, 100.45425643, 100.        ,  97.61372313,\n",
+       "       152.36809034, 138.49336843,  96.45721828, 100.53690985,\n",
+       "       100.        , 101.2655537 , 146.02827476, 135.33645481,\n",
+       "       100.27430882, 100.        ,  98.09911107, 176.12547534,\n",
+       "       155.54294689,  97.30311011, 100.        , 100.        ,\n",
+       "        49.99999999,  99.71616096, 100.19919835, 100.        ,\n",
+       "       100.        , 101.06460223, 117.47669781, 155.0912824 ,\n",
+       "       100.        ,  50.        ,  50.        , 100.        ,\n",
+       "       118.90372266, 150.30855572, 123.91608102, 151.80937842,\n",
+       "        50.        , 100.        , 101.1713926 , 100.        ,\n",
+       "       100.24978554, 100.        ,  50.        , 100.        ,\n",
+       "...\n",
+       "       141.42135624, 148.1203963 ,  95.49798263,  95.49798263,\n",
+       "       103.16115718, 138.27459884,  95.49798263,  95.49798263,\n",
+       "       116.50431365, 135.18059706,  95.49798263,  91.2081525 ,\n",
+       "        50.00000004,  50.        , 100.        , 100.        ,\n",
+       "        92.93324897,  50.00000004, 100.        , 100.        ,\n",
+       "       155.84579725,  95.49798263, 100.        ,  50.00000004,\n",
+       "       100.        , 135.6540887 , 100.        ,  50.00000004,\n",
+       "        50.00000004, 100.        , 100.        ,  50.00000004,\n",
+       "        95.49798263, 100.        ,  54.37549584,  95.49798263,\n",
+       "       100.        , 106.00042756, 100.32483763, 112.00682171,\n",
+       "       116.33219621, 104.94170053, 100.        ,  94.16001165,\n",
+       "        93.65580951,  56.75791385,  98.20041301,  97.42108072,\n",
+       "        98.3852236 ,  98.43925773,  83.81304777,  98.93043931,\n",
+       "       124.64797774, 100.        ,  96.88042599,  79.08844546,\n",
+       "        77.95811688,  81.84148604,  87.44076823,  98.16289367,\n",
+       "        98.1729813 ,  98.7708855 , 105.69997106, 100.        ,\n",
+       "        88.33452989,  87.94799687, 120.56789845, 100.        ,\n",
+       "       141.48526132,  95.49798263,  49.62389509,  95.49798263,\n",
+       "        96.53218897,  90.82490657, 105.16093569,  50.90306391,\n",
+       "        50.        ,  50.00000004,  55.0128063 ])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>coeff_to_diffusion</span></div><div class='xr-var-dims'>(time, nedge)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>0.0 0.0 0.0 0.0 ... 0.0 0.0 0.05051</div><input id='attrs-88719c20-2ebe-4aec-aae5-06e034d43fd3' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-88719c20-2ebe-4aec-aae5-06e034d43fd3' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-dde6b072-30bc-4118-9bb0-81c9fe92ca4f' class='xr-var-data-in' type='checkbox'><label for='data-dde6b072-30bc-4118-9bb0-81c9fe92ca4f' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>Units :</span></dt><dd>m3/s</dd></dl></div><div class='xr-var-data'><pre>array([[0.       , 0.       , 0.       , ..., 0.       , 0.       ,\n",
+       "        0.       ],\n",
+       "       [0.       , 0.       , 0.       , ..., 0.       , 0.       ,\n",
+       "        0.       ],\n",
+       "       [0.       , 0.       , 0.       , ..., 0.       , 0.       ,\n",
+       "        0.       ],\n",
+       "       ...,\n",
+       "       [0.       , 0.       , 0.       , ..., 0.       , 0.       ,\n",
+       "        0.0505084],\n",
+       "       [0.       , 0.       , 0.       , ..., 0.       , 0.       ,\n",
+       "        0.0505084],\n",
+       "       [0.       , 0.       , 0.       , ..., 0.       , 0.       ,\n",
+       "        0.0505084]])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>dt</span></div><div class='xr-var-dims'>(time)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>30.0 30.0 30.0 ... 30.0 30.0 nan</div><input id='attrs-47dc120c-cbb5-4898-bc42-c0bc9221dd27' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-47dc120c-cbb5-4898-bc42-c0bc9221dd27' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-cec0a89a-1029-4fd3-a3f4-84fe5bb41cd3' class='xr-var-data-in' type='checkbox'><label for='data-cec0a89a-1029-4fd3-a3f4-84fe5bb41cd3' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>Units :</span></dt><dd>s</dd></dl></div><div class='xr-var-data'><pre>array([30., 30., 30., ..., 30., 30., nan])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>tracer</span></div><div class='xr-var-dims'>(time, nface)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>100.0 100.0 100.0 ... nan nan nan</div><input id='attrs-9a93d53c-5e49-42f9-adcd-1cc43cdd9669' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-9a93d53c-5e49-42f9-adcd-1cc43cdd9669' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-cf924e7d-6fe8-4777-ab0f-e05b519cb995' class='xr-var-data-in' type='checkbox'><label for='data-cf924e7d-6fe8-4777-ab0f-e05b519cb995' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>Units :</span></dt><dd>mg/L</dd></dl></div><div class='xr-var-data'><pre>array([[100., 100., 100., ...,   0.,   0.,   0.],\n",
+       "       [ nan,  nan,  nan, ...,  nan,  nan,  nan],\n",
+       "       [ nan,  nan,  nan, ...,  nan,  nan,  nan],\n",
+       "       ...,\n",
+       "       [ nan,  nan,  nan, ...,  nan,  nan,  nan],\n",
+       "       [ nan,  nan,  nan, ...,  nan,  nan,  nan],\n",
+       "       [ nan,  nan,  nan, ...,  nan,  nan,  nan]])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>Ap</span></div><div class='xr-var-dims'>(time, nface)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>10.0 10.0 10.0 10.0 ... nan nan nan</div><input id='attrs-6e34af4d-0027-4081-a83f-b01ac7a81071' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-6e34af4d-0027-4081-a83f-b01ac7a81071' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-d7dc33bd-6165-4728-84d9-8a099ae02fb9' class='xr-var-data-in' type='checkbox'><label for='data-d7dc33bd-6165-4728-84d9-8a099ae02fb9' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>Units :</span></dt><dd>mg/L</dd></dl></div><div class='xr-var-data'><pre>array([[10., 10., 10., ..., 10., 10., 10.],\n",
+       "       [nan, nan, nan, ..., nan, nan, nan],\n",
+       "       [nan, nan, nan, ..., nan, nan, nan],\n",
+       "       ...,\n",
+       "       [nan, nan, nan, ..., nan, nan, nan],\n",
+       "       [nan, nan, nan, ..., nan, nan, nan],\n",
+       "       [nan, nan, nan, ..., nan, nan, nan]])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>DOX</span></div><div class='xr-var-dims'>(time, nface)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>8.0 8.0 8.0 8.0 ... nan nan nan nan</div><input id='attrs-75c5537b-215c-4148-adec-6be123ad6677' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-75c5537b-215c-4148-adec-6be123ad6677' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-1c2ad165-d4ae-4864-aba7-ced9f4a212d3' class='xr-var-data-in' type='checkbox'><label for='data-1c2ad165-d4ae-4864-aba7-ced9f4a212d3' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>Units :</span></dt><dd>mg/L</dd></dl></div><div class='xr-var-data'><pre>array([[ 8.,  8.,  8., ...,  8.,  8.,  8.],\n",
+       "       [nan, nan, nan, ..., nan, nan, nan],\n",
+       "       [nan, nan, nan, ..., nan, nan, nan],\n",
+       "       ...,\n",
+       "       [nan, nan, nan, ..., nan, nan, nan],\n",
+       "       [nan, nan, nan, ..., nan, nan, nan],\n",
+       "       [nan, nan, nan, ..., nan, nan, nan]])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>NH4</span></div><div class='xr-var-dims'>(time, nface)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>0.01 0.01 0.01 0.01 ... nan nan nan</div><input id='attrs-3c82be83-f4be-4942-a575-a59b993a17ac' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-3c82be83-f4be-4942-a575-a59b993a17ac' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-cc7c05ad-d971-4217-a246-cd38d4d5bea0' class='xr-var-data-in' type='checkbox'><label for='data-cc7c05ad-d971-4217-a246-cd38d4d5bea0' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>Units :</span></dt><dd>mg/L</dd></dl></div><div class='xr-var-data'><pre>array([[0.01, 0.01, 0.01, ..., 0.01, 0.01, 0.01],\n",
+       "       [ nan,  nan,  nan, ...,  nan,  nan,  nan],\n",
+       "       [ nan,  nan,  nan, ...,  nan,  nan,  nan],\n",
+       "       ...,\n",
+       "       [ nan,  nan,  nan, ...,  nan,  nan,  nan],\n",
+       "       [ nan,  nan,  nan, ...,  nan,  nan,  nan],\n",
+       "       [ nan,  nan,  nan, ...,  nan,  nan,  nan]])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>NO3</span></div><div class='xr-var-dims'>(time, nface)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>0.5 0.5 0.5 0.5 ... nan nan nan nan</div><input id='attrs-5242cb1e-9ece-4e61-8fcc-5c95e0a6c113' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-5242cb1e-9ece-4e61-8fcc-5c95e0a6c113' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-87e984c4-5321-4e19-a6c7-3db6d4c6c66e' class='xr-var-data-in' type='checkbox'><label for='data-87e984c4-5321-4e19-a6c7-3db6d4c6c66e' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>Units :</span></dt><dd>mg/L</dd></dl></div><div class='xr-var-data'><pre>array([[0.5, 0.5, 0.5, ..., 0.5, 0.5, 0.5],\n",
+       "       [nan, nan, nan, ..., nan, nan, nan],\n",
+       "       [nan, nan, nan, ..., nan, nan, nan],\n",
+       "       ...,\n",
+       "       [nan, nan, nan, ..., nan, nan, nan],\n",
+       "       [nan, nan, nan, ..., nan, nan, nan],\n",
+       "       [nan, nan, nan, ..., nan, nan, nan]])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>TIP</span></div><div class='xr-var-dims'>(time, nface)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>0.05 0.05 0.05 0.05 ... nan nan nan</div><input id='attrs-280c7ea3-5af0-4da0-943e-5ab77eac27b9' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-280c7ea3-5af0-4da0-943e-5ab77eac27b9' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-193919cb-3aad-4b5b-9afc-6e68023fb2ad' class='xr-var-data-in' type='checkbox'><label for='data-193919cb-3aad-4b5b-9afc-6e68023fb2ad' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>Units :</span></dt><dd>mg/L</dd></dl></div><div class='xr-var-data'><pre>array([[0.05, 0.05, 0.05, ..., 0.05, 0.05, 0.05],\n",
+       "       [ nan,  nan,  nan, ...,  nan,  nan,  nan],\n",
+       "       [ nan,  nan,  nan, ...,  nan,  nan,  nan],\n",
+       "       ...,\n",
+       "       [ nan,  nan,  nan, ...,  nan,  nan,  nan],\n",
+       "       [ nan,  nan,  nan, ...,  nan,  nan,  nan],\n",
+       "       [ nan,  nan,  nan, ...,  nan,  nan,  nan]])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>Ab</span></div><div class='xr-var-dims'>(time, nface)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>24.0 24.0 24.0 24.0 ... nan nan nan</div><input id='attrs-685aa4b9-5fe9-43ba-8005-c63fc2926b0c' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-685aa4b9-5fe9-43ba-8005-c63fc2926b0c' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-5572a686-8792-4cc0-a37d-c5cf2eabb7c6' class='xr-var-data-in' type='checkbox'><label for='data-5572a686-8792-4cc0-a37d-c5cf2eabb7c6' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>Units :</span></dt><dd>mg/L</dd></dl></div><div class='xr-var-data'><pre>array([[24., 24., 24., ..., 24., 24., 24.],\n",
+       "       [nan, nan, nan, ..., nan, nan, nan],\n",
+       "       [nan, nan, nan, ..., nan, nan, nan],\n",
+       "       ...,\n",
+       "       [nan, nan, nan, ..., nan, nan, nan],\n",
+       "       [nan, nan, nan, ..., nan, nan, nan],\n",
+       "       [nan, nan, nan, ..., nan, nan, nan]])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>OrgN</span></div><div class='xr-var-dims'>(time, nface)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>1.726 1.726 1.726 ... nan nan nan</div><input id='attrs-490e0a62-3fa4-407e-90cf-29dd9c8ee419' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-490e0a62-3fa4-407e-90cf-29dd9c8ee419' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-c6a21b03-888b-4d5e-a1f7-6e9790da8862' class='xr-var-data-in' type='checkbox'><label for='data-c6a21b03-888b-4d5e-a1f7-6e9790da8862' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>Units :</span></dt><dd>mg/L</dd></dl></div><div class='xr-var-data'><pre>array([[1.726, 1.726, 1.726, ..., 1.726, 1.726, 1.726],\n",
+       "       [  nan,   nan,   nan, ...,   nan,   nan,   nan],\n",
+       "       [  nan,   nan,   nan, ...,   nan,   nan,   nan],\n",
+       "       ...,\n",
+       "       [  nan,   nan,   nan, ...,   nan,   nan,   nan],\n",
+       "       [  nan,   nan,   nan, ...,   nan,   nan,   nan],\n",
+       "       [  nan,   nan,   nan, ...,   nan,   nan,   nan]])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>N2</span></div><div class='xr-var-dims'>(time, nface)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>1.0 1.0 1.0 1.0 ... nan nan nan nan</div><input id='attrs-18e460c3-cb0f-4d29-ad5c-7db9a7c251f3' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-18e460c3-cb0f-4d29-ad5c-7db9a7c251f3' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-b944dd6f-3dce-439c-96e3-d0a708eab6d3' class='xr-var-data-in' type='checkbox'><label for='data-b944dd6f-3dce-439c-96e3-d0a708eab6d3' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>Units :</span></dt><dd>mg/L</dd></dl></div><div class='xr-var-data'><pre>array([[ 1.,  1.,  1., ...,  1.,  1.,  1.],\n",
+       "       [nan, nan, nan, ..., nan, nan, nan],\n",
+       "       [nan, nan, nan, ..., nan, nan, nan],\n",
+       "       ...,\n",
+       "       [nan, nan, nan, ..., nan, nan, nan],\n",
+       "       [nan, nan, nan, ..., nan, nan, nan],\n",
+       "       [nan, nan, nan, ..., nan, nan, nan]])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>OrgP</span></div><div class='xr-var-dims'>(time, nface)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>0.24 0.24 0.24 0.24 ... nan nan nan</div><input id='attrs-1a59132e-d317-474d-b366-075842970df4' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-1a59132e-d317-474d-b366-075842970df4' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-03a959b8-6857-4f86-b10f-14959ceea6b7' class='xr-var-data-in' type='checkbox'><label for='data-03a959b8-6857-4f86-b10f-14959ceea6b7' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>Units :</span></dt><dd>mg/L</dd></dl></div><div class='xr-var-data'><pre>array([[0.24, 0.24, 0.24, ..., 0.24, 0.24, 0.24],\n",
+       "       [ nan,  nan,  nan, ...,  nan,  nan,  nan],\n",
+       "       [ nan,  nan,  nan, ...,  nan,  nan,  nan],\n",
+       "       ...,\n",
+       "       [ nan,  nan,  nan, ...,  nan,  nan,  nan],\n",
+       "       [ nan,  nan,  nan, ...,  nan,  nan,  nan],\n",
+       "       [ nan,  nan,  nan, ...,  nan,  nan,  nan]])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>POC</span></div><div class='xr-var-dims'>(time, nface)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>4.356 4.356 4.356 ... nan nan nan</div><input id='attrs-ba77b3b0-1bea-4063-9d97-c264596041d2' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-ba77b3b0-1bea-4063-9d97-c264596041d2' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-d56983df-a144-4688-aec4-956ddb013b43' class='xr-var-data-in' type='checkbox'><label for='data-d56983df-a144-4688-aec4-956ddb013b43' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>Units :</span></dt><dd>mg/L</dd></dl></div><div class='xr-var-data'><pre>array([[4.356, 4.356, 4.356, ..., 4.356, 4.356, 4.356],\n",
+       "       [  nan,   nan,   nan, ...,   nan,   nan,   nan],\n",
+       "       [  nan,   nan,   nan, ...,   nan,   nan,   nan],\n",
+       "       ...,\n",
+       "       [  nan,   nan,   nan, ...,   nan,   nan,   nan],\n",
+       "       [  nan,   nan,   nan, ...,   nan,   nan,   nan],\n",
+       "       [  nan,   nan,   nan, ...,   nan,   nan,   nan]])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>DOC</span></div><div class='xr-var-dims'>(time, nface)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>1.0 1.0 1.0 1.0 ... nan nan nan nan</div><input id='attrs-0fd0ac3c-2805-4c99-a206-725b3f2179ea' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-0fd0ac3c-2805-4c99-a206-725b3f2179ea' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-2a976f42-c14e-455c-a16d-3b5837c4b43a' class='xr-var-data-in' type='checkbox'><label for='data-2a976f42-c14e-455c-a16d-3b5837c4b43a' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>Units :</span></dt><dd>mg/L</dd></dl></div><div class='xr-var-data'><pre>array([[ 1.,  1.,  1., ...,  1.,  1.,  1.],\n",
+       "       [nan, nan, nan, ..., nan, nan, nan],\n",
+       "       [nan, nan, nan, ..., nan, nan, nan],\n",
+       "       ...,\n",
+       "       [nan, nan, nan, ..., nan, nan, nan],\n",
+       "       [nan, nan, nan, ..., nan, nan, nan],\n",
+       "       [nan, nan, nan, ..., nan, nan, nan]])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>DIC</span></div><div class='xr-var-dims'>(time, nface)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>1.0 1.0 1.0 1.0 ... nan nan nan nan</div><input id='attrs-eabd5b78-f4b0-4217-825b-c5e9fb47a7f0' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-eabd5b78-f4b0-4217-825b-c5e9fb47a7f0' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-65df7810-6106-48f1-8fa7-010bed53b1e0' class='xr-var-data-in' type='checkbox'><label for='data-65df7810-6106-48f1-8fa7-010bed53b1e0' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>Units :</span></dt><dd>mg/L</dd></dl></div><div class='xr-var-data'><pre>array([[ 1.,  1.,  1., ...,  1.,  1.,  1.],\n",
+       "       [nan, nan, nan, ..., nan, nan, nan],\n",
+       "       [nan, nan, nan, ..., nan, nan, nan],\n",
+       "       ...,\n",
+       "       [nan, nan, nan, ..., nan, nan, nan],\n",
+       "       [nan, nan, nan, ..., nan, nan, nan],\n",
+       "       [nan, nan, nan, ..., nan, nan, nan]])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>POM</span></div><div class='xr-var-dims'>(time, nface)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>1.0 1.0 1.0 1.0 ... nan nan nan nan</div><input id='attrs-affbb880-ca8e-41b9-921e-9ba7283f4344' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-affbb880-ca8e-41b9-921e-9ba7283f4344' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-83beb6ef-6e45-4360-a7d6-fc7bc40bc52b' class='xr-var-data-in' type='checkbox'><label for='data-83beb6ef-6e45-4360-a7d6-fc7bc40bc52b' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>Units :</span></dt><dd>mg/L</dd></dl></div><div class='xr-var-data'><pre>array([[ 1.,  1.,  1., ...,  1.,  1.,  1.],\n",
+       "       [nan, nan, nan, ..., nan, nan, nan],\n",
+       "       [nan, nan, nan, ..., nan, nan, nan],\n",
+       "       ...,\n",
+       "       [nan, nan, nan, ..., nan, nan, nan],\n",
+       "       [nan, nan, nan, ..., nan, nan, nan],\n",
+       "       [nan, nan, nan, ..., nan, nan, nan]])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>CBOD</span></div><div class='xr-var-dims'>(time, nface)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>1.0 1.0 1.0 1.0 ... nan nan nan nan</div><input id='attrs-2b4e3416-4ead-4951-8be7-90d3926e6e19' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-2b4e3416-4ead-4951-8be7-90d3926e6e19' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-248552fa-c76e-435a-aa61-f916adecdb01' class='xr-var-data-in' type='checkbox'><label for='data-248552fa-c76e-435a-aa61-f916adecdb01' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>Units :</span></dt><dd>mg/L</dd></dl></div><div class='xr-var-data'><pre>array([[ 1.,  1.,  1., ...,  1.,  1.,  1.],\n",
+       "       [nan, nan, nan, ..., nan, nan, nan],\n",
+       "       [nan, nan, nan, ..., nan, nan, nan],\n",
+       "       ...,\n",
+       "       [nan, nan, nan, ..., nan, nan, nan],\n",
+       "       [nan, nan, nan, ..., nan, nan, nan],\n",
+       "       [nan, nan, nan, ..., nan, nan, nan]])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>PX</span></div><div class='xr-var-dims'>(time, nface)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>1.0 1.0 1.0 1.0 ... nan nan nan nan</div><input id='attrs-77e0457a-298c-408a-916e-27798dca391a' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-77e0457a-298c-408a-916e-27798dca391a' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-d15f56a3-da86-4648-b327-629051465928' class='xr-var-data-in' type='checkbox'><label for='data-d15f56a3-da86-4648-b327-629051465928' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>Units :</span></dt><dd>mg/L</dd></dl></div><div class='xr-var-data'><pre>array([[ 1.,  1.,  1., ...,  1.,  1.,  1.],\n",
+       "       [nan, nan, nan, ..., nan, nan, nan],\n",
+       "       [nan, nan, nan, ..., nan, nan, nan],\n",
+       "       ...,\n",
+       "       [nan, nan, nan, ..., nan, nan, nan],\n",
+       "       [nan, nan, nan, ..., nan, nan, nan],\n",
+       "       [nan, nan, nan, ..., nan, nan, nan]])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>Alk</span></div><div class='xr-var-dims'>(time, nface)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>1.0 1.0 1.0 1.0 ... nan nan nan nan</div><input id='attrs-bc443766-5663-431d-bb95-9b520b9ecfae' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-bc443766-5663-431d-bb95-9b520b9ecfae' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-dd7a9feb-bd83-4422-9b24-09c7ad81b964' class='xr-var-data-in' type='checkbox'><label for='data-dd7a9feb-bd83-4422-9b24-09c7ad81b964' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>Units :</span></dt><dd>mg/L</dd></dl></div><div class='xr-var-data'><pre>array([[ 1.,  1.,  1., ...,  1.,  1.,  1.],\n",
+       "       [nan, nan, nan, ..., nan, nan, nan],\n",
+       "       [nan, nan, nan, ..., nan, nan, nan],\n",
+       "       ...,\n",
+       "       [nan, nan, nan, ..., nan, nan, nan],\n",
+       "       [nan, nan, nan, ..., nan, nan, nan],\n",
+       "       [nan, nan, nan, ..., nan, nan, nan]])</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-e30897a7-bfea-447f-b65a-9bc9001f34d3' class='xr-section-summary-in' type='checkbox'  ><label for='section-e30897a7-bfea-447f-b65a-9bc9001f34d3' class='xr-section-summary' >Indexes: <span>(1)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-index-name'><div>time</div></div><div class='xr-index-preview'>PandasIndex</div><div></div><input id='index-d5d79bda-53f7-4fa6-949a-8d44c63fdbab' class='xr-index-data-in' type='checkbox'/><label for='index-d5d79bda-53f7-4fa6-949a-8d44c63fdbab' title='Show/Hide index repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-index-data'><pre>PandasIndex(DatetimeIndex([&#x27;2022-05-13 00:00:00&#x27;, &#x27;2022-05-13 00:00:30&#x27;,\n",
+       "               &#x27;2022-05-13 00:01:00&#x27;, &#x27;2022-05-13 00:01:30&#x27;,\n",
+       "               &#x27;2022-05-13 00:02:00&#x27;, &#x27;2022-05-13 00:02:30&#x27;,\n",
+       "               &#x27;2022-05-13 00:03:00&#x27;, &#x27;2022-05-13 00:03:30&#x27;,\n",
+       "               &#x27;2022-05-13 00:04:00&#x27;, &#x27;2022-05-13 00:04:30&#x27;,\n",
+       "               ...\n",
+       "               &#x27;2022-05-14 23:55:30&#x27;, &#x27;2022-05-14 23:56:00&#x27;,\n",
+       "               &#x27;2022-05-14 23:56:30&#x27;, &#x27;2022-05-14 23:57:00&#x27;,\n",
+       "               &#x27;2022-05-14 23:57:30&#x27;, &#x27;2022-05-14 23:58:00&#x27;,\n",
+       "               &#x27;2022-05-14 23:58:30&#x27;, &#x27;2022-05-14 23:59:00&#x27;,\n",
+       "               &#x27;2022-05-14 23:59:30&#x27;, &#x27;2022-05-15 00:00:00&#x27;],\n",
+       "              dtype=&#x27;datetime64[ns]&#x27;, name=&#x27;time&#x27;, length=5761, freq=None))</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-09ab1e5e-9087-4684-bed3-e5faddf3bd97' class='xr-section-summary-in' type='checkbox'  ><label for='section-09ab1e5e-9087-4684-bed3-e5faddf3bd97' class='xr-section-summary' >Attributes: <span>(13)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><dl class='xr-attrs'><dt><span>Conventions :</span></dt><dd>CF-1.8 UGRID-1.0 Deltares-0.10</dd><dt><span>diffusion_coefficient :</span></dt><dd>0.1</dd><dt><span>volume_calculation_required :</span></dt><dd>False</dd><dt><span>face_area_calculation_required :</span></dt><dd>False</dd><dt><span>face_area_elevation_info :</span></dt><dd>Empty DataFrame\n",
+       "Columns: []\n",
+       "Index: []</dd><dt><span>face_area_elevation_values :</span></dt><dd>Empty DataFrame\n",
+       "Columns: []\n",
+       "Index: []</dd><dt><span>face_normalunitvector_and_length :</span></dt><dd>Empty DataFrame\n",
+       "Columns: []\n",
+       "Index: []</dd><dt><span>face_cell_indexes_df :</span></dt><dd>Empty DataFrame\n",
+       "Columns: []\n",
+       "Index: []</dd><dt><span>face_volume_elevation_info :</span></dt><dd>Empty DataFrame\n",
+       "Columns: []\n",
+       "Index: []</dd><dt><span>face_volume_elevation_values :</span></dt><dd>Empty DataFrame\n",
+       "Columns: []\n",
+       "Index: []</dd><dt><span>boundary_data :</span></dt><dd>Empty DataFrame\n",
+       "Columns: []\n",
+       "Index: []</dd><dt><span>units :</span></dt><dd>Metric</dd><dt><span>nreal :</span></dt><dd>366</dd></dl></div></li></ul></div></div>"
+      ],
+      "text/plain": [
+       "<xarray.Dataset> Size: 495MB\n",
+       "Dimensions:                 (node: 549, time: 5761, nface: 444, nmax_face: 8,\n",
+       "                             nedge: 915, 2: 2)\n",
+       "Coordinates:\n",
+       "    node_x                  (node) float64 4kB 5.004e+05 5.005e+05 ... 5.024e+05\n",
+       "    node_y                  (node) float64 4kB 2.381e+03 2.376e+03 ... 500.0\n",
+       "  * time                    (time) datetime64[ns] 46kB 2022-05-13 ... 2022-05-15\n",
+       "    face_x                  (nface) float64 4kB 5.005e+05 ... 5.024e+05\n",
+       "    face_y                  (nface) float64 4kB 2.45e+03 2.45e+03 ... 564.4\n",
+       "Dimensions without coordinates: node, nface, nmax_face, nedge, 2\n",
+       "Data variables: (12/34)\n",
+       "    mesh2d                  int32 4B 0\n",
+       "    face_nodes              (nface, nmax_face) int32 14kB 0 1 2 3 ... -1 -1 -1\n",
+       "    edge_nodes              (nedge, 2) int32 7kB 0 1 1 2 2 ... 547 418 548 519\n",
+       "    edge_face_connectivity  (nedge, 2) int32 7kB 0 207 0 208 ... 194 442 329 443\n",
+       "    edges_face1             (nedge) int32 4kB 0 0 0 0 207 ... 366 0 19 194 329\n",
+       "    edges_face2             (nedge) int32 4kB 207 208 1 367 ... 440 441 442 443\n",
+       "    ...                      ...\n",
+       "    DOC                     (time, nface) float64 20MB 1.0 1.0 1.0 ... nan nan\n",
+       "    DIC                     (time, nface) float64 20MB 1.0 1.0 1.0 ... nan nan\n",
+       "    POM                     (time, nface) float64 20MB 1.0 1.0 1.0 ... nan nan\n",
+       "    CBOD                    (time, nface) float64 20MB 1.0 1.0 1.0 ... nan nan\n",
+       "    PX                      (time, nface) float64 20MB 1.0 1.0 1.0 ... nan nan\n",
+       "    Alk                     (time, nface) float64 20MB 1.0 1.0 1.0 ... nan nan\n",
+       "Attributes: (12/13)\n",
+       "    Conventions:                       CF-1.8 UGRID-1.0 Deltares-0.10\n",
+       "    diffusion_coefficient:             0.1\n",
+       "    volume_calculation_required:       False\n",
+       "    face_area_calculation_required:    False\n",
+       "    face_area_elevation_info:          Empty DataFrame\\nColumns: []\\nIndex: []\n",
+       "    face_area_elevation_values:        Empty DataFrame\\nColumns: []\\nIndex: []\n",
+       "    ...                                ...\n",
+       "    face_cell_indexes_df:              Empty DataFrame\\nColumns: []\\nIndex: []\n",
+       "    face_volume_elevation_info:        Empty DataFrame\\nColumns: []\\nIndex: []\n",
+       "    face_volume_elevation_values:      Empty DataFrame\\nColumns: []\\nIndex: []\n",
+       "    boundary_data:                     Empty DataFrame\\nColumns: []\\nIndex: []\n",
+       "    units:                             Metric\n",
+       "    nreal:                             366"
+      ]
+     },
+     "execution_count": 12,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "#print(transport_model.constituent_dict)\n",
+    "transport_model.mesh"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "dcfb43d5-07c5-4c4a-842c-438734b71767",
+   "metadata": {},
+   "source": [
+    "The Clearwater Riverine currently has the cell surface area, not the *wetted* cell surface area, as required for TSM. Ultimately, we will work on incorporating this calculation into Clearwater Riverine; however, for the sake of this example, we have the wetted surface areas saved in a zarr. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "c0132f5a-2c31-4484-9680-44cb37407fd4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "wetted_sa = xr.open_zarr(wetted_surface_area_path)\n",
+    "wetted_sa = wetted_sa.compute()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "6365f6de-a977-4975-a4fb-ad1f2b2275d3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "wetted_sa_subset = wetted_sa.isel(time=slice(start_index, end_index+1))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "id": "8046a726",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[<matplotlib.lines.Line2D at 0x1c1ee259f50>]"
+      ]
+     },
+     "execution_count": 15,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAlIAAAHFCAYAAAA5VBcVAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjguNCwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8fJSN1AAAACXBIWXMAAA9hAAAPYQGoP6dpAABa+UlEQVR4nO3deVxU9f4/8NewDfvIIssoIiq4gbsBWpo7XolKS0sv6dWv2q/SKM3S6rqUknZTK+91y+te2r2p1U1xqbQMUEMxV7REBQNBlmF1gJnP7w/k1AgoHAfOoK/n4zEPnXM+c+Z9Tt3mdT+fz/kclRBCgIiIiIjqzUrpAoiIiIiaKgYpIiIiIpkYpIiIiIhkYpAiIiIikolBioiIiEgmBikiIiIimRikiIiIiGRikCIiIiKSiUGKiIiISCYGKSJqNLm5uXjmmWfg5eUFlUqFJ554QumSGkxGRgbeeusthIeHw9PTE66urujZsyfWrFkDg8Fg0rawsBCzZs3C0KFD0bx5c6hUKsybN6/WY5eXl2Pp0qUICQmBg4MDmjVrhj59+iA+Pr6Bz4qIbmejdAFE9OB45513sHPnTvz73/9G27Zt4e7urnRJDSYpKQmbNm3Cc889h7fffhu2trbYs2cP/t//+39ITEzEv//9b6ltTk4O1qxZg65du+KJJ57AJ598UutxDQYDnnzySRw+fBizZs1Cnz59UFxcjKSkJBQXFzfGqRHRn6j4rD0iaixDhgzBtWvXcPbsWaVLaXB5eXlwdnaGra2tyfaXXnoJ//znP3H16lX4+fkBAKr+M6xSqXDjxg00b94cc+fOrbFXavny5ZgxYwZ++uknhIWFNfh5ENGdcWiPiO7JvHnzoFKpcObMGTz77LPQaDTw9vbGxIkTodPpAACXL1+GSqXCgQMHcO7cOahUKqhUKhw8eBAAMH/+fISGhsLd3R2urq7o0aMH1q1bh5r+f96nn36K8PBwODs7w9nZGd26dcO6detM2hw4cACDBg2Cq6srHB0d0bdvX3z77bcNfi3+zM3NrVqIAoCHHnoIAJCeni5tq7oedfHhhx+iX79+DFFEFoJBiojMYtSoUQgKCsIXX3yBN954A59++ileeeUVAICvry8SEhLQvXt3tGnTBgkJCUhISECPHj0AVAatqVOn4vPPP8eOHTswcuRITJs2De+8847Jd/z973/HuHHjoNVqsWHDBuzcuRPjx4/HlStXpDZbtmzB0KFD4erqio0bN+Lzzz+Hu7s7hg0bVqcwVVFRUaeX3M787777DjY2NggKCqr3Z9PS0nD58mWEhIRgzpw58Pb2ho2NDTp37oyNGzfKqoeI7pEgIroHc+fOFQDEkiVLTLa/8MILwt7eXhiNRmlb//79RefOne94PIPBIMrLy8WCBQuEh4eH9PlLly4Ja2trMW7cuFo/W1xcLNzd3cVjjz1W7Zhdu3YVDz300F3PB0CdXuvXr7/rsW63d+9eYWVlJV555ZVa22RnZwsAYu7cudX2JSQkCADC1dVVdOrUSXz++edi79694qmnnhIAxJo1a+pdExHdG042JyKziIqKMnnfpUsX3Lx5E1lZWfD29r7jZ7/77jssWrQIx44dQ0FBgcm+qs/v378fBoMBL774Yq3HiY+PR25uLsaPH4+KigqTfREREViyZAmKi4vh5ORU6zGOHTt2x1qrBAQE1KldlePHj2P06NEICwtDbGxsvT5bxWg0AgBu3ryJ3bt3w9/fH0Dl3LNevXphwYIFmDx5sqxjE5E8DFJEZBYeHh4m79VqNQCgtLT0jp87evQohg4dikcffRRr165Fy5YtYWdnh127dmHhwoXS57OzswEALVu2rPVY169fBwA89dRTtbbJzc29Y5Dq1q3bHeutYm1tXad2AHDixAkMGTIEgYGB2L17t3Rt6qvqGnfo0EEKUUDlHKthw4YhNjYWWVlZ8PLyknV8Iqo/BikiUtS2bdtga2uL//3vf7C3t5e279q1y6Rd8+bNAVRO0q662+12np6eAICPP/641snYd+sdq2mCeE3Wr1+PCRMm3LXdiRMnMHjwYPj7+2Pfvn3QaDR1On5N2rZtC0dHxxr3iVtztqysOPWVqDExSBGRolQqFWxsbEx6eEpLS7F582aTdkOHDoW1tTVWrlyJ8PDwGo/Vt29fNGvWDGfPnsVLL70kqx5zDu0lJydj8ODBaNmyJfbv3w83NzdZNVWxsbHB448/jv/+97+4fPkyWrduDaAyRMXFxaFt27ZSmCSixsEgRUSKGjFiBJYuXYqxY8diypQpyMnJwT/+8Y9qw1+tW7fGnDlz8M4776C0tFRaauHs2bO4ceMG5s+fD2dnZ3z88ccYP348cnNz8dRTT8HLywvZ2dk4efIksrOzsXLlyjvW06tXL7OcV0pKCgYPHgwAWLhwIS5evIiLFy9K+9u2bSv1sgHAnj17UFxcjMLCQgDA2bNn8d///hcA8Je//EXqiXrnnXewZ88eREREYN68eXB1dcUnn3yCkydP4vPPPzdL7URUD0rPdieipq3qrr3s7GyT7evXrxcARGpqqrSttrv2/v3vf4v27dsLtVot2rRpI2JjY8W6deuqfV4IITZt2iR69+4t7O3thbOzs+jevXu1O+gOHTokRowYIdzd3YWtra1o0aKFGDFihPjPf/5jrtO+q6rzr+11e83+/v61tr39Gpw6dUqMGDFCuLi4CHt7exEWFia+/vrrRjs3IvoDVzYnIiIikomzEomIiIhkYpAiIiIikolBioiIiEgmBikiIiIimRikiIiIiGRikCIiIiKSiQty1pHRaMTvv/8OFxcXqFQqpcshIiKiOhBCoLCwEFqttkEeocQgVUe///57rc/3IiIiIsuWlpZ2x4eey8UgVUcuLi4AKv9BuLq6KlwNERER1UVBQQH8/Pyk33FzY5Cqo6rhPFdXVwYpIiKiJqahpuVwsjkRERGRTAxSRERERDIxSBERERHJxCBFREREJBODFBEREZFMDFJEREREMjFIEREREcnEIEVEREQkE4MUERERkUwMUkREREQyMUgRERERycQgRURERCQTH1pMRHSfEUJACEBU/R249V7c2g/pT4Ga29Z+8No217zjTseqbZeo5UO1t7/Td9RacL2+407f0xjn/qBo5mgHZ3XTiiZNq1oiuu8ZjAJlFUboKwzQVxilv98sN6LMYIS+vPJ9WYURFUaBcoMRBqNAhUGg3Fj593KDgMFoRLmhcrvBaES5UaDCUPmZCoNAhdF468/KYxiFgNEIGISAEAIGo4BRoHL7bfuMorLOP/9dalf1GWMN7f70+arQAtwKNFXvawlAVWEHtwWiOgcgoibgncc7Izq8tdJl1AuDFBHJcrPcgILSchTcLIeutAKFN8tRUmZAsb4CpeUGFOsNKC2rQHGZASVlBpSUVZj+qTfgZoXBJBjpb4UjInNSqWrZXmv72vbc6TO1ta/9WLXtusMn7ntWVk3v7BmkiB5wRqNAfmk5cor0uFFUhtziMuQU65FTVPlnfkk5Cm5WSKGpoLQCBTfLUVZhbPDarFSAva017GysoLaxgtrmj7/b2VjB1soKNtYqWFupYGttBRsrFWysVbC5tb3yvRVsrVSwtrKCrbXqVvtb26xVJsewUlW+rK0qf0yr/l61vfJV+R/7au1u22fSTqWCSnXrOLeOp8Kff3wr91du+2Of6tZ2qZWq5v2qykOYtK/pWFDB5Hv+aHfbZ1V3DgCKBpM7HItICQxSRPcpIQQKSiuQUVCKDN1NXNfdRIbuJjJ1N5FRUPk+p1iP3OIyyO0EUqkAV3tbuDrYwEVtCye1NRztbOBo96c/1dZwtLW5bV/l3x3sKsNRVTAy/bsVbKx5PwwRWTYGKaImTF9hQHpeKa7mluBqTgmu5JTgam4xruSUID2vFKXlhjofS+NgCw9nO3g6qeHuZAcPZzt4ONmhmaMdXB1s4Wpvc+tPW2gcK9872dk0ya54IiJzYZAiagJKyirwa1YRLlwvwsXrhbhwvRAXs4pwLb/0rhOM3Rxt4aNxgK/GHj4ae/i62sNbYw8fV3t4Oqvh6WwHNyc72LL3h4io3hQPUoWFhXj77bexc+dOZGVloXv37vjwww/Ru3dvAJXDE/Pnz8eaNWuQl5eH0NBQ/POf/0Tnzp2lY+j1esycOROfffYZSktLMWjQIPzrX/9Cy5YtpTZ5eXmYPn06vvrqKwBAVFQUPv74YzRr1qxRz5fobnKK9Pjlmg6n03X45ZoO5zMLkJZbWmt7RztrtHJ3hL+HI/w9nODn7gh/d0e0cneEj8Ye9rbWjVg9EdGDRfEg9X//9384ffo0Nm/eDK1Wiy1btmDw4ME4e/YsWrRogSVLlmDp0qXYsGEDgoKC8O6772LIkCFISUmBi4sLACAmJgZff/01tm3bBg8PD8yYMQORkZFISkqCtXXlj8jYsWORnp6OuLg4AMCUKVMQHR2Nr7/+WrFzJ9JXGHAqXYdjl/NwMi0fp67pcC2/5tDk4WSHQG9nBHm7INDbBUFezmjT3BmeznacgEtEpBCVUHD1r9LSUri4uODLL7/EiBEjpO3dunVDZGQk3nnnHWi1WsTExOD1118HUNn75O3tjcWLF2Pq1KnQ6XRo3rw5Nm/ejDFjxgAAfv/9d/j5+WH37t0YNmwYzp07h06dOiExMRGhoaEAgMTERISHh+P8+fNo3779XWstKCiARqOBTqeDq6trA1wNehCUlFUg6Uoejqbm4mhqLpLT8qGv4e63Ns2dENJCg5AWGnTWahDk7QwPZ7UCFRMRNW0N/futaI9URUUFDAYD7O3tTbY7ODjg8OHDSE1NRWZmJoYOHSrtU6vV6N+/P+Lj4zF16lQkJSWhvLzcpI1Wq0VwcDDi4+MxbNgwJCQkQKPRSCEKAMLCwqDRaBAfH19jkNLr9dDr9dL7goICc546PSCEEEi5XohDKdn44WI2jqXmocxgGpw8nOzQu7U7evg3Q0iLZujcwhWu9rYKVUxERPWhaJBycXFBeHg43nnnHXTs2BHe3t747LPPcOTIEQQGBiIzMxMA4O3tbfI5b29vXLlyBQCQmZkJOzs7uLm5VWtT9fnMzEx4eXlV+34vLy+pze1iY2Mxf/78ez5HevDoKwz46dcb2Hv6Og5eyML1Ar3J/hbNHBAa4I7eAe7o3dodbZs7cWiOiKiJUnyO1ObNmzFx4kS0aNEC1tbW6NGjB8aOHYvjx49LbW7/kRFC3PWH5/Y2NbW/03Fmz56NV199VXpfUFAAPz+/Op0TPXhKyww4dCELe05n4rtzWSjUV0j77G2tEN7GA/2CmqN/UHMEeDI4ERHdLxQPUm3btsWhQ4dQXFyMgoIC+Pr6YsyYMQgICICPjw+Ayh4lX19f6TNZWVlSL5WPjw/KysqQl5dn0iuVlZWFPn36SG2uX79e7buzs7Or9XZVUavVUKs5J4VqZzQKJKbm4Iuka9hzOgMlZX+s2eTlokZEsA8Gd/TGQwHuvHOOiOg+pXiQquLk5AQnJyfk5eVh7969WLJkiRSm9u/fj+7duwMAysrKcOjQISxevBgA0LNnT9ja2mL//v0YPXo0ACAjIwOnT5/GkiVLAADh4eHQ6XQ4evQoHnroIQDAkSNHoNPppLBFVFdXc0rwn6Q07Dh+zeQOuxbNHDA82AfDQ3zQ3c+NC1USET0AFA9Se/fuhRAC7du3x6+//orXXnsN7du3x9/+9jeoVCrExMRg0aJFCAwMRGBgIBYtWgRHR0eMHTsWAKDRaDBp0iTMmDEDHh4ecHd3x8yZMxESEoLBgwcDADp27IiIiAhMnjwZq1evBlC5/EFkZGSd7tgjMhoFfriYjU0JV/B9Spa0CKaL2gaRXX0xqkdL9PR345AdEdEDRvEgpdPpMHv2bKSnp8Pd3R2jRo3CwoULYWtbedfSrFmzUFpaihdeeEFakHPfvn3SGlIAsGzZMtjY2GD06NHSgpwbNmyQ1pACgK1bt2L69OnS3X1RUVFYsWJF454sNTnF+gp8/nMaNiVcQeqNYmn7I4GeeLqXH4Z28uawHRHRA0zRdaSaEq4j9WAp1ldgU8IVrP3xEnKLywBU9j491aslngtvjQBPJ4UrJCKiuriv15EisjRF+gpsjL+MT368hLyScgBAaw9HTHqkDUZ2bwEnNf8nQ0REf+CvAhGAwpvllQHqcCrybwWoAE8nTBvYDlFdtbDhA32JiKgGDFL0QCu4WY4NP13GusOp0JVWBqg2zSsD1GNdGKCIiOjOGKTogXSz3IAtiVew4vtfpR6ots2dMH1QICK7aGHNpQuIiKgOGKTogWIwCuw6cQ1L91+Q1oBq5+WM6YMCMSLElwGKiIjqhUGKHhg/X87F3788g7MZlQ+g9tXY45UhQRjVoyUDFBERycIgRfe9G0V6xO4+jy+OpwMAXO1t8MKAdpjQpzXXgCIionvCIEX3LaNRYOuRK1iyNwWFNysfIvxMbz/MiugAdyc7hasjIqL7AYMU3Zeu5pTgtf+exJHUXABAcAtXLHg8GD1aud3lk0RERHXHIEX3FaNRYMuRK3hvz3mUlBngYGuN1yPaIzq8NedBERGR2TFI0X0jq/AmXt1+Eod/vQEACA1wx/tPdUUrD0eFKyMiovsVgxTdF368mI1XtifjRlEZ7G2t8EZEBzwX3hpW7IUiIqIGxCBFTVqFwYhlBy7gXwd/gxBABx8XrBjbHe28XJQujYiIHgAMUtRk5RWX4cVPjyP+txwAwNjQVvh7ZCcuaUBERI2GQYqapJTMQvzfpmNIyy2Fk501Ykd1QVRXrdJlERHRA4ZBipqcfWcy8cr2ZBSXGeDn7oBPnuuN9j4cyiMiosbHIEVNyic/XsK735wDAIS38cC/xvWAGxfXJCIihTBIUZNgNArE7jmHtT+mAgD+GtYKcx/rDFtrK4UrIyKiBxmDFFm8sgojXvvvSXyZ/DsA4I3hHTC1XxuoVFzagIiIlMUgRRbtZrkBUzYn4YcL2bCxUmHJU10wskdLpcsiIiICwCBFFqy0zIBJG48h/rccONhaY1V0T/QPaq50WURERBIGKbJIxfoKTNp4DImXcuFkZ40NEx9C79buSpdFRERkgkGKLE6xvgJ/W38MRy/nwlltg40TH0JPfzelyyIiIqqGQYosir7CgKmbk3D0ci5c7G2waeJD6N6KIYqIiCwT7x0ni2EwCsRsS8bhX2/A0c6aIYqIiCwegxRZBCEE5uw4hT2nM2FnbYU10b0YooiIyOIxSJFFWLI3Bdt/ToOVCvjo2W54ONBT6ZKIiIjuikGKFPfZ0atYefA3AEDsyBBEBPsqXBEREVHdMEiRon769Qbe3nUaAPDK4CCM6d1K4YqIiIjqjkGKFPNrViGe35KECqPAE920mD6ondIlERER1QuDFCkiv6QMEzf8jMKbFejl74b3RnXhs/OIiKjJYZCiRmc0CryyPRlXc0vg5+6A1dE9YW9rrXRZRERE9cYgRY3u4+9+xfcp2VDbWGHVX3vCw1mtdElERESyMEhRozqYkoXl314AALz7RDA6azUKV0RERCQfgxQ1mmv5pYjZngwhgGcfaoWne/kpXRIREdE9UTRIVVRU4K233kJAQAAcHBzQpk0bLFiwAEajUWozYcIEqFQqk1dYWJjJcfR6PaZNmwZPT084OTkhKioK6enpJm3y8vIQHR0NjUYDjUaD6Oho5OfnN8ZpEiof//LKtmTkl5SjS0sN5j7WSemSiIiI7pmiQWrx4sVYtWoVVqxYgXPnzmHJkiV4//338fHHH5u0i4iIQEZGhvTavXu3yf6YmBjs3LkT27Ztw+HDh1FUVITIyEgYDAapzdixY5GcnIy4uDjExcUhOTkZ0dHRjXKeBKw8+CuOXs6Fk501Pn62OyeXExHRfcFGyS9PSEjA448/jhEjRgAAWrdujc8++ww///yzSTu1Wg0fH58aj6HT6bBu3Tps3rwZgwcPBgBs2bIFfn5+OHDgAIYNG4Zz584hLi4OiYmJCA0NBQCsXbsW4eHhSElJQfv27RvwLOnE1TwsO3ARADD/8WD4ezgpXBEREZF5KNoj9fDDD+Pbb7/FhQuVk49PnjyJw4cP4y9/+YtJu4MHD8LLywtBQUGYPHkysrKypH1JSUkoLy/H0KFDpW1arRbBwcGIj48HUBnYNBqNFKIAICwsDBqNRmpzO71ej4KCApMX1V+RvgIx25NhMApEdvHFqB4tlC6JiIjIbBTtkXr99deh0+nQoUMHWFtbw2AwYOHChXj22WelNsOHD8fTTz8Nf39/pKam4u2338bAgQORlJQEtVqNzMxM2NnZwc3NzeTY3t7eyMzMBABkZmbCy8ur2vd7eXlJbW4XGxuL+fPnm/FsH0wLvzmHKzkl0GrssfCJEC66SURE9xVFg9T27duxZcsWfPrpp+jcuTOSk5MRExMDrVaL8ePHAwDGjBkjtQ8ODkavXr3g7++Pb775BiNHjqz12EIIkx/tmn7Ab2/zZ7Nnz8arr74qvS8oKICfH+8yq4/4X2/gs6NXAQD/GN0VGkdbhSsiIiIyL0WD1GuvvYY33ngDzzzzDAAgJCQEV65cQWxsrBSkbufr6wt/f39cvFg558bHxwdlZWXIy8sz6ZXKyspCnz59pDbXr1+vdqzs7Gx4e3vX+D1qtRpqNReKlKukrAKv7/gFADAutBX6tPVUuCIiIiLzU3SOVElJCaysTEuwtrY2Wf7gdjk5OUhLS4Ovry8AoGfPnrC1tcX+/fulNhkZGTh9+rQUpMLDw6HT6XD06FGpzZEjR6DT6aQ2ZF7/2HsBabml0Grs8cbwDkqXQ0RE1CAU7ZF67LHHsHDhQrRq1QqdO3fGiRMnsHTpUkycOBEAUFRUhHnz5mHUqFHw9fXF5cuXMWfOHHh6euLJJ58EAGg0GkyaNAkzZsyAh4cH3N3dMXPmTISEhEh38XXs2BERERGYPHkyVq9eDQCYMmUKIiMjecdeA0i6kof18akAgEUjQ+BizyE9IiK6PykapD7++GO8/fbbeOGFF5CVlQWtVoupU6fi73//O4DK3qlTp05h06ZNyM/Ph6+vLwYMGIDt27fDxcVFOs6yZctgY2OD0aNHo7S0FIMGDcKGDRtgbf3HWkVbt27F9OnTpbv7oqKisGLFisY94QdAhcGIt3adhhDAqB4t8Wj76pP8iYiI7hcqIYRQuoimoKCgABqNBjqdDq6urkqXY7E2/JSKeV+fhcbBFt/PfBTuTnZKl0RERA+whv795rP2yGyyC/X4YF/lmmCzItozRBER0X2PQYrMJnbPORTqKxDSQoNnerdSuhwiIqIGxyBFZvHz5VzsOH4NKhXwzhPBsLbiwptERHT/Y5CieyaEwLvfnAMAjO7ph25+zZQtiIiIqJEwSNE9++ZUBpLT8uFoZ40Zw4KULoeIiKjRMEjRPSmrMGJJXAoAYEq/NvBysVe4IiIiosbDIEX3ZEviFVzNLUFzFzUmP9JG6XKIiIgaFYMUyaYrLcdH31U+8/CVwUFwUiu6visREVGjY5Ai2dYdTkV+STnaeTljdK+WSpdDRETU6BikSBZdSTnWH658nt6rQ4JgY81/lYiI6MHDXz+SZd1PqSjUV6CDjwsiOvsoXQ4REZEiGKSo3v7cG/XyoEBYcfFNIiJ6QDFIUb2tO3xJ6o0axt4oIiJ6gDFIUb3oSsux/qfLANgbRURExCBF9bL1yBUU6ivQ3pu9UURERAxSVGf6CoPUGzWlXxv2RhER0QOPQYrq7MsTvyO7UA8fV3s81lWrdDlERESKY5CiOjEaBVb/8BsAYOLDrWFnw391iIiI+GtIdfLd+Sz8ll0MF7UNnn2oldLlEBERWQQGKaqTTw5fAgCMDWsFF3tbhashIiKyDAxSdFcXrhci8VIurK1UmNCntdLlEBERWQwGKbqrzQlXAABDOnrDV+OgcDVERESWg0GK7qhIX4Edx9MBANHh/gpXQ0REZFkYpOiOdh5PR3GZAW2aO6FPWw+lyyEiIrIoDFJUKyEENidWDutFh/lDpeICnERERH/GIEW1OpqaiwvXi+Bga41RPVsqXQ4REZHFYZCiWv0nqXJuVFRXLVy55AEREVE1DFJUo2J9BXafygAAjO7N3igiIqKaMEhRjfaczkRJmQEBnk7o0cpN6XKIiIgsEoMU1ei/SWkAgKd6tuQkcyIiolowSFE1abklSLyUC5UKeLJ7C6XLISIislgMUlTNF7cW4Ozb1hPaZlzJnIiIqDYMUmRCCIGdJ64BqBzWIyIiotoxSJGJU9d0uJJTAgdbawzt7K10OURERBZN0SBVUVGBt956CwEBAXBwcECbNm2wYMECGI1GqY0QAvPmzYNWq4WDgwMeffRRnDlzxuQ4er0e06ZNg6enJ5ycnBAVFYX09HSTNnl5eYiOjoZGo4FGo0F0dDTy8/Mb4zSblP/9UrnkwcCOXnC0s1G4GiIiIsumaJBavHgxVq1ahRUrVuDcuXNYsmQJ3n//fXz88cdSmyVLlmDp0qVYsWIFjh07Bh8fHwwZMgSFhYVSm5iYGOzcuRPbtm3D4cOHUVRUhMjISBgMBqnN2LFjkZycjLi4OMTFxSE5ORnR0dGNer6WTgiBb24Fqce6+CpcDRERkeVTCSGEUl8eGRkJb29vrFu3Tto2atQoODo6YvPmzRBCQKvVIiYmBq+//jqAyt4nb29vLF68GFOnToVOp0Pz5s2xefNmjBkzBgDw+++/w8/PD7t378awYcNw7tw5dOrUCYmJiQgNDQUAJCYmIjw8HOfPn0f79u3vWmtBQQE0Gg10Oh1cXV0b4GooL+lKHkatjIeTnTWS3h4Ce1trpUsiIiK6Jw39+y177CY9PR1fffUVrl69irKyMpN9S5curdMxHn74YaxatQoXLlxAUFAQTp48icOHD2P58uUAgNTUVGRmZmLo0KHSZ9RqNfr374/4+HhMnToVSUlJKC8vN2mj1WoRHByM+Ph4DBs2DAkJCdBoNFKIAoCwsDBoNBrEx8fXKUg9CP73y+8AgCGdvBmiiIiI6kBWkPr2228RFRWFgIAApKSkIDg4GJcvX4YQAj169KjzcV5//XXodDp06NAB1tbWMBgMWLhwIZ599lkAQGZmJgDA29t00rO3tzeuXLkitbGzs4Obm1u1NlWfz8zMhJeXV7Xv9/LyktrcTq/XQ6/XS+8LCgrqfF5NkdEopEfCRHbRKlwNERFR0yBrjtTs2bMxY8YMnD59Gvb29vjiiy+QlpaG/v374+mnn67zcbZv344tW7bg008/xfHjx7Fx40b84x//wMaNG03a3b6ythDirqtt396mpvZ3Ok5sbKw0MV2j0cDPz6+up9Uk/XwlD9cL9HCxt8EjQZ5Kl0NERNQkyApS586dw/jx4wEANjY2KC0thbOzMxYsWIDFixfX+TivvfYa3njjDTzzzDMICQlBdHQ0XnnlFcTGxgIAfHx8AKBar1FWVpbUS+Xj44OysjLk5eXdsc3169erfX92dna13q4qs2fPhk6nk15paWl1Pq+maN+Zyms8pKM31DYc1iMiIqoLWUHKyclJGvbSarX47bffpH03btyo83FKSkpgZWVagrW1tbT8QUBAAHx8fLB//35pf1lZGQ4dOoQ+ffoAAHr27AlbW1uTNhkZGTh9+rTUJjw8HDqdDkePHpXaHDlyBDqdTmpzO7VaDVdXV5PX/UoIgf3nKoPmkE5cO4qIiKiuZM2RCgsLw08//YROnTphxIgRmDFjBk6dOoUdO3YgLCyszsd57LHHsHDhQrRq1QqdO3fGiRMnsHTpUkycOBFA5XBcTEwMFi1ahMDAQAQGBmLRokVwdHTE2LFjAQAajQaTJk3CjBkz4OHhAXd3d8ycORMhISEYPHgwAKBjx46IiIjA5MmTsXr1agDAlClTEBkZyYnmAH7NKsKVnBLY2VihX1BzpcshIiJqMmQFqaVLl6KoqAgAMG/ePBQVFWH79u1o164dli1bVufjfPzxx3j77bfxwgsvICsrC1qtFlOnTsXf//53qc2sWbNQWlqKF154AXl5eQgNDcW+ffvg4uIitVm2bBlsbGwwevRolJaWYtCgQdiwYQOsrf8Yotq6dSumT58u3d0XFRWFFStWyDn9+86+s5W9UX3besBJzUU4iYiI6krRdaSakvt5Hakn/vkTktPysfDJYIwL9Ve6HCIiIrNp6N9v2Sub5+fn45NPPsHs2bORm5sLADh+/DiuXbtmtuKo4WUV3kRyWj4AYHBHzo8iIiKqD1njOL/88gsGDx4MjUaDy5cvY/LkyXB3d8fOnTtx5coVbNq0ydx1UgP59lwWAKCrXzN4u9orXA0REVHTIqtH6tVXX8WECRNw8eJF2Nv/8eM7fPhw/PDDD2Yrjhret1V363WsvmApERER3ZmsIHXs2DFMnTq12vYWLVrUulI4WZ6yCiPif8sBADzankGKiIiovmQFKXt7+xofmZKSkoLmzXn7fFNx/GoeSsoM8HS2Qyff+2sCPRERUWOQFaQef/xxLFiwAOXl5QAq13u6evUq3njjDYwaNcqsBVLD+fFiNgDg4XaesLK68yN3iIiIqDpZQeof//gHsrOz4eXlhdLSUvTv3x/t2rWDi4sLFi5caO4aqYH8eLFyFfpHAtmLSEREJIesu/ZcXV1x+PBhfPfddzh+/DiMRiN69OghrSROli+3uAynrukAAI8E8iHFREREctQ7SFVUVMDe3h7JyckYOHAgBg4c2BB1UQP76dcbEALo4OMCLy57QEREJEu9h/ZsbGzg7+8Pg8HQEPVQI6maH8XeKCIiIvlkzZF66623TFY0p6ZFCIHDnB9FRER0z2TNkfroo4/w66+/QqvVwt/fH05OTib7jx8/bpbiqGFcySnB77qbsLO2Qu/W7kqXQ0RE1GTJClJPPPGEmcugxnQktXIRzq5+GjjYWStcDRERUdMlK0jNnTvX3HVQIzpyqXJINjTAQ+FKiIiImjZZc6SoaTuSeitIteGwHhER0b2Q1SNlMBiwbNkyfP7557h69SrKyspM9nMSuuVKyy3BtfxS2Fip0NPfTelyiIiImjRZPVLz58/H0qVLMXr0aOh0Orz66qsYOXIkrKysMG/ePDOXSOaUeKlyflRISw0c7WTlaCIiIrpFVpDaunUr1q5di5kzZ8LGxgbPPvssPvnkE/z9739HYmKiuWskM5KG9Tg/ioiI6J7JClKZmZkICQkBADg7O0Onq3zUSGRkJL755hvzVUdmV3XHHudHERER3TtZQaply5bIyMgAALRr1w779u0DABw7dgxqtdp81ZFZ/Z5firTcUlipgF6cH0VERHTPZAWpJ598Et9++y0A4OWXX8bbb7+NwMBAPPfcc5g4caJZCyTzSbqSBwDopHWFi72twtUQERE1fbJmG7/33nvS35966in4+fnhp59+Qrt27RAVFWW24si8jl+tDFI9WrE3ioiIyBzMcttWaGgoQkNDq20fMWIEPvnkE/j6+prja+genbiaD4BBioiIyFwadEHOH374AaWlpQ35FVRHN8sNOPN75U0BDFJERETmwZXNHxBnfteh3CDg4WQHP3cHpcshIiK6LzBIPSCOX8kHAHRv5QaVSqVsMURERPcJBqkHxIm0WxPN/ZspWwgREdF9hEHqAVHVI8X5UURERObDIPUA+D2/FJkFN2FtpUKXlhqlyyEiIrpvNGiQmjNnDtzd+SgSpSWn5QMAOvi48EHFREREZiQ7SG3evBl9+/aFVqvFlStXAADLly/Hl19+KbWZPXs2mjVrds9F0r05da1y2QP2RhEREZmXrCC1cuVKvPrqq/jLX/6C/Px8GAwGAECzZs2wfPlyc9ZHZnD6VpAKbsEgRUREZE6ygtTHH3+MtWvX4s0334S1tbW0vVevXjh16pTZiqN7J4SQeqRCGKSIiIjMSlaQSk1NRffu3attV6vVKC4uvueiyHzS80qRX1IOW2sV2vu4KF0OERHRfUVWkAoICEBycnK17Xv27EGnTp3utSYyo6phvSBvF6htrO/SmoiIiOpDVpB67bXX8OKLL2L79u0QQuDo0aNYuHAh5syZg9dee63Ox2ndujVUKlW114svvggAmDBhQrV9YWFhJsfQ6/WYNm0aPD094eTkhKioKKSnp5u0ycvLQ3R0NDQaDTQaDaKjo5Gfny/n1JscDusRERE1HFn3wv/tb39DRUUFZs2ahZKSEowdOxYtWrTAhx9+iGeeeabOxzl27Jg0UR0ATp8+jSFDhuDpp5+WtkVERGD9+vXSezs7O5NjxMTE4Ouvv8a2bdvg4eGBGTNmIDIyEklJSdL8rbFjxyI9PR1xcXEAgClTpiA6Ohpff/21nNNvUk5xojkREVGDkb2o0OTJkzF58mTcuHEDRqMRXl5e9T5G8+bNTd6/9957aNu2Lfr37y9tU6vV8PHxqfHzOp0O69atw+bNmzF48GAAwJYtW+Dn54cDBw5g2LBhOHfuHOLi4pCYmIjQ0FAAwNq1axEeHo6UlBS0b9++3nU3FUIIaWiPPVJERETmJ3uy+cWLFwEAnp6eUoi6ePEiLl++LKuQsrIybNmyBRMnTjR5qO7Bgwfh5eWFoKAgTJ48GVlZWdK+pKQklJeXY+jQodI2rVaL4OBgxMfHAwASEhKg0WikEAUAYWFh0Gg0Upua6PV6FBQUmLyammv5pcgrKYeNFSeaExERNQRZQWrChAk1hpAjR45gwoQJsgrZtWsX8vPzTT4/fPhwbN26Fd999x0++OADHDt2DAMHDoRerwcAZGZmws7ODm5ups+P8/b2RmZmptSmpt4yLy8vqU1NYmNjpTlVGo0Gfn5+ss5LSX+eaG5vy4nmRERE5iYrSJ04cQJ9+/attj0sLKzGu/nqYt26dRg+fDi0Wq20bcyYMRgxYgSCg4Px2GOPYc+ePbhw4QK++eabOx5LCGHSq/Xnv9fW5nazZ8+GTqeTXmlpaTLOSllnfq/sRQtu4apwJURERPcnWXOkVCoVCgsLq23X6XQmk8fr6sqVKzhw4AB27Nhxx3a+vr7w9/eXhhV9fHxQVlaGvLw8k16prKws9OnTR2pz/fr1asfKzs6Gt7d3rd+lVquhVqvrfS6W5FxG5T+jTr4MUkRERA1BVo/UI488gtjYWJPQZDAYEBsbi4cffrjex1u/fj28vLwwYsSIO7bLyclBWloafH19AQA9e/aEra0t9u/fL7XJyMjA6dOnpSAVHh4OnU6Ho0ePSm2OHDkCnU4ntblfnc+s7JHqwCBFRETUIGT1SC1ZsgT9+vVD+/bt8cgjjwAAfvzxRxQUFOC7776r17GMRiPWr1+P8ePHw8bmj3KKioowb948jBo1Cr6+vrh8+TLmzJkDT09PPPnkkwAAjUaDSZMmYcaMGfDw8IC7uztmzpyJkJAQ6S6+jh07IiIiApMnT8bq1asBVC5/EBkZeV/fsVdwsxzpeaUAgA6caE5ERNQgZPVIderUCb/88gtGjx6NrKwsFBYW4rnnnsP58+cRHBxcr2MdOHAAV69excSJE022W1tb49SpU3j88ccRFBSE8ePHIygoCAkJCXBx+SMYLFu2DE888QRGjx6Nvn37wtHREV9//bXJMwC3bt2KkJAQDB06FEOHDkWXLl2wefNmOafeZFzIrBzW89XYo5mj3V1aExERkRwqIYRQuoimoKCgABqNBjqdDq6ulj9UtjnxCt7edRoD2jfH+r89pHQ5REREimjo32/ZC3ICQElJCa5evYqysjKT7V26dLmnoujenc/g/CgiIqKGJitIZWdn429/+xv27NlT4345d+6ReZ2/NbTH+VFEREQNR9YcqZiYGOTl5SExMREODg6Ii4vDxo0bERgYiK+++srcNVI9GY0CKbeCVEf2SBERETUYWT1S3333Hb788kv07t0bVlZW8Pf3x5AhQ+Dq6orY2Ni7LmNADetafimK9BWws7ZCgKeT0uUQERHdt2T1SBUXF0uPXXF3d0d2djYAICQkBMePHzdfdSTLuVvzo9p5OcPWWtY/YiIiIqoDWb+y7du3R0pKCgCgW7duWL16Na5du4ZVq1ZJi2WScqT5Ub6cH0VERNSQZA3txcTEICMjAwAwd+5cDBs2DFu3boWdnR02bNhgzvpIhqoVzTv6cH4UERFRQ6pzkCooKJDWXxg3bpy0vXv37rh8+TLOnz+PVq1awdPT0/xVUr2cz2CPFBERUWOo89Cem5sbsrKyAAADBw5Efn6+tM/R0RE9evRgiLIApWUGpOYUAwA6sEeKiIioQdU5SDk7OyMnJwcAcPDgQZSXlzdYUSTfheuFEALwdLZDcxe10uUQERHd1+o8tDd48GAMGDAAHTt2BAA8+eSTsLOr+Rlu9X1wMZlPyvXKYb0gbw7rERERNbQ6B6ktW7Zg48aN+O2333Do0CF07twZjo6ODVkbyfBrVhEABikiIqLGUOcg5eDggOeffx4A8PPPP2Px4sVo1qxZQ9VFMl281SPVzstZ4UqIiIjuf/VeR6q8vBxXrlzB77//3hD10D26eKtHKpBBioiIqMHVO0jZ2tpCr9dDpVI1RD10D0rKKnAtvxQAEMihPSIiogYna2XzadOmYfHixaioqDB3PXQPLmUXQwjA3ckO7k413whARERE5iNrZfMjR47g22+/xb59+xASEgInJ9MH4+7YscMsxVH9XMzi/CgiIqLGJCtINWvWDKNGjTJ3LXSPLl7n/CgiIqLGJCtIrV+/3tx1kBn8yonmREREjUrWHCmyTFVBqp0XJ5oTERE1Blk9UgEBAXe8a+/SpUuyCyJ59BUGXL71jL1Ab/ZIERERNQZZQSomJsbkfXl5OU6cOIG4uDi89tpr5qiL6in1RjGMAnCxt4EXn7FHRETUKGQFqZdffrnG7f/85z/x888/31NBJM+l7MreqLbNnbnGFxERUSMx6xyp4cOH44svvjDnIamOUm9UBqkAT6e7tCQiIiJzMWuQ+u9//wt3d3dzHpLq6PKtINXag0GKiIioscga2uvevbvJ8JEQApmZmcjOzsa//vUvsxVHdVc10by1p6PClRARET04ZAWpJ554wuS9lZUVmjdvjkcffRQdOnQwR11UT6k3SgBwaI+IiKgxyQpSc+fONXcddA8Kb5bjRpEeANCaQYqIiKjRyJojdfz4cZw6dUp6/+WXX+KJJ57AnDlzUFZWZrbiqG6u5FT2Rnk42cHV3lbhaoiIiB4csoLU1KlTceHCBQCVi2+OGTMGjo6O+M9//oNZs2aZtUC6u6o79tgbRURE1LhkBakLFy6gW7duAID//Oc/6N+/Pz799FNs2LCByx8oIJV37BERESlCVpASQsBoNAIADhw4gL/85S8AAD8/P9y4ccN81VGdXJbWkOIde0RERI1JVpDq1asX3n33XWzevBmHDh3CiBEjAACpqanw9vY2a4F0d6k5HNojIiJSgqwgtXz5chw/fhwvvfQS3nzzTbRr1w5A5YKcffr0MWuBdHdcjJOIiEgZspY/6NKli8lde1Xef/99WFtbS+8/++wzREVFwcmJP/ANRVdajryScgDskSIiImpsZn1EjL29PWxt/7j9furUqbh+/Xqt7Vu3bg2VSlXt9eKLLwKonIs1b948aLVaODg44NFHH8WZM2dMjqHX6zFt2jR4enrCyckJUVFRSE9PN2mTl5eH6OhoaDQaaDQaREdHIz8/33wnrqD0vD+WPnBWy8rFREREJJNZg9TthBB33H/s2DFkZGRIr/379wMAnn76aQDAkiVLsHTpUqxYsQLHjh2Dj48PhgwZgsLCQukYMTEx2LlzJ7Zt24bDhw+jqKgIkZGRMBgMUpuxY8ciOTkZcXFxiIuLQ3JyMqKjoxvgjBtfWm4pAKClOyeaExERNTZFuzCaN29u8v69995D27Zt0b9/fwghsHz5crz55psYOXIkAGDjxo3w9vbGp59+iqlTp0Kn02HdunXYvHkzBg8eDADYsmUL/Pz8cODAAQwbNgznzp1DXFwcEhMTERoaCgBYu3YtwsPDkZKSgvbt2zfuSZtZVY9USzcHhSshIiJ68DRoj1R9lJWVYcuWLZg4cSJUKhVSU1ORmZmJoUOHSm3UajX69++P+Ph4AEBSUhLKy8tN2mi1WgQHB0ttEhISoNFopBAFAGFhYdBoNFKbmuj1ehQUFJi8LFF63q0eKQYpIiKiRmcxQWrXrl3Iz8/HhAkTAACZmZkAUG05BW9vb2lfZmYm7Ozs4Obmdsc2Xl5e1b7Py8tLalOT2NhYaU6VRqOBn5+f7HNrSFU9Un5uHNojIiJqbBYTpNatW4fhw4dDq9WabFepVCbvhRDVtt3u9jY1tb/bcWbPng2dTie90tLS6nIajY49UkRERMpp0CDl7+9vchdfba5cuYIDBw7g//7v/6RtPj4+AFCt1ygrK0vqpfLx8UFZWRny8vLu2KamOwezs7PvuHioWq2Gq6urycvSCCGQlnurR4qTzYmIiBpdgwap06dP12lIbP369fDy8pJWSAeAgIAA+Pj4SHfyAZXzqA4dOiQt+tmzZ0/Y2tqatMnIyMDp06elNuHh4dDpdDh69KjU5siRI9DpdE1+8dD8knIUl1XendiiGXukiIiIGlud79pzc3O765Baldzc3DoXYDQasX79eowfPx42Nn+Uo1KpEBMTg0WLFiEwMBCBgYFYtGgRHB0dMXbsWACARqPBpEmTMGPGDHh4eMDd3R0zZ85ESEiIdBdfx44dERERgcmTJ2P16tUAgClTpiAyMvI+uGOvcljPy0UNe1vru7QmIiIic6tzkFq+fLn095ycHLz77rsYNmwYwsPDAVTeHbd37168/fbb9SrgwIEDuHr1KiZOnFht36xZs1BaWooXXngBeXl5CA0Nxb59++Di4iK1WbZsGWxsbDB69GiUlpZi0KBB2LBhg8kK61u3bsX06dOlu/uioqKwYsWKetVpidK49AEREZGiVOJuq2bWYNSoURgwYABeeuklk+0rVqzAgQMHsGvXLnPVZzEKCgqg0Wig0+ksZr7Umh9+w6Ld5/F4Ny0+fKa70uUQERFZnIb+/ZY1R2rv3r2IiIiotn3YsGE4cODAPRdFdcM79oiIiJQlK0h5eHhg586d1bbv2rULHh4e91wU1U3VHXstuYYUERGRImQ9Imb+/PmYNGkSDh48KM2RSkxMRFxcHD755BOzFki1+z3/JgDesUdERKQUWUFqwoQJ6NixIz766CPs2LEDQgh06tQJP/30k8mjWKhhZegqh/Z8NfYKV0JERPRgkv3Q4tDQUGzdutWctVA9lJRVoOBmBQDAh0GKiIhIEbIX5Pztt9/w1ltvYezYscjKygIAxMXF4cyZM2YrjmqXqasc1nNW28DF/u6rxxMREZH5yQpShw4dQkhICI4cOYIvvvgCRUVFAIBffvkFc+fONWuBVLOqIOXtqla4EiIiogeXrCD1xhtv4N1338X+/fthZ2cnbR8wYAASEhLMVhzVLrOgMkj5ajjRnIiISCmygtSpU6fw5JNPVtvevHlz5OTk3HNRdHcZUo8U50cREREpRVaQatasGTIyMqptP3HiBFq0aHHPRdHdVQ3t8Y49IiIi5cgKUmPHjsXrr7+OzMxMqFQqGI1G/PTTT5g5cyaee+45c9dINaga2vNmkCIiIlKMrCC1cOFCtGrVCi1atEBRURE6deqEfv36oU+fPnjrrbfMXSPVQOqR4tAeERGRYmStI2Vra4utW7finXfewfHjx2E0GtG9e3cEBgaauz6qRVWPFNeQIiIiUo6sHqkFCxagpKQEbdq0wVNPPYXRo0cjMDAQpaWlWLBggblrpNuUVRhxo0gPgEGKiIhISbKC1Pz586W1o/6spKQE8+fPv+ei6M6yCm9CCMDO2grujnZ3/wARERE1CFlBSggBlUpVbfvJkyfh7u5+z0XRnV2/Nazn5aqGlVX1fw5ERETUOOo1R8rNzQ0qlQoqlQpBQUEmYcpgMKCoqAjPP/+82YskU9cLKof1uIYUERGRsuoVpJYvXw4hBCZOnIj58+dDo9FI++zs7NC6dWuEh4ebvUgyVTU/ytOZw3pERERKqleQGj9+PAAgICAAffv2hY2NrJv+6B7dKKwMUs1d+Jw9IiIiJcmaIzVw4EDk5uZW256TkwNra+t7LoruLFvqkWKQIiIiUpLsyeY10ev1Jg8xpoaRXVgGgEGKiIhIafUam/voo48AACqVCp988gmcnZ2lfQaDAT/88AM6dOhg3gqpmqo5UhzaIyIiUla9gtSyZcsAVPZIrVq1ymQYr2qy+apVq8xbIVWTXcihPSIiIktQryCVmpoKABgwYAB27NgBNze3BimKaieE+KNHikGKiIhIUbLmSH3//fdwc3NDWVkZUlJSUFFRYe66qBZF+groK4wAAE8XzkcjIiJSkqwgVVpaikmTJsHR0RGdO3fG1atXAQDTp0/He++9Z9YCyVTVsJ6TnTUc7bj8BBERkZJkBak33ngDJ0+exMGDB2Fv/8fq2oMHD8b27dvNVhxVd6Po1h17nGhORESkOFldGrt27cL27dsRFhZm8piYTp064bfffjNbcVQd50cRERFZDlk9UtnZ2fDy8qq2vbi4uMaHGZP58I49IiIiyyErSPXu3RvffPON9L4qPK1du5bP2mtg0nP2ONGciIhIcbKG9mJjYxEREYGzZ8+ioqICH374Ic6cOYOEhAQcOnTI3DXSn0hzpNgjRUREpDhZPVJ9+vRBfHw8SkpK0LZtW+zbtw/e3t5ISEhAz549zV0j/Ul+SWWQcndijxQREZHSZPVIjRs3Do8++ijefPNNBAUFmbsmuoO8W0FK42CrcCVEREQkq0fK2dkZH3zwATp27AitVotnn30Wq1atwvnz581dH90mv6QcAODmyB4pIiIipckKUqtXr8b58+dx7do1LF26FBqNBh9++CE6d+4MX1/feh3r2rVr+Otf/woPDw84OjqiW7duSEpKkvZPmDABKpXK5BUWFmZyDL1ej2nTpsHT0xNOTk6IiopCenq6SZu8vDxER0dDo9FAo9EgOjoa+fn5ck5fUbrSyiDVzJE9UkREREqTFaSquLi4wM3NDW5ubmjWrBlsbGzg4+NT58/n5eWhb9++sLW1xZ49e3D27Fl88MEHaNasmUm7iIgIZGRkSK/du3eb7I+JicHOnTuxbds2HD58GEVFRYiMjITBYJDajB07FsnJyYiLi0NcXBySk5MRHR19L6eviKqhvWYO7JEiIiJSmqw5Uq+//joOHTqEkydPIjg4GP369cPs2bPRr1+/aiHoThYvXgw/Pz+sX79e2ta6detq7dRqda0BTafTYd26ddi8eTMGDx4MANiyZQv8/Pxw4MABDBs2DOfOnUNcXBwSExMRGhoK4I+lGlJSUtC+ffu6n7yCbpYbcLO88jl7zZzYI0VERKQ0WT1S77//PlJTUzF37lxs2rQJH3zwAaKiouoVogDgq6++Qq9evfD000/Dy8sL3bt3x9q1a6u1O3jwILy8vBAUFITJkycjKytL2peUlITy8nIMHTpU2qbVahEcHIz4+HgAQEJCAjQajRSiACAsLAwajUZqczu9Xo+CggKTl9KqhvWsrVRwUfM5e0REREqTFaROnDiBN998E0ePHkW/fv3g4+ODMWPGYOXKlTh37lydj3Pp0iWsXLkSgYGB2Lt3L55//nlMnz4dmzZtktoMHz4cW7duxXfffYcPPvgAx44dw8CBA6HXVy5MmZmZCTs7O7i5uZkc29vbG5mZmVKbmlZi9/LyktrcLjY2VppPpdFo4OfnV+fzaih/vmOPK8gTEREpT1a3RteuXdG1a1dMnz4dAHDy5EksX74c06dPh9FoNJmbdCdGoxG9evXCokWLAADdu3fHmTNnsHLlSjz33HMAgDFjxkjtg4OD0atXL/j7++Obb77ByJEjaz22EMIkbNQUPG5v82ezZ8/Gq6++Kr0vKChQPExV3bHHieZERESWQfb40IkTJ3Dw4EEcPHgQP/74IwoKCtCtWzcMGDCgzsfw9fVFp06dTLZ17NgRX3zxxR0/4+/vj4sXLwIAfHx8UFZWhry8PJNeqaysLPTp00dqc/369WrHys7Ohre3d43fo1aroVZb1urhUpDiGlJEREQWQdbQnpubGx566CFs3boVgYGB2LRpE3Jzc/Hzzz/j/fffr/Nx+vbti5SUFJNtFy5cgL+/f62fycnJQVpamrTMQs+ePWFra4v9+/dLbTIyMnD69GkpSIWHh0On0+Ho0aNSmyNHjkCn00ltmoKqVc2bcQ0pIiIiiyCrR2rz5s3o168fXF1d7+nLX3nlFfTp0weLFi3C6NGjcfToUaxZswZr1qwBABQVFWHevHkYNWoUfH19cfnyZcyZMweenp548sknAQAajQaTJk3CjBkz4OHhAXd3d8ycORMhISHSXXwdO3ZEREQEJk+ejNWrVwMApkyZgsjIyCZzxx4A5HMNKSIiIosiK0hFRkaa5ct79+6NnTt3Yvbs2ViwYAECAgKwfPlyjBs3DgBgbW2NU6dOYdOmTcjPz4evry8GDBiA7du3w8XFRTrOsmXLYGNjg9GjR6O0tBSDBg3Chg0bYG1tLbXZunUrpk+fLt3dFxUVhRUrVpjlPBrLH0N77JEiIiKyBCohhFC6iKagoKAAGo0GOp3unnvi5Hrji1+w7VgaXh0ShOmDAhWpgYiIqClp6N/ve1rZnBrXH8/Z49AeERGRJWCQakLyS2+tI8XJ5kRERBaBQaoJYY8UERGRZWGQakI42ZyIiMiyMEg1IVVDe1z+gIiIyDIwSDURN8sNuFluBMAgRUREZCkYpJqIqmE9aysVnNWyn+xDREREZsQg1URIw3oOtrU+aJmIiIgaF4NUE5FXzMfDEBERWRoGqSZCV8oHFhMREVkaBqkm4o+lD9gjRUREZCkYpJqIvKogxR4pIiIii8Eg1URwDSkiIiLLwyDVROg4tEdERGRxGKSaiLySWz1SThzaIyIishQMUk0EJ5sTERFZHgapJkJXynWkiIiILA2DVBNRNbTnxrv2iIiILAaDVBNRNbSn4dAeERGRxWCQagJulhugrzAC4NAeERGRJWGQagKqhvVsrFRwVtsoXA0RERFVYZBqAqQ79hxtoVKpFK6GiIiIqjBINQHSGlKcaE5ERGRRGKSaAK4hRUREZJkYpJqAfD6wmIiIyCIxSDUBf6whxR4pIiIiS8Ig1QTkS3OkGKSIiIgsCYNUE8ChPSIiIsvEINUE5JXwOXtERESWiEGqCcjnc/aIiIgsEoNUE5Bfyh4pIiIiS8Qg1QRIk80d2CNFRERkSRikLJwQQpps7ubEHikiIiJLwiBl4Yr0FagwCgCcI0VERGRpGKQsXFVvlNrGCva21gpXQ0RERH+meJC6du0a/vrXv8LDwwOOjo7o1q0bkpKSpP1CCMybNw9arRYODg549NFHcebMGZNj6PV6TJs2DZ6ennByckJUVBTS09NN2uTl5SE6OhoajQYajQbR0dHIz89vjFO8J3m8Y4+IiMhiKRqk8vLy0LdvX9ja2mLPnj04e/YsPvjgAzRr1kxqs2TJEixduhQrVqzAsWPH4OPjgyFDhqCwsFBqExMTg507d2Lbtm04fPgwioqKEBkZCYPBILUZO3YskpOTERcXh7i4OCQnJyM6OroxT1eWfK4hRUREZLmEgl5//XXx8MMP17rfaDQKHx8f8d5770nbbt68KTQajVi1apUQQoj8/Hxha2srtm3bJrW5du2asLKyEnFxcUIIIc6ePSsAiMTERKlNQkKCACDOnz9fp1p1Op0AIHQ6Xb3O8V7tOpEu/F//nxizOr5Rv5eIiOh+0NC/34r2SH311Vfo1asXnn76aXh5eaF79+5Yu3attD81NRWZmZkYOnSotE2tVqN///6Ij48HACQlJaG8vNykjVarRXBwsNQmISEBGo0GoaGhUpuwsDBoNBqpze30ej0KCgpMXkqQ7tjj0B4REZHFUTRIXbp0CStXrkRgYCD27t2L559/HtOnT8emTZsAAJmZmQAAb29vk895e3tL+zIzM2FnZwc3N7c7tvHy8qr2/V5eXlKb28XGxkrzqTQaDfz8/O7tZGXic/aIiIgsl6JBymg0okePHli0aBG6d++OqVOnYvLkyVi5cqVJO5VKZfJeCFFt2+1ub1NT+zsdZ/bs2dDpdNIrLS2trqdlVlWTzTlHioiIyPIoGqR8fX3RqVMnk20dO3bE1atXAQA+Pj4AUK3XKCsrS+ql8vHxQVlZGfLy8u7Y5vr169W+Pzs7u1pvVxW1Wg1XV1eTlxL+eM4egxQREZGlUTRI9e3bFykpKSbbLly4AH9/fwBAQEAAfHx8sH//fml/WVkZDh06hD59+gAAevbsCVtbW5M2GRkZOH36tNQmPDwcOp0OR48eldocOXIEOp1OamOpcjm0R0REZLFslPzyV155BX369MGiRYswevRoHD16FGvWrMGaNWsAVA7HxcTEYNGiRQgMDERgYCAWLVoER0dHjB07FgCg0WgwadIkzJgxAx4eHnB3d8fMmTMREhKCwYMHA6js5YqIiMDkyZOxevVqAMCUKVMQGRmJ9u3bK3PydZRTpAcANHdWK1wJERER3U7RINW7d2/s3LkTs2fPxoIFCxAQEIDly5dj3LhxUptZs2ahtLQUL7zwAvLy8hAaGop9+/bBxcVFarNs2TLY2Nhg9OjRKC0txaBBg7BhwwZYW/+xEvjWrVsxffp06e6+qKgorFixovFOVqacosqhPQ9n9kgRERFZGpUQQihdRFNQUFAAjUYDnU7XaPOlhBAIemsPyg0CP70xEC2aOTTK9xIREd0vGvr3W/FHxFDtCm5WoNxQmXM9nNgjRUREZGkYpCxYbnHlsJ6z2oYPLCYiIrJADFIWrGqiOedHERERWSYGKQt2o2qiOYf1iIiILBKDlAXLKa7qkeLSB0RERJaIQcqCVS194MmhPSIiIovEIGXBpDlSTuyRIiIiskQMUhbsRjEX4yQiIrJkDFIWrKpHyp2TzYmIiCwSg5QF+2OOFIf2iIiILBGDlAW7wXWkiIiILBqDlIXSVxiQV1IOAPBysVe4GiIiIqoJg5SFyi6s7I2ys7aCm6OtwtUQERFRTRikLNT1gpsAAC9XNVQqlcLVEBERUU0YpCzU9YLKHikfVw7rERERWSoGKQtV1SPlzSBFRERksRikLFTmn4b2iIiIyDIxSFmoLA7tERERWTwGKQvFoT0iIiLLxyBloTi0R0REZPkYpCwUh/aIiIgsH4OUBSrSV6BIXwEA8GKQIiIislgMUhYoI78UAOBibwNntY3C1RAREVFtGKQsUHpeZZBq6eaocCVERER0JwxSFig9rwQA0NLNQeFKiIiI6E4YpCzQHz1SDFJERESWjEHKAnFoj4iIqGlgkLJAHNojIiJqGhikLBCH9oiIiJoGBikLU1JWgZziMgAc2iMiIrJ0DFIW5kpO5bCeq70NNA62CldDREREd8IgZWF+zSoCALTzcla4EiIiIrobBikL81s2gxQREVFTwSBlYap6pNo2Z5AiIiKydIoGqXnz5kGlUpm8fHx8pP0TJkyotj8sLMzkGHq9HtOmTYOnpyecnJwQFRWF9PR0kzZ5eXmIjo6GRqOBRqNBdHQ08vPzG+MU641De0RERE2H4j1SnTt3RkZGhvQ6deqUyf6IiAiT/bt37zbZHxMTg507d2Lbtm04fPgwioqKEBkZCYPBILUZO3YskpOTERcXh7i4OCQnJyM6OrpRzq8+KgxGpN4oBsAeKSIioqbARvECbGxMeqFup1ara92v0+mwbt06bN68GYMHDwYAbNmyBX5+fjhw4ACGDRuGc+fOIS4uDomJiQgNDQUArF27FuHh4UhJSUH79u3Nf1IyXbheBH2FES5qG7Ry59IHRERElk7xHqmLFy9Cq9UiICAAzzzzDC5dumSy/+DBg/Dy8kJQUBAmT56MrKwsaV9SUhLKy8sxdOhQaZtWq0VwcDDi4+MBAAkJCdBoNFKIAoCwsDBoNBqpjaU4mZ4PAAhpqYGVlUrZYoiIiOiuFO2RCg0NxaZNmxAUFITr16/j3XffRZ8+fXDmzBl4eHhg+PDhePrpp+Hv74/U1FS8/fbbGDhwIJKSkqBWq5GZmQk7Ozu4ubmZHNfb2xuZmZkAgMzMTHh5eVX7bi8vL6lNTfR6PfR6vfS+oKDATGddu5Np+QCArn7NGvy7iIiI6N4pGqSGDx8u/T0kJATh4eFo27YtNm7ciFdffRVjxoyR9gcHB6NXr17w9/fHN998g5EjR9Z6XCEEVKo/enT+/Pfa2twuNjYW8+fPr+8p3ZOESzkAgJ6t3O7SkoiIiCyB4kN7f+bk5ISQkBBcvHixxv2+vr7w9/eX9vv4+KCsrAx5eXkm7bKysuDt7S21uX79erVjZWdnS21qMnv2bOh0OumVlpYm97Tq5EpOMa7klMDGSoWwth4N+l1ERERkHhYVpPR6Pc6dOwdfX98a9+fk5CAtLU3a37NnT9ja2mL//v1Sm4yMDJw+fRp9+vQBAISHh0On0+Ho0aNSmyNHjkCn00ltaqJWq+Hq6mryakg/XLwBAOjh7wZnteL3ABAREVEdKPqLPXPmTDz22GNo1aoVsrKy8O6776KgoADjx49HUVER5s2bh1GjRsHX1xeXL1/GnDlz4OnpiSeffBIAoNFoMGnSJMyYMQMeHh5wd3fHzJkzERISIt3F17FjR0RERGDy5MlYvXo1AGDKlCmIjIy0qDv2fryQDQDoH9Rc4UqIiIiorhQNUunp6Xj22Wdx48YNNG/eHGFhYUhMTIS/vz9KS0tx6tQpbNq0Cfn5+fD19cWAAQOwfft2uLi4SMdYtmwZbGxsMHr0aJSWlmLQoEHYsGEDrK2tpTZbt27F9OnTpbv7oqKisGLFikY/39qUG4xI+K1yftQjgZ4KV0NERER1pRJCCKWLaAoKCgqg0Wig0+nMOsxXUlaBvWcy8cr2k3BztMXPbw2BNZc+ICIiMouG+v2uwsk4Cpv31Rl8/nPlI20eDmzOEEVERNSEMEgpzM3RDmobK/hq7DHlkTZKl0NERET1wKG9OmqorkGDUbAXioiIqIE09NCeRS1/8CBiiCIiImq6GKSIiIiIZGKQIiIiIpKJQYqIiIhIJgYpIiIiIpkYpIiIiIhkYpAiIiIikolBioiIiEgmBikiIiIimRikiIiIiGRikCIiIiKSiUGKiIiISCYGKSIiIiKZGKSIiIiIZLJRuoCmQggBACgoKFC4EiIiIqqrqt/tqt9xc2OQqqPCwkIAgJ+fn8KVEBERUX0VFhZCo9GY/bgq0VAR7T5jNBrx+++/w8XFBSqVymzHLSgogJ+fH9LS0uDq6mq24z4IeO3k4XWTh9dNPl47eXjd5Ln9ugkhUFhYCK1WCysr889oYo9UHVlZWaFly5YNdnxXV1f+D0UmXjt5eN3k4XWTj9dOHl43ef583RqiJ6oKJ5sTERERycQgRURERCQTg5TC1Go15s6dC7VarXQpTQ6vnTy8bvLwusnHaycPr5s8jX3dONmciIiISCb2SBERERHJxCBFREREJBODFBEREZFMDFJEREREMjFIKexf//oXAgICYG9vj549e+LHH39UuqRG9cMPP+Cxxx6DVquFSqXCrl27TPYLITBv3jxotVo4ODjg0UcfxZkzZ0za6PV6TJs2DZ6ennByckJUVBTS09NN2uTl5SE6OhoajQYajQbR0dHIz89v4LNrGLGxsejduzdcXFzg5eWFJ554AikpKSZteN1qtnLlSnTp0kVaqC88PBx79uyR9vO61U1sbCxUKhViYmKkbbx21c2bNw8qlcrk5ePjI+3nNavdtWvX8Ne//hUeHh5wdHREt27dkJSUJO23qGsnSDHbtm0Ttra2Yu3ateLs2bPi5ZdfFk5OTuLKlStKl9Zodu/eLd58803xxRdfCABi586dJvvfe+894eLiIr744gtx6tQpMWbMGOHr6ysKCgqkNs8//7xo0aKF2L9/vzh+/LgYMGCA6Nq1q6ioqJDaREREiODgYBEfHy/i4+NFcHCwiIyMbKzTNKthw4aJ9evXi9OnT4vk5GQxYsQI0apVK1FUVCS14XWr2VdffSW++eYbkZKSIlJSUsScOXOEra2tOH36tBCC160ujh49Klq3bi26dOkiXn75ZWk7r111c+fOFZ07dxYZGRnSKysrS9rPa1az3Nxc4e/vLyZMmCCOHDkiUlNTxYEDB8Svv/4qtbGka8cgpaCHHnpIPP/88ybbOnToIN544w2FKlLW7UHKaDQKHx8f8d5770nbbt68KTQajVi1apUQQoj8/Hxha2srtm3bJrW5du2asLKyEnFxcUIIIc6ePSsAiMTERKlNQkKCACDOnz/fwGfV8LKysgQAcejQISEEr1t9ubm5iU8++YTXrQ4KCwtFYGCg2L9/v+jfv78UpHjtajZ37lzRtWvXGvfxmtXu9ddfFw8//HCt+y3t2nFoTyFlZWVISkrC0KFDTbYPHToU8fHxClVlWVJTU5GZmWlyjdRqNfr37y9do6SkJJSXl5u00Wq1CA4OltokJCRAo9EgNDRUahMWFgaNRnNfXGudTgcAcHd3B8DrVlcGgwHbtm1DcXExwsPDed3q4MUXX8SIESMwePBgk+28drW7ePEitFotAgIC8Mwzz+DSpUsAeM3u5KuvvkKvXr3w9NNPw8vLC927d8fatWul/ZZ27RikFHLjxg0YDAZ4e3ubbPf29kZmZqZCVVmWqutwp2uUmZkJOzs7uLm53bGNl5dXteN7eXk1+WsthMCrr76Khx9+GMHBwQB43e7m1KlTcHZ2hlqtxvPPP4+dO3eiU6dOvG53sW3bNhw/fhyxsbHV9vHa1Sw0NBSbNm3C3r17sXbtWmRmZqJPnz7IycnhNbuDS5cuYeXKlQgMDMTevXvx/PPPY/r06di0aRMAy/v3zabup0YNQaVSmbwXQlTb9qCTc41ub1NT+/vhWr/00kv45ZdfcPjw4Wr7eN1q1r59eyQnJyM/Px9ffPEFxo8fj0OHDkn7ed2qS0tLw8svv4x9+/bB3t6+1na8dqaGDx8u/T0kJATh4eFo27YtNm7ciLCwMAC8ZjUxGo3o1asXFi1aBADo3r07zpw5g5UrV+K5556T2lnKtWOPlEI8PT1hbW1dLfVmZWVVS9kPqqq7W+50jXx8fFBWVoa8vLw7trl+/Xq142dnZzfpaz1t2jR89dVX+P7779GyZUtpO6/bndnZ2aFdu3bo1asXYmNj0bVrV3z44Ye8bneQlJSErKws9OzZEzY2NrCxscGhQ4fw0UcfwcbGRjovXrs7c3JyQkhICC5evMh/3+7A19cXnTp1MtnWsWNHXL16FYDl/TeOQUohdnZ26NmzJ/bv32+yff/+/ejTp49CVVmWgIAA+Pj4mFyjsrIyHDp0SLpGPXv2hK2trUmbjIwMnD59WmoTHh4OnU6Ho0ePSm2OHDkCnU7XJK+1EAIvvfQSduzYge+++w4BAQEm+3nd6kcIAb1ez+t2B4MGDcKpU6eQnJwsvXr16oVx48YhOTkZbdq04bWrA71ej3PnzsHX15f/vt1B3759qy3pcuHCBfj7+wOwwP/G1XlaOpld1fIH69atE2fPnhUxMTHCyclJXL58WenSGk1hYaE4ceKEOHHihAAgli5dKk6cOCEtAfHee+8JjUYjduzYIU6dOiWeffbZGm9xbdmypThw4IA4fvy4GDhwYI23uHbp0kUkJCSIhIQEERIS0mRvD/5//+//CY1GIw4ePGhyW3VJSYnUhtetZrNnzxY//PCDSE1NFb/88ouYM2eOsLKyEvv27RNC8LrVx5/v2hOC164mM2bMEAcPHhSXLl0SiYmJIjIyUri4uEj/jec1q9nRo0eFjY2NWLhwobh48aLYunWrcHR0FFu2bJHaWNK1Y5BS2D//+U/h7+8v7OzsRI8ePaRb2B8U33//vQBQ7TV+/HghROVtrnPnzhU+Pj5CrVaLfv36iVOnTpkco7S0VLz00kvC3d1dODg4iMjISHH16lWTNjk5OWLcuHHCxcVFuLi4iHHjxom8vLxGOkvzqul6ARDr16+X2vC61WzixInS/96aN28uBg0aJIUoIXjd6uP2IMVrV13V2ka2trZCq9WKkSNHijNnzkj7ec1q9/XXX4vg4GChVqtFhw4dxJo1a0z2W9K1UwkhRN37r4iIiIioCudIEREREcnEIEVEREQkE4MUERERkUwMUkREREQyMUgRERERycQgRURERCQTgxQRERGRTAxSRHRfO3jwIFQqFfLz85UuhYjuQ1yQk4juK48++ii6deuG5cuXA6h8Bldubi68vb3r9UR3IqK6sFG6ACKihmRnZyc9LZ6IyNw4tEdE940JEybg0KFD+PDDD6FSqaBSqbBhwwaTob0NGzagWbNm+N///of27dvD0dERTz31FIqLi7Fx40a0bt0abm5umDZtGgwGg3TssrIyzJo1Cy1atICTkxNCQ0Nx8OBBZU6UiCwGe6SI6L7x4Ycf4sKFCwgODsaCBQsAAGfOnKnWrqSkBB999BG2bduGwsJCjBw5EiNHjkSzZs2we/duXLp0CaNGjcLDDz+MMWPGAAD+9re/4fLly9i2bRu0Wi127tyJiIgInDp1CoGBgY16nkRkORikiOi+odFoYGdnB0dHR2k47/z589XalZeXY+XKlWjbti0A4KmnnsLmzZtx/fp1ODs7o1OnThgwYAC+//57jBkzBr/99hs+++wzpKenQ6vVAgBmzpyJuLg4rF+/HosWLWq8kyQii8IgRUQPHEdHRylEAYC3tzdat24NZ2dnk21ZWVkAgOPHj0MIgaCgIJPj6PV6eHh4NE7RRGSRGKSI6IFja2tr8l6lUtW4zWg0AgCMRiOsra2RlJQEa2trk3Z/Dl9E9OBhkCKi+4qdnZ3JJHFz6N69OwwGA7KysvDII4+Y9dhE1LTxrj0iuq+0bt0aR44cweXLl3Hjxg2pV+leBAUFYdy4cXjuueewY8cOpKam4tixY1i8eDF2795thqqJqKlikCKi+8rMmTNhbW2NTp06oXnz5rh69apZjrt+/Xo899xzmDFjBtq3b4+oqCgcOXIEfn5+Zjk+ETVNXNmciIiISCb2SBERERHJxCBFREREJBODFBEREZFMDFJEREREMjFIEREREcnEIEVEREQkE4MUERERkUwMUkREREQyMUgRERERycQgRURERCQTgxQRERGRTAxSRERERDL9f4Dt4aCYMvTzAAAAAElFTkSuQmCC",
+      "text/plain": [
+       "<Figure size 640x480 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "wetted_sa_subset.wetted_surface_area.isel(nface=216).plot()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "id": "a2846c4d-d26f-4ed4-b86e-6624aba1e696",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#transport_model.mesh['wetted_surface_area'] = wetted_sa_subset['wetted_surface_area']\n",
+    "\n",
+    "transport_model.mesh['wetted_surface_area'] = xr.DataArray(\n",
+    "    wetted_sa_subset['wetted_surface_area'].values,\n",
+    "    dims=('time', 'nface')\n",
+    ")\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "id": "c14fc85a",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[<matplotlib.lines.Line2D at 0x1c1dbc292d0>]"
+      ]
+     },
+     "execution_count": 17,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAkcAAAHFCAYAAAD40125AAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjguNCwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8fJSN1AAAACXBIWXMAAA9hAAAPYQGoP6dpAABy5klEQVR4nO3deVhU1f8H8PewzLAPmyyjCKSgqJi4BKi5K5iEqbkWaZrar74aqbmU5lKu5VKaS2bupW2WlZJbkuaairlvAW4gqDCAINuc3x/EjZHFYRgYwPfreeaJuffccz+H5jIfzzn3XJkQQoCIiIiIAAAmxg6AiIiIqDphckRERERUBJMjIiIioiKYHBEREREVweSIiIiIqAgmR0RERERFMDkiIiIiKoLJEREREVERTI6IiIiIimByRAa1detWNG3aFJaWlpDJZIiJiTF2SNVeXFwcZDJZia8tW7boVEdGRgYiIyOhUqlgYWGBFi1alHjswYMH8dprr6FVq1ZQKBSQyWSIi4srVu7BgwcYNGgQGjVqBFtbW1hbW6Np06b48MMP8eDBg4o2udx0bd+wYcNK/D02bty4QudfunQpGjZsCLlcDplMhtTU1ArV9yTYt28fhg8fjsaNG8Pa2hp169ZF7969ceLECZ2O37NnD7p37w6VSgWFQgEXFxd06dIFO3bsKFb2l19+wSuvvAJ/f3+Ym5tDJpOVWKchrjVDSkpKwrBhw+Ds7AwrKysEBwdj7969xcq99957CAgIgKOjIywsLPDUU09h1KhRiI+Pr/KYnxRmxg6Aao/k5GREREQgNDQUy5cvh0KhgK+vr7HDqjHGjBmDIUOGaG3z8fHR6di+ffvi+PHjmDdvHnx9ffHVV19h8ODB0Gg0WnXu3bsXe/bsQUBAAOzs7LB///4S68vNzYUQAuPGjYO3tzdMTEzwxx9/YNasWdi/fz/27Nmjdzv1oWv7AMDS0hL79u0rtk1fMTExGDt2LF577TUMHToUZmZmsLW11bu+J8WKFStw7949vPXWW2jSpAmSk5OxcOFCBAUF4bfffkOXLl3KPP7evXto2rQpXnvtNbi5ueH+/ftYuXIlevXqhY0bN+Lll1+Wym7btg1HjhxBQEAAFArFYxOwilxrhpKdnY2uXbsiNTUVn3zyCVxcXPDZZ58hNDQUe/bsQceOHaWyqampGDx4MPz8/GBra4vz58/jww8/xPbt23Hu3Dk4OTlVaexPBEFkIAcPHhQAxNatW40dSo0SGxsrAIiPPvpIr+N//fVXAUB89dVXWtu7d+8uVCqVyMvLk7bl5+dLP3/00UcCgIiNjdX5XBMnThQAxLVr1/SK9VFDhw4VHTt2LLNMedo3dOhQYW1tbZDYCm3atEkAEEePHjVovbXdnTt3im1LT08Xrq6uomvXrnrVmZOTI+rWrSueffZZre1FP9dvvvmmKO2rraLXmq46duwohg4dWmaZzz77TAAQhw4dkrbl5uaKJk2aiGeeeeax59ixY4cAINasWVPRcKkEHFYjgxg2bBjat28PABg4cCBkMhk6deoEAPjrr78waNAgeHl5wdLSEl5eXhg8eHCJXcK3bt3CqFGj4OHhAblcDpVKhRdffBF37tyRyqSlpWHChAnw9vaGXC5H3bp1ERkZWa7hnrt378LDwwNt27ZFbm6utP38+fOwtrZGRESEnr+Jqrdt2zbY2Nigf//+WttfffVV3L59G0ePHpW2mZhU7JKvU6cOAMDMTLvT+a+//kJ4eLjU7R8QEIBvvvmmQucqVJ72GVqnTp2kHorAwEDIZDIMGzYMALB792707t0b9erVg4WFBRo2bIjRo0fj7t27xeq5ePEiBg8eDFdXVygUCtSvXx+vvPIKsrOzpTKJiYkYPXo06tWrB7lcDm9vb8ycORN5eXk6x/vBBx/AzMwMN27cKLZv+PDhcHJywsOHD8v5W9CPi4tLsW02NjZo0qRJifHpwtzcHPb29sU+fxX9XJdmz5496Nq1K+zs7GBlZYV27dqVOOylj23btqFRo0YIDg6WtpmZmeHll1/GsWPHcOvWrTKPL+1aJMNgckQGMW3aNHz22WcAgDlz5uDw4cNYvnw5gIJx/kaNGmHJkiX47bffMH/+fCQkJKBNmzZaXyS3bt1CmzZtsG3bNowbNw47d+7EkiVLoFQqkZKSAgDIzMxEx44dsX79eowdOxY7d+7EpEmTsG7dOoSHh0MIoVO8zs7O2LJlC44fP45JkyZJdffv3x/169fHypUryzxeCIG8vDydXrqaN28e5HI5rKys0L59e2zfvl2n486ePQs/P79ifySbN28u7ddXYTvT0tIQFRWFhQsXYvDgwahfv75U5vfff0e7du2QmpqKlStX4qeffkKLFi0wcOBArFu3Tu9zFypv+7KysuDm5gZTU1PUq1cP//vf/3D//n29zr18+XJMnToVALB27VocPnwY06ZNAwBcu3YNwcHBWLFiBXbt2oX3338fR48eRfv27bUS7tOnT6NNmzY4cuQIZs2ahZ07d2Lu3LnIzs5GTk4OgILE6JlnnsFvv/2G999/Hzt37sSIESMwd+5cjBw5Uud4R48eDTMzM6xatUpr+/3797FlyxaMGDECFhYWpR5fGZ/rotRqNU6ePImmTZvqfIxGo0FeXh5u376N6dOn4/Llyxg/frxe5y+ky7W2adMm9OjRA3Z2dli/fj2++eYbODo6IiQkxCAJ0tmzZ6XPcFGF286dO1dsX15eHrKysnDq1ClERkbC19cXffv2rXAsVALjdlxRbfL7778LAOLbb78ts1xeXp7IyMgQ1tbW4pNPPpG2Dx8+XJibm4vz58+XeuzcuXOFiYmJOH78uNb27777TgAQO3bsKFfM8+fPFwDEtm3bxNChQ4WlpaX4+++/H3tcYVt1eT1u2Or27dti5MiR4ptvvhEHDhwQmzdvFkFBQQKAWL169WNj8fHxESEhISXWC0DMmTOnxON0GVb7+uuvtdry6quvitzcXK0yjRs3FgEBAcW2h4WFCXd3d60hj9zcXK3XK6+8Ijp06FBsu0aj0at9ixYtEosWLRK7du0Su3btEu+9956wsrISjRs3Funp6aW2syxr164VAIp95orSaDQiNzdXxMfHCwDip59+kvZ16dJF2Nvbi6SkpFKPHz16tLCxsRHx8fFa2z/++GMBQJw7d07neIcOHSpcXFxEdna2tG3+/PnCxMTksZ/Fwrbq8tLHSy+9JMzMzMRff/2l8zEhISHSOe3s7MQPP/xQZvmyhtV0vdYePHggHB0dxfPPP691fH5+vnj66ae1hr0K/98XfXXo0EG88sorxbYXZW5uLkaPHl0sxkOHDpU4jJyQkKD1+w8MDBS3bt0q83dB+mNyRAZTWnKUnp4uJk6cKBo0aCBMTU21LvDXX39dKufu7i569OhR5jnatWsnmjdvXuyPTnp6upDJZGLixInlilmj0YhevXoJCwsLAUB88cUXOh2XlpYmjh8/rtOr6JeUrnJyckRAQIBwcnIq9kf1UT4+PiI0NLTY9sLkYe7cuSUep0tydP/+fXH8+HGxb98+MXv2bGFnZyfCw8OlhOfKlSsCgPj444+L/T9Zvny5ACAlu4XzPXR5/f777xVuX6HCxHnRokVllitNacnRnTt3xOjRo0W9evWEiYmJVvzz5s0TQhR8yZqamopRo0aVeY66deuK559/vtjv8Ny5cwKAWL58uc7xnjx5UgAQmzZtEkIUfKF7eXkV+6Ivyd27d3X+XJfX1KlTBQCxdOnSch13+fJlcezYMfHTTz+J/v37C3Nz82KJQ1FlJUclKela2717twAgvvvuu2L/TyZNmiRkMpnIyMgQQuj/DyVzc3Otv3+FCpOjr7/+Wmt7bm6uOH78uDh48KBYvXq18PHxEb6+vuL27ds6t5V0x8FKqnRDhgzB3r17MW3aNLRp0wZ2dnaQyWR47rnnkJWVJZVLTk5GvXr1yqzrzp07uHr1KszNzUvcX9J8j7IUziH59ddf4ebmpvNcIxsbG7Ro0UKnsvrMCTA3N8fAgQMxefJkXLlyBX5+fqWWdXJywr1794ptLxxKcnR0LPf5Czk4OKB169YAgM6dO6NBgwYYNGgQfvrpJ/Tp00eaCzZhwgRMmDChxDoK/5+oVCocP35ca9/MmTNx+/btYsNAjRo1kn6uaPv69OkDa2trHDlypMxy5aHRaNCjRw/cvn0b06ZNg7+/P6ytraHRaBAUFCR9rlNSUpCfn6/T5/rnn382yOc6ICAAzz77LD777DO89NJL+OWXXxAXF1fsd1wSR0dHKJVKnc+lq5kzZ+LDDz/E7Nmz8b///a9cxxa9iyw8PBw9e/bEm2++iYEDBxpkrlFJ11rh5/rFF18s9bj79+/D2toarVq1Kva5Hj16NFQqFaZPn661XaVSST+X93NtZmYmXYvt2rVDaGgovL29MW/ePHzyySflaDHpgskRVSq1Wo1ffvkF06dPx+TJk6Xt2dnZxeaB1KlTBzdv3iyzPmdnZ1haWuLLL78sdX95JCQk4M0330SLFi1w7tw5TJgwAZ9++uljj4uOjkbnzp11OkdsbCy8vLzKFRcAaf7U474A/P398fXXXyMvL08rETtz5gwAoFmzZuU+d2meeeYZAMDly5cB/Pf7njJlSqlzHwoTHblcLv1xL+Tk5IT09PRi24syRPuEEAadtHv27FmcPn0a69atw9ChQ6XtV69e1Srn6OgIU1NTnT7XzZs3x+zZs0vcX/RLVRdjx45F//79cfLkSSxbtgy+vr7o3r37Y49bv349Xn31VZ3OIXSc3zdz5kzMmDEDM2bMwLvvvqvTMWV55plnEBUVheTkZLi6ula4PqD4tVb4uV66dCmCgoJKPKbw3La2tsU+v7a2tnBycnrs57rwM1yUrp/revXqQaVSSdciGRaTI6pUMpkMQggoFAqt7V988QXy8/O1tvXs2RMbN27EpUuXtHoOigoLC8OcOXPg5OQEb2/vCsWWn5+PwYMHQyaTYefOndi8eTMmTJiATp06PXaSY0n/WixNeb/YgIJ1hrZu3QpnZ2c0bNiwzLJ9+vTB6tWr8f3332PgwIHS9vXr10OlUiEwMLDc5y/N77//DgBSTI0aNYKPjw9Onz6NOXPmGOw8RVW0fd999x0yMzNL/ZLTR+Eig49+rh/tnbG0tETHjh3x7bffYvbs2aUm72FhYdixYwcaNGgABweHCsfXp08f1K9fH+PHj0d0dDQWL15c6sKIRT3//PM6f6518cEHH2DGjBmYOnVqsV4UfQghEB0dDXt7e4Ot7VPStdauXTvY29vj/Pnz5e7p0lWfPn3wxhtv4OjRo9JnOC8vD5s2bUJgYOBj/25cvXoVN2/eRHh4eKXE96RjckSVys7ODh06dMBHH30EZ2dneHl5ITo6GmvWrIG9vb1W2cI7eTp06IB3330X/v7+SE1NRVRUFMaNG4fGjRsjMjIS33//PTp06IC3334bzZs3h0ajwfXr17Fr1y6MHz9e52Rg+vTpOHDgAHbt2gU3Nzfpi2TEiBEICAgoM/kq6V+L+ho3bhxyc3PRrl07uLm54caNG1i6dCliYmKwdu1amJqaSmVnzZqFWbNmYe/evdIicT179kT37t3xf//3f0hLS0PDhg3x9ddfIyoqCps2bdI6Pjk5GdHR0QD++xfqzp07UadOHdSpU0eqc9WqVThw4AB69OgBDw8PPHjwAAcOHMDSpUvRtm1b9O7dW6pz1apV6NmzJ0JCQjBs2DDUrVsX9+/fx4ULF3Dy5El8++23Ffr96Nq++Ph4DBkyBIMGDULDhg0hk8kQHR2NJUuWSIsJFtWpUydER0fr3ANSVOPGjdGgQQNMnjwZQgg4Ojri559/xu7du4uVXbRoEdq3b4/AwEBMnjwZDRs2xJ07d7B9+3asWrUKtra2mDVrFnbv3o22bdti7NixaNSoER4+fIi4uDjs2LEDK1eufOzQXFGmpqZ48803MWnSJFhbW0vLDzyOk5OTwZKOhQsX4v3330doaCh69epVbFizaLI6YsQIrF+/HteuXYOnpycAoHfv3nj66afRokULODk54fbt21i3bh2io6Px2WefafUixsfHS0ndtWvXABQkxQDg5eUlXau6Xms2NjZYunQphg4divv37+PFF1+Ei4sLkpOTcfr0aSQnJ2PFihUV+v0MHz4cn332Gfr374958+bBxcUFy5cvx6VLl7QWWf3777/x9ttv48UXX8RTTz0FExMTnDlzBosXL4aTk1Opw9lUQcab7kS1TWkTsm/evCn69esnHBwchK2trQgNDRVnz54Vnp6exRZKu3Hjhhg+fLhwc3MT5ubmQqVSiQEDBmgtKJeRkSGmTp0qGjVqJORyuVAqlcLf31+8/fbbIjExUadYd+3aJUxMTMT06dO1tt+7d0/Ur19ftGnTRq+J1PpYs2aNeOaZZ4Sjo6MwMzMTDg4OIiQkRPz222/Fyk6fPr3YhGUhCia9jx07Vri5uQm5XC6aN29ebEKnEGVPHi26GOOff/4pwsLChEqlEnK5XFhZWYmnn35afPDBB+LBgwfF6j19+rQYMGCAcHFxEebm5sLNzU106dJFrFy5ssy267IIpK7tu3//vujTp4/w8vISlpaWQi6XCx8fHzFx4kSRmpparM5WrVoJNze3x567tAnZ58+fF927dxe2trbCwcFB9O/fX1y/fl0AKPa5On/+vOjfv79wcnIScrlc1K9fXwwbNkw8fPhQKpOcnCzGjh0rvL29hbm5uXB0dBStWrUS7733njT5tzzi4uKK3fRQlTp27Kjz3W5Dhw4tNmF5/vz5ok2bNsLBwUGYmpoKJycnERISIn755Zdi5yrrLruif2PKc60JIUR0dLTo1auXcHR0FObm5qJu3bqiV69ej70jV5dFIIUQIjExUbzyyivC0dFRWFhYiKCgILF79+5iZV5++WXRoEEDYWVlJeRyuXjqqafE66+/Lq5fv/7Yc5B+ZELo8c8mIqIaLD09HY6OjliyZAnefPNNY4dTKZYuXYqxY8fi7Nmz5VpXiIg4rEZET6A//vgDdevWLdcCizXFqVOnEBsbi1mzZqF3795MjIj0wJ4jqnU0Gg00Gk2ZZbjkPtU0+fn5Zc6PkslkMDU1hZeXFxITE/Hss89i48aNcHNzq8IoiWoHJkdU6wwbNgzr168vsww/9lTTFE4gL42npyfi4uKqLiCiWozJEdU6cXFxj100z1B3mhFVlUuXLiE9Pb3U/QqFAv7+/lUYEVHtxeSIiIiIqAjDLRlLREREVAtwVqqONBoNbt++DVtbW51WmiUiIiLjE0IgPT0dKpVK58cIMTnS0e3bt+Hh4WHsMIiIiEgPN27c0HmleSZHOrK1tQVQ8Mu1s7MzcjRERESki7S0NHh4eEjf47pgcqSjwqE0Ozs7JkdEREQ1THmmxHBCNhEREVERTI6IiIiIimByRERERFQEkyMiIiKiIpgcERERERXB5IiIiIioCCZHREREREUwOSIiIiIqgskRERERURFMjoiIiIiKYHJEREREVASTIyIiIqIi+OBZIqJaRggBIQBR+DPw73vx735I/xUouWzplZe2ueQdZdVV2i5RykGlly/rHKUGXK5zlHWeqmj7k8LeSg4bhfFTE+NHQERURL5GICdPg+y8fGTnaaSfH+ZqkJOvQXZuwfucPA3yNAK5+RrkawTy8gVyNQU/5+YL5Gs0yM0v2J6v0SBXI5CXX3BMXr5Ankbz738L6tAIAY0GyBcCQgjkawQ0AgXbH9mnEQVxFv1ZKld4jKaEckWOL0xEgH+TlML3pSQ1hQkMHklydE5qiGqAD3o3RUSwl7HDYHJERPp5mJuPtKxcpD3MhTorD+kPc5GZk48H2XnIys3Hg+x8ZOXk4UFOPjJz8pGZk6f93+x8PMzL10p2sv9NeIgMSSYrZXup5UvbU9YxpZUvva7SdpVxRK1nYlI9Ws/kiOgJp9EIpGbl4l5GNu5m5OD+gxzce5CNexkF/03NzEXawzwpEUrLykPaw1zk5GkqPTYTGWBhbgq5mQkUZiZQmP33s9zMBOYmJjAzlcHURAZzUxOYmchgZiqD2b/bC96bwNxEBlMTE5ibyv4t/+82U5lWHSaygpepScEXZOHPhdsLXgV/wIuVe2SfVjmZDDLZv/X8W58MRb9QC/YXbPtvn+zf7VIpWcn7ZQVVaJUvqS7IoHWe/8o9cqys7C91oyYbZdRFZChMjohqKSEE0rLykJCWhQT1Q9xRP0SC+iES1Q+RkFbw/t6DbNx/kAN9O2tkMsDOwhx2lmawVZjDWmEKK7kZrORF/qswhZW52SP7Cn62lBckPIXJjvbPJjAz5T0jRFT1mBwR1WDZefm4mZKF6/czcf1eJuLvZeL6/QeIv5eJmylZyMrN17kupaU5nGzkcLZWwNFaDicbOZys5bC3ksPO0hx2Fmb//tccSquC99Zys2rTDU5EZChMjohqgMycPFxNysDlOxm4cicdl++k40pSBm6lZj12Eq6DlTnclJZwV1rATWkBdzsLuCot4GZnAWcbBZxt5HCwlsOcvTRERACqQXKUnp6OadOmYdu2bUhKSkJAQAA++eQTtGnTBkDB0MDMmTPx+eefIyUlBYGBgfjss8/QtGlTqY7s7GxMmDABX3/9NbKystC1a1csX74c9erVk8qkpKRg7Nix2L59OwAgPDwcS5cuhb29fZW2l+hx7mVk4+9bapy9qcbft9S4mJiGG/ezSi1vJTdFfUcreDpZwdPJGh6OVvB0tEJ9Ryu4KS1gYW5ahdETEdV8Rk+OXnvtNZw9exYbN26ESqXCpk2b0K1bN5w/fx5169bFggULsGjRIqxbtw6+vr748MMP0b17d1y6dAm2trYAgMjISPz888/YsmULnJycMH78eISFheHEiRMwNS34YhgyZAhu3ryJqKgoAMCoUaMQERGBn3/+2WhtJ8rOy8eZm2ocj0vB6RupOHNLjVupJSdCTtZy+LjawNfVFj6utvB1scFTdWzgbCPnJFUiIgOSCSOuOJWVlQVbW1v89NNP6NWrl7S9RYsWCAsLwwcffACVSoXIyEhMmjQJQEEvkaurK+bPn4/Ro0dDrVajTp062LhxIwYOHAgAuH37Njw8PLBjxw6EhITgwoULaNKkCY4cOYLAwEAAwJEjRxAcHIyLFy+iUaNGj401LS0NSqUSarUadnZ2lfDboCdBZk4eTsSn4FjsfRyLvY+YG6nILuGur6fqWMO/rhL+dZVoqlLC19UGTjYKI0RMRFSz6fP9bdSeo7y8POTn58PCwkJru6WlJQ4ePIjY2FgkJiaiR48e0j6FQoGOHTvi0KFDGD16NE6cOIHc3FytMiqVCs2aNcOhQ4cQEhKCw4cPQ6lUSokRAAQFBUGpVOLQoUMlJkfZ2dnIzs6W3qelpRmy6fSEEELg0p10RF9Kxh9XknE8NgU5+drJkJO1HG28HNHS0x7+de3RtK4d7CzMjRQxEREZNTmytbVFcHAwPvjgA/j5+cHV1RVff/01jh49Ch8fHyQmJgIAXF1dtY5zdXVFfHw8ACAxMRFyuRwODg7FyhQen5iYCBcXl2Lnd3Fxkco8au7cuZg5c2aF20hPnuy8fPx59S5+O3sH+y8n4U5attb+uvaWCPR2RBtvR7TxckSDOtYcFiMiqkaMPudo48aNGD58OOrWrQtTU1O0bNkSQ4YMwcmTJ6Uyj35xCCEe+2XyaJmSypdVz5QpUzBu3DjpfVpaGjw8PHRqEz15snLyEX05CTvPJmLfhSSkZ+dJ+yzMTRD8lBM6+NZBR9868HZmMkREVJ0ZPTlq0KABoqOj8eDBA6SlpcHd3R0DBw6Et7c33NzcABT0/Li7u0vHJCUlSb1Jbm5uyMnJQUpKilbvUVJSEtq2bSuVuXPnTrFzJycnF+uVKqRQKKBQcI4HlU6jETgSew/fn7iFnWcTkJnz35pCLrYKhDZzQzc/Vzzj7cg7xoiIahCjJ0eFrK2tYW1tjZSUFPz2229YsGCBlCDt3r0bAQEBAICcnBxER0dj/vz5AIBWrVrB3Nwcu3fvxoABAwAACQkJOHv2LBYsWAAACA4OhlqtxrFjx/DMM88AAI4ePQq1Wi0lUES6un4vE9+euIEfTt7SurOsrr0lejZzQ09/NwR4OHBxRCKiGsroydFvv/0GIQQaNWqEq1ev4p133kGjRo3w6quvQiaTITIyEnPmzIGPjw98fHwwZ84cWFlZYciQIQAApVKJESNGYPz48XBycoKjoyMmTJgAf39/dOvWDQDg5+eH0NBQjBw5EqtWrQJQcCt/WFiYTneqEWk0An9cScaGw/H4/VKStPCircIMYU+7o1/Lemjl6cDhMiKiWsDoyZFarcaUKVNw8+ZNODo6ol+/fpg9ezbMzQvu1pk4cSKysrLwxhtvSItA7tq1S1rjCAAWL14MMzMzDBgwQFoEct26ddIaRwCwefNmjB07VrqrLTw8HMuWLavaxlKN8yA7D9/8dQMbDscj9u4DafuzPs7o39oDPZq4csiMiKiWMeo6RzUJ1zl6sjzIzsOGw/FYfeAf3H+QA6Cgl+jF1vXwSrAXvJ2tjRwhERHposatc0RU3WRk52H9oTh8ceAfpGTmAgC8nKww4tmn0DegLqwVvGSIiGo7/qUnApD+MLcgKToYi9R/kyJvZ2uM6dIQ4U+rYMaHshIRPTGYHNETLe1hLtb9GYc1B2OhzipIip6qU5AUPd+cSRER0ZOIyRE9kR7m5mPTkXgs+/2q1FPUoI41xnb1QVhzFUx5Gz4R0ROLyRE9UfI1Aj+euoVFuy9LaxQ1dLHB2K4+6OXvzqSIiIiYHNGT46+4+3j/p3M4n1DwEGF3pQXe7u6Lfi3rMSkiIiIJkyOq9e5mZGPujov4/uRNAICdhRne6NwQw9p6cY0iIiIqhskR1VoajcDmo/FY8NslpD8seBDsoDYemBjaGI7WciNHR0RE1RWTI6qVrt/LxDvfncbR2PsAgGZ17TCrdzO0rO/wmCOJiOhJx+SIahWNRmDT0XjM23kRmTn5sDQ3xaTQRogI9uK8IiIi0gmTI6o1ktIfYtzW0zh49S4AINDbER+9+DTqO1kZOTIiIqpJmBxRrXDgSjLe3hqDuxk5sDA3weTQxngl2Asm7C0iIqJyYnJENVpevgaL91zG8v3XIATQ2M0Wy4YEoKGLrbFDIyKiGorJEdVYKQ9y8OZXJ3Ho2j0AwJDA+ng/rAlvzyciogphckQ10qXEdLy24Thu3M+CtdwUc/s1R/jTKmOHRUREtQCTI6pxdp1LxNtbY/AgJx8ejpb44pU2aOTGYTQiIjIMJkdUo3xx4B98+OsFAEDwU05Y/lJLOHBBRyIiMiAmR1QjaDQCc3dewOoDsQCAl4PqY/rzTWFuamLkyIiIqLZhckTVXk6eBu98dxo/xdwGAEzu2RijOzwFmYy36RMRkeExOaJq7WFuPkZtPIE/LifDzESGBS82R9+W9YwdFhER1WJMjqjaysrJx4j1x3Ho2j1YmptiZUQrdPStY+ywiIiolmNyRNXSg+w8jFh/HEf+uQ9ruSnWDX8GbbwcjR0WERE9AZgcUbXzIDsPr649jmNx92GjMMP64c+glaeDscMiIqInBJMjqlay8/IxeuMJHIu7D1sLM2wY/gwC6jMxIiKiqsP7oKnayNcIRG6JwcGrd2ElN2ViRERERsHkiKoFIQTe/eEMdp5NhNzUBJ9HtGZiRERERsHkiKqFBb9dwta/bsBEBnw6uAXa+zgbOyQiInpCMTkio/v62HWs2H8NADC3rz9Cm7kbOSIiInqSMTkio/rz6l1M+/EsAODtbr4Y2Ka+kSMiIqInHZMjMpqrSel4fdMJ5GkEXmihwtiuDY0dEhEREZMjMo7UzBwMX/cX0h/mobWnA+b1a85npRERUbXA5IiqnEYj8PbWGFy/nwkPR0usimgFC3NTY4dFREQEgMkRGcHSfVfx+6VkKMxMsPLlVnCyURg7JCIiIgmTI6pS+y8lYcneywCAD19ohqYqpZEjIiIi0sbkiKrMrdQsRG6NgRDA4Gfqo39rD2OHREREVIxRk6O8vDxMnToV3t7esLS0xFNPPYVZs2ZBo9FIZYYNGwaZTKb1CgoK0qonOzsbY8aMgbOzM6ytrREeHo6bN29qlUlJSUFERASUSiWUSiUiIiKQmppaFc0kFDwa5O0tMUjNzEXzekpMf76JsUMiIiIqkVGTo/nz52PlypVYtmwZLly4gAULFuCjjz7C0qVLtcqFhoYiISFBeu3YsUNrf2RkJLZt24YtW7bg4MGDyMjIQFhYGPLz86UyQ4YMQUxMDKKiohAVFYWYmBhERERUSTsJWLH/Ko7F3Ye13BRLBwdwAjYREVVbZsY8+eHDh9G7d2/06tULAODl5YWvv/4af/31l1Y5hUIBNze3EutQq9VYs2YNNm7ciG7dugEANm3aBA8PD+zZswchISG4cOECoqKicOTIEQQGBgIAVq9ejeDgYFy6dAmNGjWqxFbSqespWLznCgBgZu9m8HSyNnJEREREpTNqz1H79u2xd+9eXL5cMEH39OnTOHjwIJ577jmtcvv374eLiwt8fX0xcuRIJCUlSftOnDiB3Nxc9OjRQ9qmUqnQrFkzHDp0CEBBEqZUKqXECACCgoKgVCqlMo/Kzs5GWlqa1ovKLyM7D5FbY5CvEQhr7o5+LesaOyQiIqIyGbXnaNKkSVCr1WjcuDFMTU2Rn5+P2bNnY/DgwVKZnj17on///vD09ERsbCymTZuGLl264MSJE1AoFEhMTIRcLoeDg/YT3F1dXZGYmAgASExMhIuLS7Hzu7i4SGUeNXfuXMycOdOArX0yzf71AuLvZUKltMDsF/y50CMREVV7Rk2Otm7dik2bNuGrr75C06ZNERMTg8jISKhUKgwdOhQAMHDgQKl8s2bN0Lp1a3h6euLXX39F3759S61bCKH1RVzSl/KjZYqaMmUKxo0bJ71PS0uDhwfvriqPQ1fv4utj1wEAHw94GkorcyNHRERE9HhGTY7eeecdTJ48GYMGDQIA+Pv7Iz4+HnPnzpWSo0e5u7vD09MTV64UzGFxc3NDTk4OUlJStHqPkpKS0LZtW6nMnTt3itWVnJwMV1fXEs+jUCigUHBxQn1l5uRh0g9/AwBeCqyPtg2cjRwRERGRbow65ygzMxMmJtohmJqaat3K/6h79+7hxo0bcHd3BwC0atUK5ubm2L17t1QmISEBZ8+elZKj4OBgqNVqHDt2TCpz9OhRqNVqqQwZ1se/XcaN+1lQKS0wuWdjY4dDRESkM6P2HD3//POYPXs26tevj6ZNm+LUqVNYtGgRhg8fDgDIyMjAjBkz0K9fP7i7uyMuLg7vvvsunJ2d0adPHwCAUqnEiBEjMH78eDg5OcHR0RETJkyAv7+/dPean58fQkNDMXLkSKxatQoAMGrUKISFhfFOtUpwIj4Faw/FAgDm9PWHrQWH04iIqOYwanK0dOlSTJs2DW+88QaSkpKgUqkwevRovP/++wAKepHOnDmDDRs2IDU1Fe7u7ujcuTO2bt0KW1tbqZ7FixfDzMwMAwYMQFZWFrp27Yp169bB1PS/tXQ2b96MsWPHSne1hYeHY9myZVXb4CdAXr4GU388CyGAfi3roVOj4hPhiYiIqjOZEEIYO4iaIC0tDUqlEmq1GnZ2dsYOp9pa92csZvx8HkpLc/w+oRMcreXGDomIiJ5g+nx/89lqZDDJ6dlYuKtgzaqJoY2YGBERUY3E5IgMZu7OC0jPzoN/XSUGtalv7HCIiIj0wuSIDOKvuPv44eQtyGTABy80g6kJF3skIqKaickRVZgQAh/+egEAMKCVB1p42Bs3ICIiogpgckQV9uuZBMTcSIWV3BTjQ3yNHQ4REVGFMDmiCsnJ02BB1CUAwKgOT8HF1sLIEREREVUMkyOqkE1H4nH9fibq2Cow8tmnjB0OERFRhTE5Ir2ps3Lx6b6CZ9y93c0X1gqjrilKRERkEEyOSG9rDsYiNTMXDV1sMKB1PWOHQ0REZBBMjkgv6sxcrD1Y8Py0cd19YWbKjxIREdUO/EYjvaz5Mxbp2Xlo7GaL0KZuxg6HiIjIYJgcUbkV7TV6q6sPTLjgIxER1SJMjqjc1hz8R+o1CmGvERER1TJMjqhc1Fm5WPtnHAD2GhERUe3E5IjKZfPReKRn56GRK3uNiIiodmJyRDrLzsuXeo1GdXiKvUZERFQrMTkinf106jaS07PhZmeB559WGTscIiKiSsHkiHSi0Qis+uMaAGB4ey/IzfjRISKi2onfcKSTfReTcC35AWwVZhj8TH1jh0NERFRpmByRTr44+A8AYEhQfdhamBs5GiIiosrD5Ige6/KddBz55z5MTWQY1tbL2OEQERFVKiZH9FgbD8cDALr7ucJdaWnkaIiIiCoXkyMqU0Z2Hn44eRMAEBHsaeRoiIiIKh+TIyrTtpM38SAnH0/VsUbbBk7GDoeIiKjSMTmiUgkhsPFIwZBaRJAnZDIu+khERLUfkyMq1bHY+7h8JwOW5qbo16qescMhIiKqEkyOqFTfniiYaxT+tAp2vH2fiIieEEyOqEQPsvOw40wCAGBAG/YaERHRk4PJEZVo59lEZObkw9vZGi3rOxg7HCIioirD5IhK9N2JGwCAF1vV40RsIiJ6ojA5omJu3M/EkX/uQyYD+gTUNXY4REREVYrJERXz/b+LPrZr4AyVPVfEJiKiJwuTI9IihMC2U7cAFAypERERPWmYHJGWM7fUiL+XCUtzU/Ro6mrscIiIiKqcUZOjvLw8TJ06Fd7e3rC0tMRTTz2FWbNmQaPRSGWEEJgxYwZUKhUsLS3RqVMnnDt3Tque7OxsjBkzBs7OzrC2tkZ4eDhu3rypVSYlJQURERFQKpVQKpWIiIhAampqVTSzRvnl74Lb97v4ucBKbmbkaIiIiKqeUZOj+fPnY+XKlVi2bBkuXLiABQsW4KOPPsLSpUulMgsWLMCiRYuwbNkyHD9+HG5ubujevTvS09OlMpGRkdi2bRu2bNmCgwcPIiMjA2FhYcjPz5fKDBkyBDExMYiKikJUVBRiYmIQERFRpe2t7oQQ+PXf5Oj55u5GjoaIiMg4ZEIIYayTh4WFwdXVFWvWrJG29evXD1ZWVti4cSOEEFCpVIiMjMSkSZMAFPQSubq6Yv78+Rg9ejTUajXq1KmDjRs3YuDAgQCA27dvw8PDAzt27EBISAguXLiAJk2a4MiRIwgMDAQAHDlyBMHBwbh48SIaNWr02FjT0tKgVCqhVqthZ2dXCb8N4zsRn4J+Kw7BWm6KE9O6w8Lc1NghERERVYg+3996j5vcvHkT27dvx/Xr15GTk6O1b9GiRTrV0b59e6xcuRKXL1+Gr68vTp8+jYMHD2LJkiUAgNjYWCQmJqJHjx7SMQqFAh07dsShQ4cwevRonDhxArm5uVplVCoVmjVrhkOHDiEkJASHDx+GUqmUEiMACAoKglKpxKFDh3RKjp4Ev/x9GwDQvYkrEyMiInpi6ZUc7d27F+Hh4fD29salS5fQrFkzxMXFQQiBli1b6lzPpEmToFar0bhxY5iamiI/Px+zZ8/G4MGDAQCJiYkAAFdX7YnBrq6uiI+Pl8rI5XI4ODgUK1N4fGJiIlxcXIqd38XFRSrzqOzsbGRnZ0vv09LSdG5XTaTRCOlxIWHNVUaOhoiIyHj0mnM0ZcoUjB8/HmfPnoWFhQW+//573LhxAx07dkT//v11rmfr1q3YtGkTvvrqK5w8eRLr16/Hxx9/jPXr12uVe3SFZiHEY1dtfrRMSeXLqmfu3LnS5G2lUgkPDw9dm1Uj/RWfgjtp2bC1MMOzvs7GDoeIiMho9EqOLly4gKFDhwIAzMzMkJWVBRsbG8yaNQvz58/XuZ533nkHkydPxqBBg+Dv74+IiAi8/fbbmDt3LgDAzc0NAIr17iQlJUm9SW5ubsjJyUFKSkqZZe7cuVPs/MnJycV6pQpNmTIFarVaet24cUPndtVEu84V/I67+7lCYcYhNSIienLplRxZW1tLQ04qlQrXrl2T9t29e1fnejIzM2Fioh2CqampdCu/t7c33NzcsHv3bml/Tk4OoqOj0bZtWwBAq1atYG5urlUmISEBZ8+elcoEBwdDrVbj2LFjUpmjR49CrVZLZR6lUChgZ2en9aqthBDYfaEgeezehGsbERHRk02vOUdBQUH4888/0aRJE/Tq1Qvjx4/HmTNn8MMPPyAoKEjnep5//nnMnj0b9evXR9OmTXHq1CksWrQIw4cPB1AwFBYZGYk5c+bAx8cHPj4+mDNnDqysrDBkyBAAgFKpxIgRIzB+/Hg4OTnB0dEREyZMgL+/P7p16wYA8PPzQ2hoKEaOHIlVq1YBAEaNGoWwsDBOxgZwNSkD8fcyITczQQffOsYOh4iIyKj0So4WLVqEjIwMAMCMGTOQkZGBrVu3omHDhli8eLHO9SxduhTTpk3DG2+8gaSkJKhUKowePRrvv/++VGbixInIysrCG2+8gZSUFAQGBmLXrl2wtbWVyixevBhmZmYYMGAAsrKy0LVrV6xbtw6mpv8ND23evBljx46V7moLDw/HsmXL9Gl+rbPrfEGvUbsGTrBWcOFHIiJ6shl1naOapDavc/TCZ38i5kYqZvdphpcCPY0dDhERkcHo8/2t9wrZqamp+OKLLzBlyhTcv38fAHDy5EncunVL3yrJCJLSHyLmRioAoJsf5xsRERHpNYby999/o1u3blAqlYiLi8PIkSPh6OiIbdu2IT4+Hhs2bDB0nFRJ9l5IAgA87WEPVzsLI0dDRERkfHr1HI0bNw7Dhg3DlStXYGHx3xdqz5498ccffxgsOKp8ewvvUvMrvkgmERHRk0iv5Oj48eMYPXp0se1169YtdcVpqn5y8jQ4dO0eAKBTIyZHREREgJ7JkYWFRYmP07h06RLq1OGt4DXFyespyMzJh7ONHE3ca9ckcyIiIn3plRz17t0bs2bNQm5uLoCC9YiuX7+OyZMno1+/fgYNkCrPgSvJAID2DZ1hYlL241iIiIieFHolRx9//DGSk5Ph4uKCrKwsdOzYEQ0bNoStrS1mz55t6Bipkhy4UrCa+bM+7O0jIiIqpNfdanZ2djh48CD27duHkydPQqPRoGXLltKK1FT93X+QgzO31ACAZ334oFkiIqJC5U6O8vLyYGFhgZiYGHTp0gVdunSpjLiokv159S6EABq72cKFt/ATERFJyj2sZmZmBk9PT+Tn51dGPFRFCucbsdeIiIhIm15zjqZOnaq1MjbVLEIIHOR8IyIiohLpNefo008/xdWrV6FSqeDp6Qlra2ut/SdPnjRIcFQ54u9l4rb6IeSmJmjj5WjscIiIiKoVvZKjF154wcBhUFU6Gluw8OPTHkpYyk2NHA0REVH1oldyNH36dEPHQVXo6D8Fw6GB3k5GjoSIiKj60WvOEdVsR2P/TY6e4pAaERHRo/TqOcrPz8fixYvxzTff4Pr168jJydHaz4na1deN+5m4lZoFMxMZWnk6GDscIiKiakevnqOZM2di0aJFGDBgANRqNcaNG4e+ffvCxMQEM2bMMHCIZEhH/imYb+RfTwkruV65MRERUa2mV3K0efNmrF69GhMmTICZmRkGDx6ML774Au+//z6OHDli6BjJgKQhNc43IiIiKpFeyVFiYiL8/f0BADY2NlCrCx5DERYWhl9//dVw0ZHBFd6pxvlGREREJdMrOapXrx4SEhIAAA0bNsSuXbsAAMePH4dCoTBcdGRQt1OzcON+FkxkQGvONyIiIiqRXslRnz59sHfvXgDAW2+9hWnTpsHHxwevvPIKhg8fbtAAyXBOxKcAAJqo7GBrYW7kaIiIiKonvWbkzps3T/r5xRdfhIeHB/788080bNgQ4eHhBguODOvk9YLkqGV99hoRERGVxiC3KwUGBiIwMLDY9l69euGLL76Au7u7IU5DFXTqeioAJkdERERlqdRFIP/44w9kZWVV5ilIRw9z83HudsHEeSZHREREpeMK2U+Ic7fVyM0XcLKWw8PR0tjhEBERVVtMjp4QJ+NTAQAB9R0gk8mMGwwREVE1xuToCXHqxr+TsT3tjRsIERFRNcfk6AlR2HPE+UZERERlY3L0BLidmoXEtIcwNZGheT2lscMhIiKq1io1OXr33Xfh6MjHVBhbzI1UAEBjN1s+bJaIiOgx9E6ONm7ciHbt2kGlUiE+Ph4AsGTJEvz0009SmSlTpsDe3r7CQVLFnLlVcAs/e42IiIgeT6/kaMWKFRg3bhyee+45pKamIj8/HwBgb2+PJUuWGDI+MoCz/yZHzeoyOSIiInocvZKjpUuXYvXq1XjvvfdgamoqbW/dujXOnDljsOCo4oQQUs+RP5MjIiKix9IrOYqNjUVAQECx7QqFAg8ePKhwUGQ4N1OykJqZC3NTGRq52Ro7HCIiompPr+TI29sbMTExxbbv3LkTTZo0qWhMZECFQ2q+rrZQmJk+pjQRERHplRy98847ePPNN7F161YIIXDs2DHMnj0b7777Lt555x2d6/Hy8oJMJiv2evPNNwEAw4YNK7YvKChIq47s7GyMGTMGzs7OsLa2Rnh4OG7evKlVJiUlBREREVAqlVAqlYiIiEBqaqo+Ta9xOKRGRERUPnrd1/3qq68iLy8PEydORGZmJoYMGYK6devik08+waBBg3Su5/jx49JkbgA4e/Ysunfvjv79+0vbQkNDsXbtWum9XC7XqiMyMhI///wztmzZAicnJ4wfPx5hYWE4ceKENB9qyJAhuHnzJqKiogAAo0aNQkREBH7++Wd9ml+jnOFkbCIionLRe9GbkSNHYuTIkbh79y40Gg1cXFzKXUedOnW03s+bNw8NGjRAx44dpW0KhQJubm4lHq9Wq7FmzRps3LgR3bp1AwBs2rQJHh4e2LNnD0JCQnDhwgVERUXhyJEjCAwMBACsXr0awcHBuHTpEho1alTuuGsKIYQ0rMaeIyIiIt3oPSH7ypUrAABnZ2cpMbpy5Qri4uL0CiQnJwebNm3C8OHDtR6Mun//fri4uMDX1xcjR45EUlKStO/EiRPIzc1Fjx49pG0qlQrNmjXDoUOHAACHDx+GUqmUEiMACAoKglKplMqUJDs7G2lpaVqvmuZWahZSMnNhZsLJ2ERERLrSKzkaNmxYiYnF0aNHMWzYML0C+fHHH5Gamqp1fM+ePbF582bs27cPCxcuxPHjx9GlSxdkZ2cDABITEyGXy+HgoP28MFdXVyQmJkplSurVcnFxkcqUZO7cudIcJaVSCQ8PD73aZUxFJ2NbmHMyNhERkS70So5OnTqFdu3aFdseFBRU4l1sulizZg169uwJlUolbRs4cCB69eqFZs2a4fnnn8fOnTtx+fJl/Prrr2XWJYTQ6n0q+nNpZR41ZcoUqNVq6XXjxg09WmVc524X9HY1q2tn5EiIiIhqDr3mHMlkMqSnpxfbrlartSZY6yo+Ph579uzBDz/8UGY5d3d3eHp6SkN6bm5uyMnJQUpKilbvUVJSEtq2bSuVuXPnTrG6kpOT4erqWuq5FAoFFApFudtSnVxIKPh/1MSdyREREZGu9Oo5evbZZzF37lytRCg/Px9z585F+/bty13f2rVr4eLigl69epVZ7t69e7hx4wbc3d0BAK1atYK5uTl2794tlUlISMDZs2el5Cg4OBhqtRrHjh2Tyhw9ehRqtVoqU1tdTCzoOWrM5IiIiEhnevUcLViwAB06dECjRo3w7LPPAgAOHDiAtLQ07Nu3r1x1aTQarF27FkOHDoWZ2X/hZGRkYMaMGejXrx/c3d0RFxeHd999F87OzujTpw8AQKlUYsSIERg/fjycnJzg6OiICRMmwN/fX7p7zc/PD6GhoRg5ciRWrVoFoOBW/rCwsFp9p1raw1zcTMkCADTmZGwiIiKd6dVz1KRJE/z9998YMGAAkpKSkJ6ejldeeQUXL15Es2bNylXXnj17cP36dQwfPlxru6mpKc6cOYPevXvD19cXQ4cOha+vLw4fPgxb2/++7BcvXowXXngBAwYMQLt27WBlZYWff/5Z65lvmzdvhr+/P3r06IEePXqgefPm2Lhxoz5NrzEuJxYMqbkrLWBvJX9MaSIiIiokE0IIYwdRE6SlpUGpVEKtVsPOrvoPU208Eo9pP55F50Z1sPbVZ4wdDhERkVHo8/2t9yKQAJCZmYnr168jJydHa3vz5s0rUi0ZwMUEzjciIiLSh17JUXJyMl599VXs3LmzxP363LFGhnXx32E1zjciIiIqH73mHEVGRiIlJQVHjhyBpaUloqKisH79evj4+GD79u2GjpHKSaMRuPRvcuTHniMiIqJy0avnaN++ffjpp5/Qpk0bmJiYwNPTE927d4ednR3mzp372FvyqXLdSs1CRnYe5KYm8Ha2NnY4RERENYpePUcPHjyQHsnh6OiI5ORkAIC/vz9OnjxpuOhILxf+nW/U0MUG5qZ6/S8mIiJ6Yun1zdmoUSNcunQJANCiRQusWrUKt27dwsqVK6UFGsl4pPlG7pxvREREVF56DatFRkYiISEBADB9+nSEhIRg8+bNkMvlWLdunSHjIz0Urozt58b5RkREROWlc3KUlpYmrQ/w0ksvSdsDAgIQFxeHixcvon79+nB2djZ8lFQuFxPYc0RERKQvnYfVHBwckJSUBADo0qULUlNTpX1WVlZo2bIlE6NqICsnH7H3HgAAGrPniIiIqNx0To5sbGxw7949AMD+/fuRm5tbaUGR/i7fSYcQgLONHHVsFcYOh4iIqMbReVitW7du6Ny5M/z8/AAAffr0gVxe8jO7yvvwWTKcS3cKhtR8XTmkRkREpA+dk6NNmzZh/fr1uHbtGqKjo9G0aVNYWVlVZmykh6tJGQCYHBEREelL5+TI0tISr7/+OgDgr7/+wvz582Fvb19ZcZGervzbc9TQxcbIkRAREdVM5V7nKDc3F/Hx8bh9+3ZlxEMVdOXfniMfJkdERER6KXdyZG5ujuzsbMhkssqIhyogMycPt1KzAAA+HFYjIiLSi14rZI8ZMwbz589HXl6eoeOhCvgn+QGEAByt5XC0LnmyPBEREZVNrxWyjx49ir1792LXrl3w9/eHtbX2w01/+OEHgwRH5XMlifONiIiIKkqv5Mje3h79+vUzdCxUQVfucL4RERFRRemVHK1du9bQcZABXOVkbCIiogrTa84RVU+FyVFDF07GJiIi0pdePUfe3t5l3q32zz//6B0Q6Sc7Lx9x/z5TzceVPUdERET60is5ioyM1Hqfm5uLU6dOISoqCu+8844h4qJyir37ABoB2FqYwYXPVCMiItKbXsnRW2+9VeL2zz77DH/99VeFAiL9/JNc0GvUoI4N16AiIiKqAIPOOerZsye+//57Q1ZJOoq9W5AceTtbP6YkERERlcWgydF3330HR0dHQ1ZJOor7NznycmJyREREVBF6DasFBARoDd0IIZCYmIjk5GQsX77cYMGR7gonY3s5Wxk5EiIioppNr+TohRde0HpvYmKCOnXqoFOnTmjcuLEh4qJyir2bCYDDakRERBWlV3I0ffp0Q8dBFZD+MBd3M7IBAF5MjoiIiCpErzlHJ0+exJkzZ6T3P/30E1544QW8++67yMnJMVhwpJv4ewW9Rk7WcthZmBs5GiIioppNr+Ro9OjRuHz5MoCCBR8HDhwIKysrfPvtt5g4caJBA6THK7xTjb1GREREFadXcnT58mW0aNECAPDtt9+iY8eO+Oqrr7Bu3Treym8EsbxTjYiIyGD0So6EENBoNACAPXv24LnnngMAeHh44O7du4aLjnQSJ61xxDvViIiIKkqv5Kh169b48MMPsXHjRkRHR6NXr14AgNjYWLi6uho0QHq82HscViMiIjIUvZKjJUuW4OTJk/jf//6H9957Dw0bNgRQsAhk27ZtDRogPR4XgCQiIjIcvW7lb968udbdaoU++ugjmJqaSu+//vprhIeHw9qaX9qVRZ2Vi5TMXADsOSIiIjIEgz4+xMLCAubm/91KPnr0aNy5c6fU8l5eXpDJZMVeb775JoCCuU0zZsyASqWCpaUlOnXqhHPnzmnVkZ2djTFjxsDZ2RnW1tYIDw/HzZs3tcqkpKQgIiICSqUSSqUSERERSE1NNVzDjehmyn+38dso9Mp1iYiIqAiDJkePEkKUuf/48eNISEiQXrt37wYA9O/fHwCwYMECLFq0CMuWLcPx48fh5uaG7t27Iz09XaojMjIS27Ztw5YtW3Dw4EFkZGQgLCwM+fn5UpkhQ4YgJiYGUVFRiIqKQkxMDCIiIiqhxVXvxv0sAEA9R07GJiIiMgSjdjXUqVNH6/28efPQoEEDdOzYEUIILFmyBO+99x769u0LAFi/fj1cXV3x1VdfYfTo0VCr1VizZg02btyIbt26AQA2bdoEDw8P7NmzByEhIbhw4QKioqJw5MgRBAYGAgBWr16N4OBgXLp0CY0aNaraRhtYYc9RPQdLI0dCRERUO1Rqz1F55OTkYNOmTRg+fDhkMhliY2ORmJiIHj16SGUUCgU6duyIQ4cOAQBOnDiB3NxcrTIqlQrNmjWTyhw+fBhKpVJKjAAgKCgISqVSKlOS7OxspKWlab2qo5sp//YcMTkiIiIyiGqTHP34449ITU3FsGHDAACJiYkAUGxpAFdXV2lfYmIi5HI5HBwcyizj4uJS7HwuLi5SmZLMnTtXmqOkVCrh4eGhd9sqU2HPkYcDh9WIiIgModokR2vWrEHPnj2hUqm0tstkMq33Qohi2x71aJmSyj+unilTpkCtVkuvGzdu6NKMKseeIyIiIsOq1OTI09NT6+610sTHx2PPnj147bXXpG1ubm4AUKx3JykpSepNcnNzQ05ODlJSUsosU9Idc8nJyWUuWKlQKGBnZ6f1qm6EELhx/9+eI07IJiIiMohKTY7Onj2r03DU2rVr4eLiIq20DQDe3t5wc3OT7mADCuYlRUdHSwtNtmrVCubm5lplEhIScPbsWalMcHAw1Go1jh07JpU5evQo1Gp1jV+wMjUzFw9yCu7Kq2vPniMiIiJD0PluNQcHh8cOZxW6f/++zgFoNBqsXbsWQ4cOhZnZf+HIZDJERkZizpw58PHxgY+PD+bMmQMrKysMGTIEAKBUKjFixAiMHz8eTk5OcHR0xIQJE+Dv7y/dvebn54fQ0FCMHDkSq1atAgCMGjUKYWFhteBOtYIhNRdbBSzMTR9TmoiIiHShc3K0ZMkS6ed79+7hww8/REhICIKDgwEU3BX222+/Ydq0aeUKYM+ePbh+/TqGDx9ebN/EiRORlZWFN954AykpKQgMDMSuXbtga2srlVm8eDHMzMwwYMAAZGVloWvXrli3bp3WSt2bN2/G2LFjpbvawsPDsWzZsnLFWR3d4G38REREBicTj1upsQT9+vVD586d8b///U9r+7Jly7Bnzx78+OOPhoqv2khLS4NSqYRara42848+/+Ma5uy4iN4tVPhkUICxwyEiIqp29Pn+1mvO0W+//YbQ0NBi20NCQrBnzx59qiQ98E41IiIiw9MrOXJycsK2bduKbf/xxx/h5ORU4aBIN4V3qtXjGkdEREQGo9fjQ2bOnIkRI0Zg//790pyjI0eOICoqCl988YVBA6TS3U59CIB3qhERERmSXsnRsGHD4Ofnh08//RQ//PADhBBo0qQJ/vzzT63HdFDlSlAXDKu5Ky2MHAkREVHtofeDZwMDA7F582ZDxkLlkJmTh7SHeQAANyZHREREBqP3IpDXrl3D1KlTMWTIECQlJQEAoqKicO7cOYMFR6VLVBcMqdkozGBr8fhVyImIiEg3eiVH0dHR8Pf3x9GjR/H9998jIyMDAPD3339j+vTpBg2QSlaYHLnaKYwcCRERUe2iV3I0efJkfPjhh9i9ezfkcrm0vXPnzjh8+LDBgqPSJaYVJEfuSk7GJiIiMiS9kqMzZ86gT58+xbbXqVMH9+7dq3BQ9HgJUs8R5xsREREZkl7Jkb29PRISEoptP3XqFOrWrVvhoOjxCofVeKcaERGRYemVHA0ZMgSTJk1CYmIiZDIZNBoN/vzzT0yYMAGvvPKKoWOkEhQOq7kyOSIiIjIovZKj2bNno379+qhbty4yMjLQpEkTdOjQAW3btsXUqVMNHSOVQOo54rAaERGRQem1zpG5uTk2b96MDz74ACdPnoRGo0FAQAB8fHwMHR+VorDniGscERERGZZePUezZs1CZmYmnnrqKbz44osYMGAAfHx8kJWVhVmzZhk6RnpETp4GdzOyATA5IiIiMjS9kqOZM2dKaxsVlZmZiZkzZ1Y4KCpbUvpDCAHITU3gaCV//AFERESkM72SIyEEZDJZse2nT5+Go6NjhYOist35d0jNxU4BE5Pi/x+IiIhIf+Wac+Tg4ACZTAaZTAZfX1+tBCk/Px8ZGRl4/fXXDR4kabuTVjCkxjWOiIiIDK9cydGSJUsghMDw4cMxc+ZMKJVKaZ9cLoeXlxeCg4MNHiRpK5xv5GzDITUiIiJDK1dyNHToUACAt7c32rVrBzMzvW52owq6m16QHNWx5XPViIiIDE2vOUddunTB/fv3i22/d+8eTE1NKxwUlS1Z6jlickRERGRoek/ILkl2drbWg2ipciSn5wBgckRERFQZyjUu9umnnwIAZDIZvvjiC9jY2Ej78vPz8ccff6Bx48aGjZCKKZxzxGE1IiIiwytXcrR48WIABT1HK1eu1BpCK5yQvXLlSsNGSMUkp3NYjYiIqLKUKzmKjY0FAHTu3Bk//PADHBwcKiUoKp0Q4r+eIyZHREREBqfXnKPff/8dDg4OyMnJwaVLl5CXl2fouKgUGdl5yM7TAACcbTm/i4iIyND0So6ysrIwYsQIWFlZoWnTprh+/ToAYOzYsZg3b55BAyRthUNq1nJTWMm5lAIREZGh6ZUcTZ48GadPn8b+/fthYfHfKs3dunXD1q1bDRYcFXc349871TgZm4iIqFLo1fXw448/YuvWrQgKCtJ6hEiTJk1w7do1gwVHxXG+ERERUeXSq+coOTkZLi4uxbY/ePCgxAfSkuHwTjUiIqLKpVdy1KZNG/z666/S+8KEaPXq1Xy2WiWTnqvGydhERESVQq9htblz5yI0NBTnz59HXl4ePvnkE5w7dw6HDx9GdHS0oWOkIqQ5R+w5IiIiqhR69Ry1bdsWhw4dQmZmJho0aIBdu3bB1dUVhw8fRqtWrQwdIxWRmlmQHDlas+eIiIioMujVc/TSSy+hU6dOeO+99+Dr62vomKgMKf8mR0pLcyNHQkREVDvp1XNkY2ODhQsXws/PDyqVCoMHD8bKlStx8eJFQ8dHj0jNzAUAOFix54iIiKgy6JUcrVq1ChcvXsStW7ewaNEiKJVKfPLJJ2jatCnc3d3LVdetW7fw8ssvw8nJCVZWVmjRogVOnDgh7R82bBhkMpnWKygoSKuO7OxsjBkzBs7OzrC2tkZ4eDhu3rypVSYlJQURERFQKpVQKpWIiIhAamqqPs03KnVWQXJkb8WeIyIiosqgV3JUyNbWFg4ODnBwcIC9vT3MzMzg5uam8/EpKSlo164dzM3NsXPnTpw/fx4LFy6Evb29VrnQ0FAkJCRIrx07dmjtj4yMxLZt27BlyxYcPHgQGRkZCAsLQ35+vlRmyJAhiImJQVRUFKKiohATE4OIiIiKNN8oCofV7C3Zc0RERFQZ9JpzNGnSJERHR+P06dNo1qwZOnTogClTpqBDhw7FEpuyzJ8/Hx4eHli7dq20zcvLq1g5hUJRatKlVquxZs0abNy4Ed26dQMAbNq0CR4eHtizZw9CQkJw4cIFREVF4ciRIwgMDATw37IDly5dQqNGjXRvvBE9zM3Hw9yC56rZW7PniIiIqDLo1XP00UcfITY2FtOnT8eGDRuwcOFChIeHlysxAoDt27ejdevW6N+/P1xcXBAQEIDVq1cXK7d//364uLjA19cXI0eORFJSkrTvxIkTyM3NRY8ePaRtKpUKzZo1w6FDhwAAhw8fhlKplBIjAAgKCoJSqZTKPCo7OxtpaWlaL2MrHFIzNZHBVsHnqhEREVUGvZKjU6dO4b333sOxY8fQoUMHuLm5YeDAgVixYgUuXLigcz3//PMPVqxYAR8fH/z22294/fXXMXbsWGzYsEEq07NnT2zevBn79u3DwoULcfz4cXTp0gXZ2QWLISYmJkIul8PBwUGrbldXVyQmJkplSlrR28XFRSrzqLlz50rzk5RKJTw8PHRuV2UpeqcaVyInIiKqHHp1Pzz99NN4+umnMXbsWADA6dOnsWTJEowdOxYajUZrrk9ZNBoNWrdujTlz5gAAAgICcO7cOaxYsQKvvPIKAGDgwIFS+WbNmqF169bw9PTEr7/+ir59+5ZatxBCK4EoKZl4tExRU6ZMwbhx46T3aWlpRk+QCu9U42RsIiKiyqP32MypU6ewf/9+7N+/HwcOHEBaWhpatGiBzp0761yHu7s7mjRporXNz88P33//fZnHeHp64sqVKwAANzc35OTkICUlRav3KCkpCW3btpXK3Llzp1hdycnJcHV1LfE8CoUCCkX1WoVaSo64xhEREVGl0WtYzcHBAc888ww2b94MHx8fbNiwAffv38dff/2Fjz76SOd62rVrh0uXLmltu3z5Mjw9PUs95t69e7hx44a0ZECrVq1gbm6O3bt3S2USEhJw9uxZKTkKDg6GWq3GsWPHpDJHjx6FWq2WytQEhatj23ONIyIiokqjV8/Rxo0b0aFDB9jZ2VXo5G+//Tbatm2LOXPmYMCAATh27Bg+//xzfP755wCAjIwMzJgxA/369YO7uzvi4uLw7rvvwtnZGX369AEAKJVKjBgxAuPHj4eTkxMcHR0xYcIE+Pv7S3ev+fn5ITQ0FCNHjsSqVasAAKNGjUJYWFiNuVMNAFK5xhEREVGl0ys5CgsLM8jJ27Rpg23btmHKlCmYNWsWvL29sWTJErz00ksAAFNTU5w5cwYbNmxAamoq3N3d0blzZ2zduhW2trZSPYsXL4aZmRkGDBiArKwsdO3aFevWrYOpqalUZvPmzRg7dqx0V1t4eDiWLVtmkHZUlf+G1dhzREREVFlkQghh7CBqgrS0NCiVSqjV6gr3mOlr8vd/Y8vxGxjX3Rdju/oYJQYiIqKaRJ/v7wqtkE1V67/nqnFYjYiIqLIwOapBUrP+XeeIE7KJiIgqDZOjGoQ9R0RERJWPyVENwgnZRERElY/JUQ1SOKzGW/mJiIgqD5OjGuJhbj4e5moAMDkiIiKqTEyOaojCITVTExlsFHo/9YWIiIgeg8lRDSENqVmal/qwXCIiIqo4Jkc1RMoDPjqEiIioKjA5qiHUWXzoLBERUVVgclRD/HcbP3uOiIiIKhOToxoipTA5Ys8RERFRpWJyVENwjSMiIqKqweSohlBzWI2IiKhKMDmqIVIy/+05suawGhERUWViclRDcEI2ERFR1WByVEOos7jOERERUVVgclRDFA6rOfBuNSIiokrF5KiGKBxWU3JYjYiIqFIxOaoBHubmIztPA4DDakRERJWNyVENUDikZmYig43CzMjREBER1W5MjmoA6U41K3PIZDIjR0NERFS7MTmqAaQ1jjgZm4iIqNIxOaoBuMYRERFR1WFyVAOk8qGzREREVYbJUQ3w3xpH7DkiIiKqbEyOaoBUac4RkyMiIqLKxuSoBuCwGhERUdVhclQDpGTyuWpERERVhclRDZDK56oRERFVGSZHNUBqFnuOiIiIqgqToxpAmpBtyZ4jIiKiysbkqJoTQkgTsh2s2XNERERU2ZgcVXMZ2XnI0wgAnHNERERUFZgcVXOFvUYKMxNYmJsaORoiIqLaz+jJ0a1bt/Dyyy/DyckJVlZWaNGiBU6cOCHtF0JgxowZUKlUsLS0RKdOnXDu3DmtOrKzszFmzBg4OzvD2toa4eHhuHnzplaZlJQUREREQKlUQqlUIiIiAqmpqVXRxApJ4Z1qREREVcqoyVFKSgratWsHc3Nz7Ny5E+fPn8fChQthb28vlVmwYAEWLVqEZcuW4fjx43Bzc0P37t2Rnp4ulYmMjMS2bduwZcsWHDx4EBkZGQgLC0N+fr5UZsiQIYiJiUFUVBSioqIQExODiIiIqmyuXlK5xhEREVHVEkY0adIk0b59+1L3azQa4ebmJubNmydte/jwoVAqlWLlypVCCCFSU1OFubm52LJli1Tm1q1bwsTERERFRQkhhDh//rwAII4cOSKVOXz4sAAgLl68qFOsarVaABBqtbpcbayoH0/dFJ6TfhEDVx2q0vMSERHVBvp8fxu152j79u1o3bo1+vfvDxcXFwQEBGD16tXS/tjYWCQmJqJHjx7SNoVCgY4dO+LQoUMAgBMnTiA3N1erjEqlQrNmzaQyhw8fhlKpRGBgoFQmKCgISqVSKvOo7OxspKWlab2MQbpTjcNqREREVcKoydE///yDFStWwMfHB7/99htef/11jB07Fhs2bAAAJCYmAgBcXV21jnN1dZX2JSYmQi6Xw8HBocwyLi4uxc7v4uIilXnU3LlzpflJSqUSHh4eFWusnvhcNSIioqpl1ORIo9GgZcuWmDNnDgICAjB69GiMHDkSK1as0Conk8m03gshim171KNlSipfVj1TpkyBWq2WXjdu3NC1WQZVOCGbc46IiIiqhlGTI3d3dzRp0kRrm5+fH65fvw4AcHNzA4BivTtJSUlSb5KbmxtycnKQkpJSZpk7d+4UO39ycnKxXqlCCoUCdnZ2Wi9j+O+5akyOiIiIqoJRk6N27drh0qVLWtsuX74MT09PAIC3tzfc3Nywe/duaX9OTg6io6PRtm1bAECrVq1gbm6uVSYhIQFnz56VygQHB0OtVuPYsWNSmaNHj0KtVktlqqv7HFYjIiKqUmbGPPnbb7+Ntm3bYs6cORgwYACOHTuGzz//HJ9//jmAgqGwyMhIzJkzBz4+PvDx8cGcOXNgZWWFIUOGAACUSiVGjBiB8ePHw8nJCY6OjpgwYQL8/f3RrVs3AAW9UaGhoRg5ciRWrVoFABg1ahTCwsLQqFEj4zReR/cysgEAdWwURo6EiIjoyWDU5KhNmzbYtm0bpkyZglmzZsHb2xtLlizBSy+9JJWZOHEisrKy8MYbbyAlJQWBgYHYtWsXbG1tpTKLFy+GmZkZBgwYgKysLHTt2hXr1q2Dqel/K0pv3rwZY8eOle5qCw8Px7Jly6qusXq6l1EwrOZkw54jIiKiqiATQghjB1ETpKWlQalUQq1WV9n8IyEEfKfuRG6+wJ+Tu6CuvWWVnJeIiKi20Of72+iPD6HSpT3MQ25+Qe7qZM2eIyIioqrA5Kgau/+gYEjNRmHGh84SERFVESZH1VjhZGzONyIiIqo6TI6qsbuFk7E5pEZERFRlmBxVY/ceFPYc8TZ+IiKiqsLkqBorvI3fmcNqREREVYbJUTUmzTmyZs8RERFRVWFyVI3dfcAFIImIiKoak6NqrLDnyJETsomIiKoMk6Nq7L85RxxWIyIiqipMjqqxu1zniIiIqMoxOaqmsvPykZKZCwBwsbUwcjRERERPDiZH1VRyekGvkdzUBA5W5kaOhoiI6MnB5KiaupP2EADgYqeATCYzcjRERERPDiZH1dSdtIKeIzc7DqkRERFVJSZH1VRhz5ErkyMiIqIqxeSomkosMqxGREREVYfJUTWVxGE1IiIio2ByVE1xWI2IiMg4mBxVUxxWIyIiMg4mR9UUh9WIiIiMg8lRNZSRnYeM7DwAgAuTIyIioirF5KgaSkjNAgDYWpjBRmFm5GiIiIieLEyOqqGbKQXJUT0HKyNHQkRE9ORhclQN3UzJBADUc7A0ciRERERPHiZH1dB/PUdMjoiIiKoak6NqiMNqRERExsPkqBrisBoREZHxMDmqhjisRkREZDxMjqqZzJw83HuQA4DDakRERMbA5Kiaib9XMKRmZ2EGpaW5kaMhIiJ68jA5qmauJmUAABq62Bg5EiIioicTk6Nq5loykyMiIiJjYnJUzRT2HDWow+SIiIjIGIyaHM2YMQMymUzr5ebmJu0fNmxYsf1BQUFadWRnZ2PMmDFwdnaGtbU1wsPDcfPmTa0yKSkpiIiIgFKphFKpREREBFJTU6uiieXGYTUiIiLjMnrPUdOmTZGQkCC9zpw5o7U/NDRUa/+OHTu09kdGRmLbtm3YsmULDh48iIyMDISFhSE/P18qM2TIEMTExCAqKgpRUVGIiYlBRERElbSvPPLyNYi9+wAAe46IiIiMxeiPfDczM9PqLXqUQqEodb9arcaaNWuwceNGdOvWDQCwadMmeHh4YM+ePQgJCcGFCxcQFRWFI0eOIDAwEACwevVqBAcH49KlS2jUqJHhG6Wny3cykJ2nga3CDPUdeRs/ERGRMRi95+jKlStQqVTw9vbGoEGD8M8//2jt379/P1xcXODr64uRI0ciKSlJ2nfixAnk5uaiR48e0jaVSoVmzZrh0KFDAIDDhw9DqVRKiREABAUFQalUSmWqi9M3UwEA/vWUMDGRGTcYIiKiJ5RRe44CAwOxYcMG+Pr64s6dO/jwww/Rtm1bnDt3Dk5OTujZsyf69+8PT09PxMbGYtq0aejSpQtOnDgBhUKBxMREyOVyODg4aNXr6uqKxMREAEBiYiJcXFyKndvFxUUqU5Ls7GxkZ2dL79PS0gzU6tKdvpEKAHjaw77Sz0VEREQlM2py1LNnT+lnf39/BAcHo0GDBli/fj3GjRuHgQMHSvubNWuG1q1bw9PTE7/++iv69u1bar1CCMhk//W8FP25tDKPmjt3LmbOnFneJlXI4X/uAQBa1Xd4TEkiIiKqLEYfVivK2toa/v7+uHLlSon73d3d4enpKe13c3NDTk4OUlJStMolJSXB1dVVKnPnzp1idSUnJ0tlSjJlyhSo1WrpdePGDX2bpZP4ew8Qfy8TZiYyBDVwqtRzERERUemqVXKUnZ2NCxcuwN3dvcT99+7dw40bN6T9rVq1grm5OXbv3i2VSUhIwNmzZ9G2bVsAQHBwMNRqNY4dOyaVOXr0KNRqtVSmJAqFAnZ2dlqvyvTHlbsAgJaeDrBRGH2ePBER0RPLqN/CEyZMwPPPP4/69esjKSkJH374IdLS0jB06FBkZGRgxowZ6NevH9zd3REXF4d3330Xzs7O6NOnDwBAqVRixIgRGD9+PJycnODo6IgJEybA399funvNz88PoaGhGDlyJFatWgUAGDVqFMLCwqrVnWoHLicDADr61jFyJERERE82oyZHN2/exODBg3H37l3UqVMHQUFBOHLkCDw9PZGVlYUzZ85gw4YNSE1Nhbu7Ozp37oytW7fC1tZWqmPx4sUwMzPDgAEDkJWVha5du2LdunUwNTWVymzevBljx46V7moLDw/HsmXLqry9pcnN1+DwtYL5Rs/6OBs5GiIioiebTAghjB1ETZCWlgalUgm1Wm3QIbbMnDz8di4Rb289DQcrc/w1tTtMeRs/ERGRQejz/c3JLUY2Y/s5fPNXweNO2vvUYWJERERkZEyOjMzBSg6FmQnclRYY9exTxg6HiIjoicdhNR1V1rBavkawt4iIiKiS6PP9Xa1u5X8SMTEiIiKqXpgcERERERXB5IiIiIioCCZHREREREUwOSIiIiIqgskRERERURFMjoiIiIiKYHJEREREVASTIyIiIqIimBwRERERFcHkiIiIiKgIJkdERERERTA5IiIiIiqCyRERERFREWbGDqCmEEIAANLS0owcCREREemq8Hu78HtcF0yOdJSeng4A8PDwMHIkREREVF7p6elQKpU6lZWJ8qRSTzCNRoPbt2/D1tYWMpnMYPWmpaXBw8MDN27cgJ2dncHqrU5qextre/uA2t9Gtq/mq+1tZPv0J4RAeno6VCoVTEx0m03EniMdmZiYoF69epVWv52dXa38wBdV29tY29sH1P42sn01X21vI9unH117jApxQjYRERFREUyOiIiIiIpgcmRkCoUC06dPh0KhMHYolaa2t7G2tw+o/W1k+2q+2t5Gtq9qcUI2ERERURHsOSIiIiIqgskRERERURFMjoiIiIiKYHJEREREVASTIx0MGzYMMpkMr7/+erF9b7zxBmQyGYYNG1apMbz11lto1aoVFAoFWrRoUWz/pUuX0LlzZ7i6usLCwgJPPfUUpk6ditzc3Aqfe/ny5fD29oaFhQVatWqFAwcOaO2/cOECwsPDoVQqYWtri6CgIFy/fr3MOs+cOYOOHTvC0tISdevWxaxZs4o99yY6OhqtWrWS2rNy5coKt+VRf/zxB55//nmoVCrIZDL8+OOP0r7c3FxMmjQJ/v7+sLa2hkqlwiuvvILbt28/tt6a0D4AyMjIwP/+9z/Uq1cPlpaW8PPzw4oVKx5brzHaVxOuw6KuXr0KW1tb2NvbV/i8vAZr7jUI1J7rsCZcg3FxcZDJZMVeUVFR5TuRoMcaOnSo8PDwEEqlUmRmZkrbs7KyhL29vahfv74YOnRopcYwZswYsWzZMhERESGefvrpYvuvXbsmvvzySxETEyPi4uLETz/9JFxcXMSUKVMqdN4tW7YIc3NzsXr1anH+/Hnx1ltvCWtraxEfHy+EEOLq1avC0dFRvPPOO+LkyZPi2rVr4pdffhF37twptU61Wi1cXV3FoEGDxJkzZ8T3338vbG1txccffyyV+eeff4SVlZV46623xPnz58Xq1auFubm5+O677yrUnkft2LFDvPfee+L7778XAMS2bdukfampqaJbt25i69at4uLFi+Lw4cMiMDBQtGrVqsw6a0r7hBDitddeEw0aNBC///67iI2NFatWrRKmpqbixx9/rHbtqwnXYaGcnBzRunVr0bNnT6FUKit0Tl6DNfsafFwbhag512FNuAZjY2MFALFnzx6RkJAgvbKzs8t1HiZHOhg6dKjo3bu38Pf3F5s2bZK2b968Wfj7+4vevXtLH4idO3eKdu3aCaVSKRwdHUWvXr3E1atXpWM6d+4s3nzzTa367969K+Ryudi7d+9jY5k+fXqZf5SLevvtt0X79u11KluaZ555Rrz++uta2xo3biwmT54shBBi4MCB4uWXXy5XncuXLxdKpVI8fPhQ2jZ37lyhUqmERqMRQggxceJE0bhxY63jRo8eLYKCgvRphk5K+qP1qGPHjgkA0hdTSWpS+5o2bSpmzZqlta1ly5Zi6tSppdZjrPbVpOtw4sSJ4uWXXxZr166tcHLEa1BbTb4GhajZ12FNuAYLk6NTp07p1cZCHFYrh1dffRVr166V3n/55ZcYPny4VpkHDx5g3LhxOH78OPbu3QsTExP06dMHGo0GAPDaa6/hq6++QnZ2tnTM5s2boVKp0LlzZ4PFevXqVURFRaFjx45615GTk4MTJ06gR48eWtt79OiBQ4cOQaPR4Ndff4Wvry9CQkLg4uKCwMDAYl3Gw4YNQ6dOnaT3hw8fRseOHbUW+woJCcHt27cRFxcnlXn0vCEhIfjrr78MMlSoL7VaDZlMpjVUUpPb1759e2zfvh23bt2CEAK///47Ll++jJCQEKlMdWtfdb8O9+3bh2+//RafffZZheoBeA2WpLZdg0DNuw6r+zUIAOHh4XBxcUG7du3w3Xfflft4JkflEBERgYMHDyIuLg7x8fH4888/8fLLL2uV6devH/r27QsfHx+0aNECa9aswZkzZ3D+/Hlpv0wmw08//SQds3btWmkst6Latm0LCwsL+Pj44Nlnn8WsWbP0ruvu3bvIz8+Hq6ur1nZXV1ckJiYiKSkJGRkZmDdvHkJDQ7Fr1y706dMHffv2RXR0tFTe3d0d9evXl94nJiaWWGfhvrLK5OXl4e7du3q3qSIePnyIyZMnY8iQIVoPRqzJ7fv000/RpEkT1KtXD3K5HKGhoVi+fDnat28vlalu7avO1+G9e/cwbNgwrFu3ziAPz+Q1qK02XoNAzbsOq/M1aGNjg0WLFuG7777Djh070LVrVwwcOBCbNm0qVz1mekfwBHJ2dkavXr2wfv16CCHQq1cvODs7a5W5du0apk2bhiNHjuDu3btSlnz9+nU0a9YMCoUCL7/8Mr788ksMGDAAMTExOH36tPQvvZ49e0qTLT09PXHu3Llyxbh161akp6fj9OnTeOedd/Dxxx9j4sSJFWr3ox9UIQRkMpnUtt69e+Ptt98GALRo0QKHDh3CypUrpV6ruXPn6lTno9t1KVNVcnNzMWjQIGg0GixfvlxrX01u36effoojR45g+/bt8PT0xB9//IE33ngD7u7u6NatG4Dq177qfB2OHDkSQ4YMQYcOHSrUxkfxGqy91yBQ867D6nwNOjs7S9cCALRu3RopKSlYsGBBsQSuLEyOymn48OH43//+BwAldps///zz8PDwwOrVq6FSqaDRaNCsWTPk5ORIZV577TW0aNECN2/exJdffomuXbvC09MTAPDFF18gKysLAGBubl7u+Dw8PAAATZo0QX5+PkaNGoXx48fD1NS03HU5OzvD1NRU+ldIoaSkJLi6usLZ2RlmZmZo0qSJ1n4/Pz8cPHiw1Hrd3NxKrBP4718+pZUxMzODk5NTudtSEbm5uRgwYABiY2Oxb9++x/YI1JT2ZWVl4d1338W2bdvQq1cvAEDz5s0RExODjz/+WPqj/Kjq0L7qeh3u27cP27dvx8cffwyg4ItIo9HAzMwMn3/+ebGhh8fhNVigtl6DQM29DqvrNViSoKAgfPHFF+U6hsNq5RQaGoqcnBzk5ORojQcDBV3qFy5cwNSpU9G1a1f4+fkhJSWlWB3+/v5o3bo1Vq9eja+++krrD2bdunXRsGFDNGzYUPqQ6EsIgdzc3GK3dupKLpejVatW2L17t9b23bt3o23btpDL5WjTpg0uXbqktf/y5ctlxh4cHIw//vhD6yLZtWsXVCoVvLy8pDKPnnfXrl1o3bp1hS+U8ij8o3zlyhXs2bNHpz8oNaV9ubm5yM3NhYmJ9p8BU1NT6V95JakO7auu1+Hhw4cRExMjvWbNmgVbW1vExMSgT58+5W4nr8HafQ0CNfc6rK7XYElOnToFd3f38h1UoencT4jCGfqF1Gq1UKvV0vvCGfr5+fnCyclJvPzyy+LKlSti7969ok2bNiXenfD5558LuVwu7O3tRVZW1mNjuHLlijh16pQYPXq08PX1FadOnRKnTp2Sbk/ctGmT2Lp1qzh//ry4du2a+Oabb0TdunXFSy+9VKG2F95GvGbNGnH+/HkRGRkprK2tRVxcnBBCiB9++EGYm5uLzz//XFy5ckUsXbpUmJqaigMHDkh1TJ48WUREREjvU1NThaurqxg8eLA4c+aM+OGHH4SdnV2Jt6C+/fbb4vz582LNmjWVcpttenq69LsEIBYtWiROnTol4uPjRW5urggPDxf16tUTMTExpd4WWlPbJ4QQHTt2FE2bNhW///67+Oeff8TatWuFhYWFWL58ebVrX024Dh9liLvVeA3W7GvwcW0UouZchzXhGly3bp3YvHmzOH/+vLh48aL46KOPhLm5uVi0aFG52srkSAePfiAeVfT2xd27dws/Pz+hUChE8+bNxf79+0v8QKSnpwsrKyvxxhtv6BRDx44dBYBir9jYWCFEwR/Qli1bChsbG2FtbS2aNGki5syZo9OH7XE+++wz4enpKeRyuWjZsqWIjo7W2r9mzRrRsGFDYWFhIZ5++ulia3MMHTpUdOzYUWvb33//LZ599lmhUCiEm5ubmDFjhnT7aaH9+/eLgIAAIZfLhZeXl1ixYkWF2/Ko33//vcTf69ChQ6VbQkt6/f777zW+fUIIkZCQIIYNGyZUKpWwsLAQjRo1EgsXLtSKtbq0ryZch48yRHIkBK/BmnwNPq6NQtSc67AmXIPr1q0Tfn5+wsrKStja2opWrVqJjRs3lrutMiH0HHOhCrlx4wa8vLxw/PhxtGzZ0tjhED2ReB0SGVd1vQaZHFWx3NxcJCQkYPLkydItkERUtXgdEhlXdb8GOSG7iv3555/w9PTEiRMnKu05PkRUNl6HRMZV3a9B9hwRERERFcGeIyIiIqIimBwRERERFcHkiIiIiKgIJkdERERERTA5IqJabf/+/ZDJZEhNTTV2KERa5s6dizZt2sDW1hYuLi544YUXij0KRgiBGTNmQKVSwdLSEp06ddJ6COv9+/cxZswYNGrUCFZWVqhfvz7Gjh0LtVotlYmLi8OIESPg7e0NS0tLNGjQANOnT9d69EhJCq8dBwcHPHz4UGvfsWPHIJPJquQhvT/88ANCQkLg7OwMmUyGmJiYYmU6deokxVP4GjRokN7nZHJERLVKp06dEBkZKb1v27YtEhISoFQqjRcUUQmio6Px5ptv4siRI9i9ezfy8vLQo0cPPHjwQCqzYMECLFq0CMuWLcPx48fh5uaG7t27Iz09HQBw+/Zt3L59Gx9//DHOnDmDdevWISoqCiNGjJDquHjxIjQaDVatWoVz585h8eLFWLlyJd59912d4rS1tcW2bdu0tn355ZeoX7++AX4Lj/fgwQO0a9cO8+bNK7PcyJEjkZCQIL1WrVql/0nLvaY2EVE11rFjR/HWW28ZOwyicktKShIApMfDaDQa4ebmJubNmyeVefjwoVAqlWLlypWl1vPNN98IuVwucnNzSy2zYMEC4e3tXWY8hY89mTp1qujWrZu0PTMzUyiVSjFt2jRRNI24e/euGDRokKhbt66wtLQUzZo1E1999ZW0f/369cLR0VE8fPhQ6zx9+/bVem5caQofJ3Pq1Kli+wx93bPniIhqjWHDhiE6OhqffPKJ1LW+bt06rWG1devWwd7eHr/88os0FPHiiy/iwYMHWL9+Pby8vODg4IAxY8YgPz9fqjsnJwcTJ05E3bp1YW1tjcDAQOzfv984DaVaqXAozNHREQAQGxuLxMRE9OjRQyqjUCjQsWNHHDp0qMx67OzsYGZmVmaZwvM8TkREBA4cOIDr168DAL7//nt4eXkVe9zHw4cP0apVK/zyyy84e/YsRo0ahYiICBw9ehQA0L9/f+Tn52P79u3SMXfv3sUvv/yCV199VadYyrJ582Y4OzujadOmmDBhgtS7po/Sf3NERDXMJ598gsuXL6NZs2aYNWsWAGjNzyiUmZmJTz/9FFu2bEF6ejr69u2Lvn37wt7eHjt27MA///yDfv36oX379hg4cCAA4NVXX0VcXBy2bNkClUqFbdu2ITQ0FGfOnIGPj0+VtpNqHyEExo0bh/bt26NZs2YAgMTERACAq6urVllXV1fEx8eXWM+9e/fwwQcfYPTo0aWe69q1a1i6dCkWLlyoU2wuLi7o2bMn1q1bh/fffx9ffvklhg8fXqxc3bp1MWHCBOn9mDFjEBUVhW+//RaBgYGwtLTEkCFDsHbtWvTv3x9AQUJTr149dOrUSadYSvPSSy/B29sbbm5uOHv2LKZMmYLTp09j9+7d+lVosD4oIqJq4NHu9cKhgZSUFCGEEGvXrhUAxNWrV6Uyo0ePFlZWViI9PV3aFhISIkaPHi2EEOLq1atCJpOJW7duaZ2ra9euYsqUKZXXGHpivPHGG8LT01PcuHFD2vbnn38KAOL27dtaZV977TUREhJSrA61Wi0CAwNFaGioyMnJKfE8t27dEg0bNhQjRozQ2t6kSRNhbW0trK2tRWhoqBBC+9rZvn278Pb2FteuXRMWFhbi7t27Ytu2bVrDanl5eeLDDz8U/v7+wtHRUVhbWwszMzPRv39/qczJkyeFqampuHnzphBCiKefflrMmjVLCCHEpk2bpBisra3FH3/8oRVjWcNqj/rrr78EAHHixInHli0Je46I6IljZWWFBg0aSO9dXV3h5eUFGxsbrW1JSUkAgJMnT0IIAV9fX616srOz4eTkVDVBU601ZswYbN++HX/88Qfq1asnbXdzcwNQ0IPk7u4ubU9KSirWm5Seno7Q0FDY2Nhg27ZtMDc3L3ae27dvo3PnzggODsbnn3+utW/Hjh3Izc0FAFhaWhY79rnnnsPo0aMxYsQIPP/88yV+7hcuXIjFixdjyZIl8Pf3h7W1NSIjI7XuigsICMDTTz+NDRs2ICQkBGfOnMHPP/8MAAgPD0dgYKBUtm7duqX/0h6jZcuWMDc3x5UrV4oN/+mCyRERPXEe/eKQyWQlbtNoNAAAjUYDU1NTnDhxAqamplrliiZUROUhhMCYMWOwbds27N+/H97e3lr7C4eJdu/ejYCAAAAFc9+io6Mxf/58qVxaWhpCQkKgUCiwfft2WFhYFDvXrVu30LlzZ7Rq1Qpr166FiYn2lGNPT88yYzU1NUVERAQWLFiAnTt3lljmwIED6N27N15++WUABdfNlStX4Ofnp1Xutddew+LFi3Hr1i1069YNHh4eAAruirO1tS0zDl2dO3cOubm5WklleTA5IqJaRS6Xa02kNoSAgADk5+cjKSkJzz77rEHrpifXm2++ia+++go//fQTbG1tpTlGSqUSlpaWkMlkiIyMxJw5c+Dj4wMfHx/MmTMHVlZWGDJkCICCHqMePXogMzMTmzZtQlpaGtLS0gAAderUgampKW7fvo1OnTqhfv36+Pjjj5GcnCzFUNg7pYsPPvgA77zzTqm9pQ0bNsT333+PQ4cOwcHBAYsWLUJiYmKx5Oill17ChAkTsHr1amzYsOGx571//z6uX7+O27dvA4C0FpSbmxvc3Nxw7do1bN68Gc899xycnZ1x/vx5jB8/HgEBAWjXrp3O7SuKyRER1SpeXl44evQo4uLiYGNjI/X+VISvry9eeuklvPLKK1i4cCECAgJw9+5d7Nu3D/7+/njuuecMEDk9aVasWAEAxSYjr127FsOGDQMATJw4EVlZWXjjjTeQkpKCwMBA7Nq1S+phOXHihHQ3WMOGDbXqiY2NhZeXF3bt2oWrV6/i6tWrWsN2QEHvla7kcjmcnZ1L3T9t2jTExsYiJCQEVlZWGDVqFF544QWtBSkBwM7ODv369cOvv/6KF1544bHn3b59u9bdbIWLO06fPh0zZsyAXC7H3r178cknnyAjIwMeHh7o1asXpk+fXqynV1cyUZ7fDBFRNXf58mUMHToUp0+fRlZWFtauXYtXX30VKSkpsLe3x7p16xAZGam1YvaMGTPw448/aq28O2zYMKSmpuLHH38EAOTm5uLDDz/Ehg0bcOvWLTg5OSE4OBgzZ86Ev79/1TaSqIbr3r07/Pz88Omnnxo7lBIxOSIiIqIqcf/+fezatQsvvfQSzp8/j0aNGhk7pBJxWI2IiIiqRMuWLZGSkoL58+dX28QIYM8RERERkRY+PoSIiIioCCZHREREREUwOSIiIiIqgskRERERURFMjoiIiIiKYHJEREREVASTIyIiIqIimBwRERERFcHkiIiIiKgIJkdERERERfw/LEwRgdoUjmMAAAAASUVORK5CYII=",
+      "text/plain": [
+       "<Figure size 640x480 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "transport_model.mesh.wetted_surface_area.isel(nface=216).plot()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ef31e680-4792-4e1d-85b0-ab682dd36a53",
+   "metadata": {},
+   "source": [
+    "### Clearwater-Modules\n",
+    "\n",
+    "#### Initial State Values\n",
+    "The initial state values are `water_temp_c`, `volume`, and `surface_area` come from Clearwater-riverine mesh at the first timestep."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "id": "befc95d9-663d-42f7-9f96-ec96821dcf40",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Provide xr.data array values for initial state values\n",
+    "initial_state_values = {\n",
+    "    'Ap': transport_model.mesh['Ap'].isel(\n",
+    "        time=0,\n",
+    "        nface=slice(0, transport_model.mesh.nreal+1)\n",
+    "    ),\n",
+    "    'DOX': transport_model.mesh['DOX'].isel(\n",
+    "        time=0,\n",
+    "        nface=slice(0, transport_model.mesh.nreal+1)\n",
+    "    ),\n",
+    "    'NH4': transport_model.mesh['NH4'].isel(\n",
+    "        time=0,\n",
+    "        nface=slice(0, transport_model.mesh.nreal+1)\n",
+    "    ),\n",
+    "    'NO3': transport_model.mesh['NO3'].isel(\n",
+    "        time=0,\n",
+    "        nface=slice(0, transport_model.mesh.nreal+1)\n",
+    "    ),\n",
+    "    'TIP': transport_model.mesh['TIP'].isel(\n",
+    "        time=0,\n",
+    "        nface=slice(0, transport_model.mesh.nreal+1)\n",
+    "    ),\n",
+    "    'Ab': transport_model.mesh['Ab'].isel(\n",
+    "        time=0,\n",
+    "        nface=slice(0, transport_model.mesh.nreal+1)\n",
+    "    ),\n",
+    "    'OrgN': transport_model.mesh['OrgN'].isel(\n",
+    "        time=0,\n",
+    "        nface=slice(0, transport_model.mesh.nreal+1)\n",
+    "    ),\n",
+    "    'N2': transport_model.mesh['N2'].isel(\n",
+    "        time=0,\n",
+    "        nface=slice(0, transport_model.mesh.nreal+1)\n",
+    "    ),\n",
+    "    'OrgP': transport_model.mesh['OrgP'].isel(\n",
+    "        time=0,\n",
+    "        nface=slice(0, transport_model.mesh.nreal+1)\n",
+    "    ),\n",
+    "    'POC': transport_model.mesh['POC'].isel(\n",
+    "        time=0,\n",
+    "        nface=slice(0, transport_model.mesh.nreal+1)\n",
+    "    ),\n",
+    "    'DOC': transport_model.mesh['DOC'].isel(\n",
+    "        time=0,\n",
+    "        nface=slice(0, transport_model.mesh.nreal+1)\n",
+    "    ),\n",
+    "    'DIC': transport_model.mesh['DIC'].isel(\n",
+    "        time=0,\n",
+    "        nface=slice(0, transport_model.mesh.nreal+1)\n",
+    "    ),\n",
+    "    'POM': transport_model.mesh['POM'].isel(\n",
+    "        time=0,\n",
+    "        nface=slice(0, transport_model.mesh.nreal+1)\n",
+    "    ),\n",
+    "    'CBOD': transport_model.mesh['CBOD'].isel(\n",
+    "        time=0,\n",
+    "        nface=slice(0, transport_model.mesh.nreal+1)\n",
+    "    ),\n",
+    "    'PX': transport_model.mesh['PX'].isel(\n",
+    "        time=0,\n",
+    "        nface=slice(0, transport_model.mesh.nreal+1)\n",
+    "    ),\n",
+    "    'Alk': transport_model.mesh['Alk'].isel(\n",
+    "        time=0,\n",
+    "        nface=slice(0, transport_model.mesh.nreal+1)\n",
+    "    ),\n",
+    "    'volume': transport_model.mesh['volume'].isel(\n",
+    "        time=0,\n",
+    "        nface=slice(0, transport_model.mesh.nreal+1)\n",
+    "    ),\n",
+    "    'surface_area': transport_model.mesh['wetted_surface_area'].isel(\n",
+    "        time=0,\n",
+    "        nface=slice(0, transport_model.mesh.nreal + 1)\n",
+    "    ),\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "738c906c-2143-404a-982c-cba751248fc1",
+   "metadata": {},
+   "source": [
+    "#### Meteorological Parameters\n",
+    "The meteorological parameters that we'll be adjusting for this model are `q_solar` and `air_temp_c`. In this example, `q_solar` and `air_temp_c` are pulled from meteorological stations in Arizona. \n",
+    "We will need to interpolate these datasets to our model timestep, using the following function:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "id": "3d319864-884e-40db-9a85-93f56c87ba53",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def interpolate_to_model_timestep(meteo_df, model_dates, col_name):\n",
+    "    merged_df = pd.merge_asof(\n",
+    "        pd.DataFrame({'time': model_dates}),\n",
+    "        meteo_df,\n",
+    "        left_on='time',\n",
+    "        right_on='Datetime')\n",
+    "    merged_df[col_name.lower()] = merged_df[col_name].interpolate(method='linear')\n",
+    "    merged_df.drop(\n",
+    "        columns=['Datetime', col_name],\n",
+    "        inplace=True)\n",
+    "    merged_df.rename(\n",
+    "        columns={'time': 'Datetime'},\n",
+    "        inplace=True,\n",
+    "    )\n",
+    "    return merged_df"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "id": "abc09be6-f808-49bc-b6e9-dc2f792928d6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "xarray_time_index = pd.DatetimeIndex(\n",
+    "    transport_model.mesh.time.values\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "48f7491a-25ee-48cb-8609-4c174ff53073",
+   "metadata": {},
+   "source": [
+    "Create timeseries of Q solar and Air Temperature aligned with the timestep of the model:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "id": "0145082a-c55b-43be-abd0-75647b5863bb",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Q Solar\n",
+    "q_solar = pd.read_csv(\n",
+    "    q_solar_path, \n",
+    "    parse_dates=['Datetime'])\n",
+    "q_solar.dropna(axis=0, inplace=True)\n",
+    "\n",
+    "q_solar_interp = interpolate_to_model_timestep(\n",
+    "    q_solar,\n",
+    "    xarray_time_index,\n",
+    "    'q_Solar'\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "id": "2b0ba137-e173-442e-b2a9-0478e7adad33",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Air Temperature\n",
+    "air_temp_c = pd.read_csv(\n",
+    "    air_temp_path, \n",
+    "    parse_dates=['Datetime'])\n",
+    "air_temp_c.dropna(axis=0, inplace=True)\n",
+    "\n",
+    "air_temp_c_interp = interpolate_to_model_timestep(\n",
+    "    air_temp_c,\n",
+    "    xarray_time_index,\n",
+    "    'TairC'\n",
+    ")\n",
+    "\n",
+    "air_temp_c_interp['air_temp_c'] = (air_temp_c_interp.tairc - 32)* (5/9)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "id": "0964e5b0-b9b4-4299-bfe5-2514eaf4b795",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# process for clearwater-modules input\n",
+    "q_solar_array = q_solar_interp.q_solar.to_numpy()\n",
+    "air_temp_array = air_temp_c_interp.air_temp_c.to_numpy()\n",
+    "\n",
+    "# for each individual timestep\n",
+    "all_meteo_params = {\n",
+    "    'q_solar': q_solar_array,\n",
+    "    'air_temp_c': air_temp_array,\n",
+    "}\n",
+    "\n",
+    "# for initial conditions\n",
+    "initial_meteo_params = {\n",
+    "    'air_temp_c': air_temp_array[0],\n",
+    "    'q_solar': q_solar_array[0],\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "id": "468dbf2a-5bc5-4186-b543-56e13ab4e34f",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(5761,)"
+      ]
+     },
+     "execution_count": 24,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "np.shape(air_temp_array)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "id": "e832b78f-9599-4c10-bdfc-d0dc0b0b69ca",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "5761\n",
+      "<class 'int'>\n"
+     ]
+    }
+   ],
+   "source": [
+    "time_Steps = len(transport_model.mesh.time)\n",
+    "print(time_Steps)\n",
+    "print(type(time_Steps))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "782cbe25-8c4f-4a3b-a134-3507bf20f247",
+   "metadata": {},
+   "source": [
+    "#### Instantiate Clearwater Modules\n",
+    "We instantiate Clearwater Modules with the following:\n",
+    "* `initial_state_values` (required): our initial conditions of water temperature, cell volumes, and cell surface areas.\n",
+    "* `time_dim` (optional): the model timestep\n",
+    "* `meteo_parameters` (optional): intitial meteorological parameters. If not provided, all meteo parameters will fall to default values.\n",
+    "* `track_dynamic_variables` (optional): boolean indicating whether or not the user wants to track all intermediate information used in the calculations. We set this to `False` to save on memory.\n",
+    "* `use_sed_temp` (optional): boolean indicating whether to use the sediment temperature in TSM calculations. We opt to turn this off for simplicity.\n",
+    "* `updateable_static_variables` (optional): by default, the meteorological variables are static in TSM. If we want these to update over time, we must provide a list of variables that we want to be updateable as input when instantiating the model. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 26,
+   "id": "86b811c9-f20b-4d23-8af4-85cd2a7876b0",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Initializing from dicts...\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "D:\\Clearwater\\ClearWater-modules\\src\\clearwater_modules\\base.py:223: UserWarning: Variable volume is not a state variable, skipping.\n",
+      "  warnings.warn(\n",
+      "D:\\Clearwater\\ClearWater-modules\\src\\clearwater_modules\\base.py:223: UserWarning: Variable surface_area is not a state variable, skipping.\n",
+      "  warnings.warn(\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Model initialized from input dicts successfully!.\n"
+     ]
+    }
+   ],
+   "source": [
+    "reaction_model = NutrientBudget(\n",
+    "    time_steps=time_Steps,\n",
+    "    initial_state_values=initial_state_values,\n",
+    "    updateable_static_variables=['q_solar'],\n",
+    "    \n",
+    "    algae_parameters = {\n",
+    "    'AWd': 100,\n",
+    "    'AWc': 40,\n",
+    "    'AWn': 7.2,\n",
+    "    'AWp': 1,\n",
+    "    'AWa': 1000,\n",
+    "    'KL': 10,\n",
+    "    'KsN': 0.04,\n",
+    "    'KsP': 0.0012,\n",
+    "    'mu_max_20': 1,\n",
+    "    'kdp_20': 0.15,\n",
+    "    'krp_20': 0.2,\n",
+    "    'vsap': 0.15,\n",
+    "    'growth_rate_option': 3,\n",
+    "    'light_limitation_option': 1 \n",
+    "    },\n",
+    "\n",
+    "    global_parameters={\n",
+    "    'use_NH4': True,\n",
+    "    'use_NO3': True, \n",
+    "    'use_OrgN': False,\n",
+    "    'use_OrgP': False,\n",
+    "    'use_TIP': True,  \n",
+    "    'use_SedFlux': False,\n",
+    "    'use_DOX': True,\n",
+    "    'use_Algae': True,\n",
+    "    'use_Balgae': False,\n",
+    "    'use_POC': False,\n",
+    "    'use_DOC': False,\n",
+    "    'use_DIC': False,\n",
+    "    'use_N2': False,\n",
+    "    'use_Pathogen': False,\n",
+    "    'use_Alk': False,\n",
+    "    'use_POM': False \n",
+    "    },\n",
+    "\n",
+    "\n",
+    "    global_vars = {\n",
+    "    'vson': 0.01,\n",
+    "    'vsoc': 0.01,\n",
+    "    'vsop': 0.01,\n",
+    "    'vs': 0.01,\n",
+    "    'SOD_20': .5,\n",
+    "    'SOD_theta': 1.047,\n",
+    "    'vb': 0.01,\n",
+    "    'fcom': 0.4,\n",
+    "    'kaw_20_user': 0,\n",
+    "    'kah_20_user': 1,\n",
+    "    'hydraulic_reaeration_option': 1,\n",
+    "    'wind_reaeration_option': 1,    \n",
+    "    'dt': 0.0003472222,\n",
+    "    'depth': 1.5,\n",
+    "    'TwaterC': 25,\n",
+    "    'theta': 1.047,\n",
+    "    'velocity': 1,\n",
+    "    'flow': 150,\n",
+    "    'topwidth': 100,\n",
+    "    'slope': .0002,\n",
+    "    'shear_velocity': 0.05334,\n",
+    "    'pressure_atm': 1013.25,\n",
+    "    'wind_speed': 3,\n",
+    "    'q_solar': 500,\n",
+    "    'Solid': 1,\n",
+    "    'lambda0': 0.02,\n",
+    "    'lambda1': 0.0088,\n",
+    "    'lambda2': 0.054,\n",
+    "    'lambdas': 0.056,\n",
+    "    'lambdam': 0.174, \n",
+    "    'Fr_PAR': 0.47  \n",
+    "    },\n",
+    "\n",
+    "    track_dynamic_variables=False, \n",
+    "    time_dim='seconds'    \n",
+    "    )\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2d2da52a-724d-46c7-9ed7-fda8bedfa6f3",
+   "metadata": {},
+   "source": [
+    "## Couple Models\n",
+    "Optionally, you can log output if you run for a long simulation to track progress."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 27,
+   "id": "462f0a9e-7b70-4ae3-bb06-9e67ba4b80ca",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def setup_function_logger(name):\n",
+    "    logger = logging.getLogger('function_logger')\n",
+    "    handler = logging.FileHandler(f'{name}.log')\n",
+    "    formatter = logging.Formatter('%(asctime)s - %(levelname)s - %(message)s')\n",
+    "    handler.setFormatter(formatter)\n",
+    "    logger.addHandler(handler)\n",
+    "    logger.setLevel(logging.DEBUG)  # Adjust the level based on your needs\n",
+    "    return logger"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 28,
+   "id": "32e3aed0-8dad-4767-bd0f-2bfe5308b4fe",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def run_n_timesteps(\n",
+    "    time_steps: int,\n",
+    "    reaction: NutrientBudget,\n",
+    "    transport: cwr.ClearwaterRiverine,\n",
+    "    meteo_params: dict,\n",
+    "    concentration_update = None,\n",
+    "    logging = True,\n",
+    "    log_file_name='log',\n",
+    "):\n",
+    "    \"\"\"Function to couple Clearwater Riverine and Modules for n timesteps.\"\"\"\n",
+    "\n",
+    "    # Set up logger\n",
+    "    if logging:\n",
+    "        logger = setup_function_logger(f'{log_file_name}')\n",
+    "\n",
+    "    for i in range(1, time_steps):\n",
+    "        if i % 100 == 0:\n",
+    "            status = {\n",
+    "                'timesteps': i,\n",
+    "                'cwr': transport.mesh.nbytes * 1e-9,\n",
+    "                'cwm': reaction.dataset.nbytes*1e-9,\n",
+    "            }\n",
+    "            if logging:\n",
+    "                logger.debug(status)\n",
+    "\n",
+    "        # Top of timestep: update transport model using values with output from reaction model, if available\n",
+    "        transport.update(concentration_update)\n",
+    "\n",
+    "        # Update state values\n",
+    "        updated_state_values = {\n",
+    "            'Ap': transport.mesh['Ap'].isel(\n",
+    "                time=i,\n",
+    "                nface=slice(0,transport.mesh.nreal+1)\n",
+    "            ), \n",
+    "            'NH4': transport.mesh['NH4'].isel(\n",
+    "                time=i,\n",
+    "                nface=slice(0,transport.mesh.nreal+1)\n",
+    "            ), \n",
+    "            'NO3': transport.mesh['NO3'].isel(\n",
+    "                time=i,\n",
+    "                nface=slice(0,transport.mesh.nreal+1)\n",
+    "            ), \n",
+    "            'TIP': transport.mesh['TIP'].isel(\n",
+    "                time=i,\n",
+    "                nface=slice(0,transport.mesh.nreal+1)\n",
+    "            ), \n",
+    "            'DOX': transport.mesh['DOX'].isel(\n",
+    "                time=i,\n",
+    "                nface=slice(0,transport.mesh.nreal+1)\n",
+    "            ), \n",
+    "            'q_solar': transport.mesh.Ap.isel(\n",
+    "                time=i,\n",
+    "                nface=slice(0, transport.mesh.nreal + 1)\n",
+    "            ) * 0 + meteo_params['q_solar'][i],\n",
+    "        }\n",
+    "\n",
+    "        # Bottom of timestep: update nutrient budget (NSM1)\n",
+    "        reaction.increment_timestep(updated_state_values)\n",
+    "\n",
+    "        # Prepare data for input back into Riverine\n",
+    "        ds = reaction.dataset.copy()\n",
+    "        ds['Ap'] = ds['Ap'].where(\n",
+    "            ~np.isinf(ds['Ap']),\n",
+    "            transport.mesh['Ap'].isel(\n",
+    "                nface=slice(0, transport.mesh.nreal+1),\n",
+    "                time=i\n",
+    "            )\n",
+    "        )            \n",
+    "        ds['Ap'] = ds['Ap'].fillna(\n",
+    "            transport.mesh['Ap'].isel(\n",
+    "                nface=slice(0, transport.mesh.nreal+1),\n",
+    "                time=i\n",
+    "            )\n",
+    "        )\n",
+    "\n",
+    "\n",
+    "        ds['DOX'] = ds['DOX'].where(\n",
+    "            ~np.isinf(ds['DOX']),\n",
+    "            transport.mesh['DOX'].isel(\n",
+    "                nface=slice(0, transport.mesh.nreal+1),\n",
+    "                time=i\n",
+    "            )\n",
+    "        )            \n",
+    "        ds['DOX'] = ds['DOX'].fillna(\n",
+    "            transport.mesh['DOX'].isel(\n",
+    "                nface=slice(0, transport.mesh.nreal+1),\n",
+    "                time=i\n",
+    "            )\n",
+    "        )\n",
+    "\n",
+    "\n",
+    "        ds['NH4'] = ds['NH4'].where(\n",
+    "            ~np.isinf(ds['NH4']),\n",
+    "            transport.mesh['NH4'].isel(\n",
+    "                nface=slice(0, transport.mesh.nreal+1),\n",
+    "                time=i\n",
+    "            )\n",
+    "        )            \n",
+    "        ds['NH4'] = ds['NH4'].fillna(\n",
+    "            transport.mesh['NH4'].isel(\n",
+    "                nface=slice(0, transport.mesh.nreal+1),\n",
+    "                time=i\n",
+    "            )\n",
+    "        )\n",
+    "\n",
+    "\n",
+    "        ds['NO3'] = ds['NO3'].where(\n",
+    "            ~np.isinf(ds['NO3']),\n",
+    "            transport.mesh['NO3'].isel(\n",
+    "                nface=slice(0, transport.mesh.nreal+1),\n",
+    "                time=i\n",
+    "            )\n",
+    "        )            \n",
+    "        ds['NO3'] = ds['NO3'].fillna(\n",
+    "            transport.mesh['NO3'].isel(\n",
+    "                nface=slice(0, transport.mesh.nreal+1),\n",
+    "                time=i\n",
+    "            )\n",
+    "        )\n",
+    "\n",
+    "\n",
+    "        ds['TIP'] = ds['TIP'].where(\n",
+    "            ~np.isinf(ds['TIP']),\n",
+    "            transport.mesh['TIP'].isel(\n",
+    "                nface=slice(0, transport.mesh.nreal+1),\n",
+    "                time=i\n",
+    "            )\n",
+    "        )            \n",
+    "        ds['TIP'] = ds['TIP'].fillna(\n",
+    "            transport.mesh['TIP'].isel(\n",
+    "                nface=slice(0, transport.mesh.nreal+1),\n",
+    "                time=i\n",
+    "            )\n",
+    "        )\n",
+    "\n",
+    "\n",
+    "        concentration_update = {\"Ap\": ds.Ap.isel(seconds=i),\n",
+    "                                \"DOX\": ds.DOX.isel(seconds=i),\n",
+    "                                \"NH4\": ds.NH4.isel(seconds=i),\n",
+    "                                \"NO3\": ds.NO3.isel(seconds=i),\n",
+    "                                \"TIP\": ds.TIP.isel(seconds=i)\n",
+    "                                }\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 29,
+   "id": "28b35563-bf79-4be1-9c30-7d86b41d2e7e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "TIME_STEPS = len(transport_model.mesh.time) - 1 # 5760  # len(transport_model.mesh.time) - 60"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 30,
+   "id": "6572e8e7",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "5760"
+      ]
+     },
+     "execution_count": 30,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "TIME_STEPS"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 31,
+   "id": "408f2fbe-ffbd-4cfb-afa2-45df1a5526f2",
+   "metadata": {},
+   "outputs": [
+    {
+     "ename": "ValueError",
+     "evalue": "axis 0 index 442 exceeds matrix dimension 367",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[1;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[1;31mValueError\u001b[0m                                Traceback (most recent call last)",
+      "File \u001b[1;32m<timed eval>:1\u001b[0m\n",
+      "Cell \u001b[1;32mIn[28], line 27\u001b[0m, in \u001b[0;36mrun_n_timesteps\u001b[1;34m(time_steps, reaction, transport, meteo_params, concentration_update, logging, log_file_name)\u001b[0m\n\u001b[0;32m     24\u001b[0m         logger\u001b[38;5;241m.\u001b[39mdebug(status)\n\u001b[0;32m     26\u001b[0m \u001b[38;5;66;03m# Top of timestep: update transport model using values with output from reaction model, if available\u001b[39;00m\n\u001b[1;32m---> 27\u001b[0m \u001b[43mtransport\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mupdate\u001b[49m\u001b[43m(\u001b[49m\u001b[43mconcentration_update\u001b[49m\u001b[43m)\u001b[49m\n\u001b[0;32m     29\u001b[0m \u001b[38;5;66;03m# Update state values\u001b[39;00m\n\u001b[0;32m     30\u001b[0m updated_state_values \u001b[38;5;241m=\u001b[39m {\n\u001b[0;32m     31\u001b[0m     \u001b[38;5;124m'\u001b[39m\u001b[38;5;124mAp\u001b[39m\u001b[38;5;124m'\u001b[39m: transport\u001b[38;5;241m.\u001b[39mmesh[\u001b[38;5;124m'\u001b[39m\u001b[38;5;124mAp\u001b[39m\u001b[38;5;124m'\u001b[39m]\u001b[38;5;241m.\u001b[39misel(\n\u001b[0;32m     32\u001b[0m         time\u001b[38;5;241m=\u001b[39mi,\n\u001b[1;32m   (...)\u001b[0m\n\u001b[0;32m     54\u001b[0m     ) \u001b[38;5;241m*\u001b[39m \u001b[38;5;241m0\u001b[39m \u001b[38;5;241m+\u001b[39m meteo_params[\u001b[38;5;124m'\u001b[39m\u001b[38;5;124mq_solar\u001b[39m\u001b[38;5;124m'\u001b[39m][i],\n\u001b[0;32m     55\u001b[0m }\n",
+      "File \u001b[1;32mD:\\Clearwater\\ClearWater-riverine\\src\\clearwater_riverine\\transport.py:185\u001b[0m, in \u001b[0;36mClearwaterRiverine.update\u001b[1;34m(self, update_concentration)\u001b[0m\n\u001b[0;32m    179\u001b[0m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mlhs\u001b[38;5;241m.\u001b[39mupdate_values(\n\u001b[0;32m    180\u001b[0m     \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mmesh,\n\u001b[0;32m    181\u001b[0m     \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mtime_step\n\u001b[0;32m    182\u001b[0m )\n\u001b[0;32m    184\u001b[0m \u001b[38;5;66;03m# Define compressed sparse row matrix for LHS\u001b[39;00m\n\u001b[1;32m--> 185\u001b[0m A \u001b[38;5;241m=\u001b[39m \u001b[43mcsr_matrix\u001b[49m\u001b[43m(\u001b[49m\n\u001b[0;32m    186\u001b[0m \u001b[43m    \u001b[49m\u001b[43m(\u001b[49m\u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mlhs\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mcoef\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43m(\u001b[49m\u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mlhs\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mrows\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mlhs\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mcols\u001b[49m\u001b[43m)\u001b[49m\u001b[43m)\u001b[49m\u001b[43m,\u001b[49m\n\u001b[0;32m    187\u001b[0m \u001b[43m    \u001b[49m\u001b[43mshape\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43m(\u001b[49m\u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mmesh\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mnreal\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;241;43m+\u001b[39;49m\u001b[43m \u001b[49m\u001b[38;5;241;43m1\u001b[39;49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mmesh\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mnreal\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;241;43m+\u001b[39;49m\u001b[43m \u001b[49m\u001b[38;5;241;43m1\u001b[39;49m\u001b[43m)\u001b[49m\n\u001b[0;32m    188\u001b[0m \u001b[43m\u001b[49m\u001b[43m)\u001b[49m\n\u001b[0;32m    190\u001b[0m \u001b[38;5;66;03m# Check if constituent_name from update_concentration dict is one\u001b[39;00m\n\u001b[0;32m    191\u001b[0m \u001b[38;5;66;03m# of the constituents in the model\u001b[39;00m\n\u001b[0;32m    193\u001b[0m \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;28misinstance\u001b[39m(update_concentration, \u001b[38;5;28mdict\u001b[39m):\n",
+      "File \u001b[1;32mc:\\Users\\rushmore\\AppData\\Local\\miniconda3\\envs\\clearwater_riverine\\Lib\\site-packages\\scipy\\sparse\\_compressed.py:55\u001b[0m, in \u001b[0;36m_cs_matrix.__init__\u001b[1;34m(self, arg1, shape, dtype, copy)\u001b[0m\n\u001b[0;32m     52\u001b[0m \u001b[38;5;28;01melse\u001b[39;00m:\n\u001b[0;32m     53\u001b[0m     \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;28mlen\u001b[39m(arg1) \u001b[38;5;241m==\u001b[39m \u001b[38;5;241m2\u001b[39m:\n\u001b[0;32m     54\u001b[0m         \u001b[38;5;66;03m# (data, ij) format\u001b[39;00m\n\u001b[1;32m---> 55\u001b[0m         coo \u001b[38;5;241m=\u001b[39m \u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43m_coo_container\u001b[49m\u001b[43m(\u001b[49m\u001b[43marg1\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mshape\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mshape\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mdtype\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mdtype\u001b[49m\u001b[43m)\u001b[49m\n\u001b[0;32m     56\u001b[0m         arrays \u001b[38;5;241m=\u001b[39m coo\u001b[38;5;241m.\u001b[39m_coo_to_compressed(\u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_swap)\n\u001b[0;32m     57\u001b[0m         \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mindptr, \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mindices, \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mdata, \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_shape \u001b[38;5;241m=\u001b[39m arrays\n",
+      "File \u001b[1;32mc:\\Users\\rushmore\\AppData\\Local\\miniconda3\\envs\\clearwater_riverine\\Lib\\site-packages\\scipy\\sparse\\_coo.py:99\u001b[0m, in \u001b[0;36m_coo_base.__init__\u001b[1;34m(self, arg1, shape, dtype, copy)\u001b[0m\n\u001b[0;32m     96\u001b[0m \u001b[38;5;28;01mif\u001b[39;00m dtype \u001b[38;5;129;01mis\u001b[39;00m \u001b[38;5;129;01mnot\u001b[39;00m \u001b[38;5;28;01mNone\u001b[39;00m:\n\u001b[0;32m     97\u001b[0m     \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mdata \u001b[38;5;241m=\u001b[39m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mdata\u001b[38;5;241m.\u001b[39mastype(dtype, copy\u001b[38;5;241m=\u001b[39m\u001b[38;5;28;01mFalse\u001b[39;00m)\n\u001b[1;32m---> 99\u001b[0m \u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43m_check\u001b[49m\u001b[43m(\u001b[49m\u001b[43m)\u001b[49m\n",
+      "File \u001b[1;32mc:\\Users\\rushmore\\AppData\\Local\\miniconda3\\envs\\clearwater_riverine\\Lib\\site-packages\\scipy\\sparse\\_coo.py:205\u001b[0m, in \u001b[0;36m_coo_base._check\u001b[1;34m(self)\u001b[0m\n\u001b[0;32m    203\u001b[0m \u001b[38;5;28;01mfor\u001b[39;00m i, idx \u001b[38;5;129;01min\u001b[39;00m \u001b[38;5;28menumerate\u001b[39m(\u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mcoords):\n\u001b[0;32m    204\u001b[0m     \u001b[38;5;28;01mif\u001b[39;00m idx\u001b[38;5;241m.\u001b[39mmax() \u001b[38;5;241m>\u001b[39m\u001b[38;5;241m=\u001b[39m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mshape[i]:\n\u001b[1;32m--> 205\u001b[0m         \u001b[38;5;28;01mraise\u001b[39;00m \u001b[38;5;167;01mValueError\u001b[39;00m(\u001b[38;5;124mf\u001b[39m\u001b[38;5;124m'\u001b[39m\u001b[38;5;124maxis \u001b[39m\u001b[38;5;132;01m{\u001b[39;00mi\u001b[38;5;132;01m}\u001b[39;00m\u001b[38;5;124m index \u001b[39m\u001b[38;5;132;01m{\u001b[39;00midx\u001b[38;5;241m.\u001b[39mmax()\u001b[38;5;132;01m}\u001b[39;00m\u001b[38;5;124m exceeds \u001b[39m\u001b[38;5;124m'\u001b[39m\n\u001b[0;32m    206\u001b[0m                          \u001b[38;5;124mf\u001b[39m\u001b[38;5;124m'\u001b[39m\u001b[38;5;124mmatrix dimension \u001b[39m\u001b[38;5;132;01m{\u001b[39;00m\u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mshape[i]\u001b[38;5;132;01m}\u001b[39;00m\u001b[38;5;124m'\u001b[39m)\n\u001b[0;32m    207\u001b[0m     \u001b[38;5;28;01mif\u001b[39;00m idx\u001b[38;5;241m.\u001b[39mmin() \u001b[38;5;241m<\u001b[39m \u001b[38;5;241m0\u001b[39m:\n\u001b[0;32m    208\u001b[0m         \u001b[38;5;28;01mraise\u001b[39;00m \u001b[38;5;167;01mValueError\u001b[39;00m(\u001b[38;5;124mf\u001b[39m\u001b[38;5;124m'\u001b[39m\u001b[38;5;124mnegative axis \u001b[39m\u001b[38;5;132;01m{\u001b[39;00mi\u001b[38;5;132;01m}\u001b[39;00m\u001b[38;5;124m index: \u001b[39m\u001b[38;5;132;01m{\u001b[39;00midx\u001b[38;5;241m.\u001b[39mmin()\u001b[38;5;132;01m}\u001b[39;00m\u001b[38;5;124m'\u001b[39m)\n",
+      "\u001b[1;31mValueError\u001b[0m: axis 0 index 442 exceeds matrix dimension 367"
+     ]
+    }
+   ],
+   "source": [
+    "%%time\n",
+    "run_n_timesteps(\n",
+    "    TIME_STEPS,\n",
+    "    reaction_model,\n",
+    "    transport_model,\n",
+    "    all_meteo_params,\n",
+    "    logging=True,\n",
+    ")\n",
+    "\n",
+    "#zarr_outpath = network_path / 'output.zarr'\n",
+    "#netCDF_outpath = network_path / 'output.nc'\n",
+    "#transport_model.finalize(True, zarr_outpath)\n",
+    "#transport_model.finalize(True, netCDF_outpath)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 32,
+   "id": "d5ce5d8b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "zarr_outpath = network_path / 'output.zarr'\n",
+    "netCDF_outpath = network_path / 'output.nc'\n",
+    "transport_model.finalize(True, zarr_outpath)\n",
+    "transport_model.finalize(True, netCDF_outpath)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 33,
+   "id": "1ffec8b8-04e2-4a05-b835-f4f507bfeb7c",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[<matplotlib.lines.Line2D at 0x1c1ef9d3dd0>]"
+      ]
+     },
+     "execution_count": 33,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAksAAAHFCAYAAADi7703AAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjguNCwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8fJSN1AAAACXBIWXMAAA9hAAAPYQGoP6dpAAAzsUlEQVR4nO3de3hU1b3/8c9Ikgm3DIFAQhAhKCcQgQqhhFBzQq2Ei1JuVcQSb2BJqSIgRVBPiSgEsIeiAnIKQW2Ldy7SU6SgBA5KAEFAhECrgGDNEEHIBLkmWb8/aObHMMkigVwYfL+eZ56ns/Z37b3WSup82HvPjsMYYwQAAIBSXVfTAwAAALiaEZYAAAAsCEsAAAAWhCUAAAALwhIAAIAFYQkAAMCCsAQAAGBBWAIAALAgLAEAAFgQloArsGHDBqWnp+v48eN+27p3767u3btX+5iqwz/+8Q+NGzdO8fHxatCggRo2bKif/OQnevfdd0utz8vL0wMPPKCIiAjVqVNHiYmJ+vDDD31qPB6PpkyZou7duysqKkr16tVT+/btNX36dJ0+fdqnduvWrfrNb36j9u3bq379+oqMjNTtt9+uNWvWVGge5RmXdP5n6XA4/F69evUq97FmzZqlgQMHKiYmRg6Ho9y/G08//bQcDofatWvnbUtPTy91PBe/So6xa9cujRw5UomJiapbt64cDofWrl3rd6y1a9da95eWllbu+ZYYOnSoHA6H7rzzzlK3v/nmm7rlllsUGhqq6OhojR49WidOnCj3/vft26eBAweqQYMGqlevnnr06KFPP/20So6FHzAD4LI9//zzRpLZv3+/37Zdu3aZXbt2Vf+gqsFLL71k2rRpY6ZMmWJWrVplVqxYYe6//34jyTzzzDM+tadPnzbt2rUz119/vfnLX/5iVq1aZfr162eCgoLM2rVrvXU7d+40ERERZsyYMea9994zH374oUlPTzehoaHmZz/7mSkuLvbWPv7446Zz585m5syZ5sMPPzTLly83ffr0MZLMa6+9Vq45lHdcxhiTnJxsWrVqZbKzs31eOTk55V6z2NhY06lTJ/PQQw+Zxo0bm+Tk5Ev22bZtm3E6nSYyMtLcfPPN3vZDhw75jGPJkiVGknn00Ud92kt+/1599VXTtGlT06dPH9O3b18jyWRlZfkdLz8/32+O2dnZ5r777jOSzMqVK8s9X2OM+d///V9Tt25dExYWZu644w6/7X/5y1+MJDN8+HCzZs0aM2/ePONyuUyPHj3Ktf+8vDwTHR1tbr75ZrN48WLzt7/9zdx6662mfv36Zs+ePZV6LPywEZaAK2ALS9eyb7/91ie8lLjjjjtMnTp1zOnTp71tc+bMMZLMhg0bvG3nzp0zcXFxpkuXLt62EydOmBMnTvjts2SN169f7207fPiwX11hYaHp0KGDufHGG8s1h/KOy5jzYenCsHI5ioqKvP/75ptvvmRYOnfunLnlllvMqFGjLnn8/fv3G0nm+eefv+Sx33nnnTLDUmmKi4tNq1atTIsWLXz2cynHjx83zZo1MzNnzjQtWrTwC0uFhYWmadOmJiUlxad90aJFRpJZsWLFJY/x29/+1gQHB5sDBw542/Lz801ERIS5++67K/VY+GHjMhxwmdLT0/Xb3/5WkryXVi68vHHxZbgDBw7I4XDo+eef1/Tp09WyZUvVrl1b3bt31z/+8Q+dO3dOEyZMUHR0tFwulwYMGKC8vDy/47711lveyyn16tVTz549tW3btuqYsldERIQcDodfe5cuXXTy5El999133ralS5cqNjZWiYmJ3ragoCANHTpUmzdv1r/+9S9JUt26dVW3bt1S9ylJhw4d8rY1adLEr65WrVqKj4/3qbMp77gqy3XXVew/t9OmTdN3332nKVOmVPuxL5SVlaV9+/bpwQcfrNB+Hn/8cTVt2lSjRo0qdfvGjRuVm5urBx980Kf9rrvuUr169bR06dJLHmPp0qW67bbb1KJFC29bWFiYBg4cqL/+9a8qLCystGPhh42wBFym4cOH69FHH5UkLVmyRNnZ2crOzlanTp2s/ebMmaOPP/5Yc+bM0YIFC7Rnzx717dtXw4YN07fffquFCxdqxowZ+uCDDzR8+HCfvlOnTtWQIUMUFxent99+W3/+859VUFCgpKQk7d69+5JjLiwsLNfLGHNZa5KVlaXGjRv7hJnPP/9cHTp08Kstadu1a5d1nyX3Id18883WusLCQq1fv/6SdZc7ri+//FINGzZUUFCQbrzxRj311FM6depUuY5VUbt379Zzzz2nl19+WfXq1auSY5RXZmamrrvuOr+gIanMe68++OAD/elPf9KCBQtUq1atUvf7+eefS5LfzyA4OFht2rTxbi/rWKdOndKXX35Z5s/w1KlT2rdv32UdC7hYUE0PAAhU119/vW644QZJUseOHdWyZcty9WvQoIGWLVvm/Vf6kSNHNHr0aLVp00bvvfeet27Pnj2aNWuWPB6PwsLCdOjQIU2aNEmPPPKIXnzxRW9djx491Lp1az3zzDN66623yjzugQMHFBMTU64xZmVlVfjm9AULFmjt2rV64YUXfD4gjx49qoYNG/rVl7QdPXq0zH1+9tlnmjFjhgYMGFDqh+KF0tPT9cUXX2jZsmXlGm9FxnXrrbdq8ODBatOmjU6dOqX3339fM2bM0EcffaSsrKwrOnNzseLiYj300EMaOHCg+vTpU2n7vRzHjx/XkiVL1KNHD+/v+oVq1arlF4ZOnDihhx9+WOPGjdOPfvSjMvddsr5l/QwOHDhgPdaxY8dkjCnXz7CixwIuRlgCqlmfPn18Plzbtm0rSbrjjjt86kraDx48qHbt2unvf/+7CgsLdd9993kvL0hSaGiokpOTlZWVZT1udHS0Pvnkk3KNMTY2tlx1Jd5//3395je/0S9+8Qvv2bYLlXbJ7lLbDhw4oDvvvFPNmzfXggULrMdfsGCBpkyZoscff1z9+vXzthtjVFRU5FMbFPT//7NX3nE999xzPtv69Omjli1baty4cXrvvfc0YMAASfL5uUjnP+BtxyjNzJkz9c9//lPLly+vUL+qsGjRIp0+fdrvDGeJi+crSRMmTFBwcLB+97vflesYZa3Pxe2lHcvWv7Rt5T0WcDHCElDNLv7XbUhIiLW95Gvzhw8fliT9+Mc/LnW/lzq7ERISoltuuaVcYyzr0klp/v73v2vgwIHq0aOHFi1a5PfB06hRo1LPHpXc11Tav/a/+uor/fSnP1VQUJA+/PDDUmtKvPLKKxoxYoR+9atf6fnnn/fZ9tprr/ldPiq5xHg547rQ0KFDNW7cOG3cuNEbloKDg/3G9sADD1j3c6GDBw/qd7/7naZNm6aQkBDvIykKCwtVXFys48ePy+l0qnbt2uXe55XIzMxU48aNfQKozebNmzV37lwtWbJEp0+f9v7uFhcXq7CwUMePH1ft2rXldDrVqFEjSefP+kRGRvrs57vvvrvk+oeHh8vhcJTrZ3ilxwIIS0CAiIiIkCS9++67Pje0lldVXIb7+9//rv79+ys5OVmLFy/2BrwLtW/fXjt37vRrL2m78PlB0vmg1L17dxljtHbtWl1//fVlHv+VV17R8OHDdf/992vevHl+Qa1v375lnk2r6LjKcmFIvfhY5V3vEvv27dOpU6f02GOP6bHHHvPbHh4erscee0yzZs2q0H4vx7Zt27Rt2zY9/vjjfiGwLLt375YxxhseL3To0CGFh4frD3/4g0aPHq327dtLOr/ecXFx3rrCwkLt2bNHQ4YMsR6rdu3auummm8r8GdauXVutWrWSpCs+FkBYAq6A0+mUpCq70fdCPXv2VFBQkL788ksNGjSowv0r+zLcqlWr1L9/f916661atmyZdy0uNmDAAI0cOVKbNm1SQkKCpPMfUn/5y1+UkJCg6Ohob+3BgwfVvXt3FRUVae3atdZQ+Oqrr2r48OEaOnSoFixYUOqllEaNGnnPKlzJuErz2muvSZK6du3qbevcubO1z6XccsstpV5OHT16tPLz8/XKK69Yw2NlyszMlCQNGzas3H169epV6vjvuecexcTEKCMjQzfddJMkKSEhQU2bNtWrr76qwYMHe2vfffddnThxQgMHDrzk8QYMGKBZs2bp0KFDat68uSSpoKBAS5Ys0c9//nPvJdfKOBZ+2AhLwBUo+RfrCy+8oPvvv1/BwcGKjY1V/fr1K/1YLVu21OTJk/XUU09p37596tWrl8LDw3X48GFt3rxZdevW1TPPPFNm/5CQkCv+MC/x0UcfqX///oqKitKTTz6p7du3+2yPi4tTWFiYJOmhhx7SnDlzdNddd2natGlq0qSJ5s6dq7179+qDDz7w9snLy9NPf/pT5ebmKjMzU3l5eT6PTrj++uu9QeGdd97RsGHDdMstt2jEiBHavHmzz/E7duxYZngrUd5xrV+/XlOmTNGAAQPUqlUrnT59Wu+//77++Mc/6rbbblPfvn3LtWZbtmzx3kjs8XhkjPE+8fzHP/6xWrRooQYNGpR6Rq9BgwYqLCy87CfCnzx5UitWrJB0/mv0krRu3TodOXJEdevWVe/evX3qT58+rddff13dunXz3jtXmqCgICUnJ3ufeh4VFaWoqCi/utDQUDVq1Mhn/LVq1dKMGTOUmpqqESNGaMiQIfrnP/+p8ePHq0ePHn5PR7/4WJI0btw4/fnPf9Ydd9yhyZMny+l0atq0aTp9+rTS09Mv+1iAnxp8xhNwTZg4caKJjo421113nc/D/pKTk30ePFjWgwOzsrKMJPPOO+/4tL/yyitGkvnkk0982pctW2Z++tOfmrCwMON0Ok2LFi3ML37xC/PBBx9UyfxKM2nSJCOpzNfFDzx0u93mvvvuMw0bNjShoaGma9euZvXq1T41JetQ1mvSpEne2pKnhZf1Ku9DQsszrn/+85+mT58+plmzZsbpdJrQ0FDTvn17M2XKFJ+Hb16KbcyvvPKKte+VPpSyZHtprxYtWvjVlzysceHChdZxSSrXk8hLeyhliddff9106NDBhISEmKioKDNq1ChTUFBQ7mN98cUXpn///iYsLMzUqVPH/OxnPzNbt269omMBF3MYc5kPVAEAAPgB4KGUAAAAFoQlAAAAC8ISAACABWEJAADAgrAEAABgQVgCAACw4KGUlaC4uFjffPON6tevzx9kBAAgQBhjVFBQoOjoaOvf1yQsVYJvvvnG+6h9AAAQWA4dOmT9U0KEpUpQ8qctDh065P0TDwAA4Orm8XjUvHnzS/6JKsJSJSi59BYWFkZYAgAgwFzqFhpu8AYAALAgLAEAAFgQlgAAACwISwAAABaEJQAAAAvCEgAAgAVhCQAAwIKwBAAAYEFYAgAAsCAsAQAAWBCWAAAALAhLAAAAFoQlAAAAC8ISAACABWEJAADAgrAEAABgQVgCAACwICwBAABYEJYAAAAsCEsAAAAWhCUAAAALwhIAAIAFYQkAAMCCsAQAAGBBWAIAALAgLAEAAFgQlgAAACwISwAAABaEJQAAAAvCEgAAgAVhCQAAwIKwBAAAYEFYAgAAsCAsAQAAWBCWAAAALAhLAAAAFoQlAAAAC8ISAACABWEJAADAgrAEAABgQVgCAACwICwBAABYEJYAAAAsAi4szZ07VzExMQoNDVV8fLzWr19vrV+3bp3i4+MVGhqqVq1aad68eWXWvvnmm3I4HOrfv38ljxoAAASqgApLb731lkaPHq2nnnpK27ZtU1JSknr37q2DBw+WWr9//3716dNHSUlJ2rZtm5588kmNGjVKixcv9qv96quvNG7cOCUlJVX1NAAAQABxGGNMTQ+ivBISEtSpUye9/PLL3ra2bduqf//+ysjI8Kt/4okntHz5cuXk5Hjb0tLStGPHDmVnZ3vbioqKlJycrAcffFDr16/X8ePHtWzZsnKPy+PxyOVyKT8/X2FhYZc3OQAAUK3K+/kdMGeWzp49q61btyolJcWnPSUlRRs2bCi1T3Z2tl99z549tWXLFp07d87bNnnyZDVu3FjDhg2r/IEDAICAFlTTAyivI0eOqKioSJGRkT7tkZGRcrvdpfZxu92l1hcWFurIkSNq2rSpPv74Y2VmZmr79u3lHsuZM2d05swZ73uPx1P+iQAAgIASMGeWSjgcDp/3xhi/tkvVl7QXFBRo6NChmj9/viIiIso9hoyMDLlcLu+refPmFZgBAAAIJAFzZikiIkK1atXyO4uUl5fnd/aoRFRUVKn1QUFBatSokXbt2qUDBw6ob9++3u3FxcWSpKCgIO3du1c33nij334nTpyosWPHet97PB4CEwAA16iACUshISGKj4/X6tWrNWDAAG/76tWr1a9fv1L7JCYm6q9//atP26pVq9S5c2cFBwerTZs22rlzp8/2p59+WgUFBXrhhRfKDEBOp1NOp/MKZwQAAAJBwIQlSRo7dqxSU1PVuXNnJSYm6o9//KMOHjyotLQ0SefP+PzrX//Sn/70J0nnv/k2e/ZsjR07Vg8//LCys7OVmZmpN954Q5IUGhqqdu3a+RyjQYMGkuTXDgAAfpgCKiwNHjxYR48e1eTJk5Wbm6t27dppxYoVatGihSQpNzfX55lLMTExWrFihcaMGaM5c+YoOjpaL774ogYNGlRTUwAAAAEmoJ6zdLXiOUsAAASea+45SwAAADWBsAQAAGBBWAIAALAgLAEAAFgQlgAAACwISwAAABaEJQAAAAvCEgAAgAVhCQAAwIKwBAAAYEFYAgAAsCAsAQAAWBCWAAAALAhLAAAAFoQlAAAAC8ISAACABWEJAADAgrAEAABgQVgCAACwICwBAABYEJYAAAAsCEsAAAAWhCUAAAALwhIAAIAFYQkAAMCCsAQAAGBBWAIAALAgLAEAAFgQlgAAACwISwAAABaEJQAAAAvCEgAAgAVhCQAAwIKwBAAAYEFYAgAAsCAsAQAAWBCWAAAALAhLAAAAFoQlAAAAC8ISAACABWEJAADAgrAEAABgQVgCAACwICwBAABYEJYAAAAsCEsAAAAWhCUAAAALwhIAAIAFYQkAAMCCsAQAAGBBWAIAALAgLAEAAFgQlgAAACwISwAAABaEJQAAAAvCEgAAgEXAhaW5c+cqJiZGoaGhio+P1/r1663169atU3x8vEJDQ9WqVSvNmzfPZ/v8+fOVlJSk8PBwhYeH6/bbb9fmzZurcgoAACCABFRYeuuttzR69Gg99dRT2rZtm5KSktS7d28dPHiw1Pr9+/erT58+SkpK0rZt2/Tkk09q1KhRWrx4sbdm7dq1GjJkiLKyspSdna0bbrhBKSkp+te//lVd0wIAAFcxhzHG1PQgyishIUGdOnXSyy+/7G1r27at+vfvr4yMDL/6J554QsuXL1dOTo63LS0tTTt27FB2dnapxygqKlJ4eLhmz56t++67r1zj8ng8crlcys/PV1hYWAVnBQAAakJ5P78D5szS2bNntXXrVqWkpPi0p6SkaMOGDaX2yc7O9qvv2bOntmzZonPnzpXa5+TJkzp37pwaNmxYOQMHAAABLaimB1BeR44cUVFRkSIjI33aIyMj5Xa7S+3jdrtLrS8sLNSRI0fUtGlTvz4TJkxQs2bNdPvtt5c5ljNnzujMmTPe9x6PpyJTAQAAASRgziyVcDgcPu+NMX5tl6ovrV2SZsyYoTfeeENLlixRaGhomfvMyMiQy+Xyvpo3b16RKQAAgAASMGEpIiJCtWrV8juLlJeX53f2qERUVFSp9UFBQWrUqJFP++9//3tNnTpVq1atUocOHaxjmThxovLz872vQ4cOXcaMAABAIAiYsBQSEqL4+HitXr3ap3316tXq1q1bqX0SExP96letWqXOnTsrODjY2/b888/r2Wef1cqVK9W5c+dLjsXpdCosLMznBQAArk0BE5YkaezYsVqwYIEWLlyonJwcjRkzRgcPHlRaWpqk82d8LvwGW1pamr766iuNHTtWOTk5WrhwoTIzMzVu3DhvzYwZM/T0009r4cKFatmypdxut9xut06cOFHt8wMAAFefgLnBW5IGDx6so0ePavLkycrNzVW7du20YsUKtWjRQpKUm5vr88ylmJgYrVixQmPGjNGcOXMUHR2tF198UYMGDfLWzJ07V2fPntUvfvELn2NNmjRJ6enp1TIvAABw9Qqo5yxdrXjOEgAAgeeae84SAABATSAsAQAAWBCWAAAALAhLAAAAFoQlAAAAC8ISAACABWEJAADAgrAEAABgQVgCAACwICwBAABYEJYAAAAsCEsAAAAWhCUAAAALwhIAAIAFYQkAAMCCsAQAAGBBWAIAALAgLAEAAFgQlgAAACwISwAAABaEJQAAAAvCEgAAgAVhCQAAwIKwBAAAYEFYAgAAsCAsAQAAWBCWAAAALAhLAAAAFoQlAAAAC8ISAACABWEJAADAgrAEAABgQVgCAACwICwBAABYEJYAAAAsCEsAAAAWhCUAAAALwhIAAIAFYQkAAMCCsAQAAGBBWAIAALAgLAEAAFgQlgAAACwISwAAABaEJQAAAAvCEgAAgAVhCQAAwIKwBAAAYEFYAgAAsCAsAQAAWBCWAAAALAhLAAAAFoQlAAAAC8ISAACARdDldCoqKtLSpUuVk5Mjh8OhNm3aqH///goKuqzdAQAAXLUqnG4+//xz9evXT263W7GxsZKkf/zjH2rcuLGWL1+u9u3bV/ogAQAAakqFL8MNHz5cN998s77++mt9+umn+vTTT3Xo0CF16NBBv/rVr6pijAAAADWmwmFpx44dysjIUHh4uLctPDxcU6ZM0fbt2ytzbKWaO3euYmJiFBoaqvj4eK1fv95av27dOsXHxys0NFStWrXSvHnz/GoWL16suLg4OZ1OxcXFaenSpVU1fAAAEGAqHJZiY2N1+PBhv/a8vDzddNNNlTKosrz11lsaPXq0nnrqKW3btk1JSUnq3bu3Dh48WGr9/v371adPHyUlJWnbtm168sknNWrUKC1evNhbk52drcGDBys1NVU7duxQamqq7r77bm3atKlK5wIAAAKDwxhjKtJhxYoVGj9+vNLT09W1a1dJ0saNGzV58mRNmzZNt956q7c2LCysUgebkJCgTp066eWXX/a2tW3bVv3791dGRoZf/RNPPKHly5crJyfH25aWlqYdO3YoOztbkjR48GB5PB69//773ppevXopPDxcb7zxRrnG5fF45HK5lJ+fX+lzBgAAVaO8n98VvsH7zjvvlCTdfffdcjgckqSSvNW3b1/ve4fDoaKiogoPvCxnz57V1q1bNWHCBJ/2lJQUbdiwodQ+2dnZSklJ8Wnr2bOnMjMzde7cOQUHBys7O1tjxozxq5k1a1aZYzlz5ozOnDnjfe/xeCo4GwAAECgqHJaysrLK3Pbpp5+qU6dOVzSgshw5ckRFRUWKjIz0aY+MjJTb7S61j9vtLrW+sLBQR44cUdOmTcusKWufkpSRkaFnnnnmMmcCAAACSYXDUnJyss/7/Px8LVq0SAsWLNCOHTsq9WxSaUrOZpUoOYtVkfqL2yu6z4kTJ2rs2LHe9x6PR82bN7/04AEAQMC57KdIrlmzRgsXLtSSJUvUokULDRo0SJmZmZU5Nh8RERGqVauW3xmfvLw8vzNDJaKiokqtDwoKUqNGjaw1Ze1TkpxOp5xO5+VMAwAABJgKfRvu66+/1nPPPadWrVppyJAhCg8P17lz57R48WI999xz6tixY1WNUyEhIYqPj9fq1at92levXq1u3bqV2icxMdGvftWqVercubOCg4OtNWXtEwAA/LCUOyz16dNHcXFx2r17t1566SV98803eumll6pybH7Gjh2rBQsWaOHChcrJydGYMWN08OBBpaWlSTp/eey+++7z1qelpemrr77S2LFjlZOTo4ULFyozM1Pjxo3z1jz22GNatWqVpk+frj179mj69On64IMPNHr06GqdGwAAuDqV+zLcqlWrNGrUKP36179W69atq3JMZRo8eLCOHj2qyZMnKzc3V+3atdOKFSvUokULSVJubq7PM5diYmK0YsUKjRkzRnPmzFF0dLRefPFFDRo0yFvTrVs3vfnmm3r66af1X//1X7rxxhv11ltvKSEhodrnBwAArj7lfs5Sdna2Fi5cqLfffltt2rRRamqqBg8erOjoaO3YsUNxcXFVPdarFs9ZAgAg8JT387vcl+ESExM1f/585ebmasSIEXrzzTfVrFkzFRcXa/Xq1SooKKiUgQMAAFxNKvwE7wvt3btXmZmZ+vOf/6zjx4+rR48eWr58eWWOLyBwZgkAgMBT6WeWShMbG6sZM2bo66+/LvefBgEAAAgkV3RmCedxZgkAgMBTLWeWAAAArnWEJQAAAAvCEgAAgAVhCQAAwIKwBAAAYEFYAgAAsCAsAQAAWBCWAAAALAhLAAAAFoQlAAAAC8ISAACABWEJAADAgrAEAABgQVgCAACwICwBAABYEJYAAAAsCEsAAAAWhCUAAAALwhIAAIAFYQkAAMCCsAQAAGBBWAIAALAgLAEAAFgQlgAAACwISwAAABaEJQAAAAvCEgAAgAVhCQAAwIKwBAAAYEFYAgAAsCAsAQAAWBCWAAAALAhLAAAAFoQlAAAAC8ISAACABWEJAADAgrAEAABgQVgCAACwICwBAABYEJYAAAAsCEsAAAAWhCUAAAALwhIAAIAFYQkAAMCCsAQAAGBBWAIAALAgLAEAAFgQlgAAACwISwAAABaEJQAAAAvCEgAAgAVhCQAAwCJgwtKxY8eUmpoql8sll8ul1NRUHT9+3NrHGKP09HRFR0erdu3a6t69u3bt2uXd/t133+nRRx9VbGys6tSpoxtuuEGjRo1Sfn5+Fc8GAAAEioAJS/fee6+2b9+ulStXauXKldq+fbtSU1OtfWbMmKGZM2dq9uzZ+uSTTxQVFaUePXqooKBAkvTNN9/om2++0e9//3vt3LlTr776qlauXKlhw4ZVx5QAAEAAcBhjTE0P4lJycnIUFxenjRs3KiEhQZK0ceNGJSYmas+ePYqNjfXrY4xRdHS0Ro8erSeeeEKSdObMGUVGRmr69OkaMWJEqcd65513NHToUH3//fcKCgoq1/g8Ho9cLpfy8/MVFhZ2mbMEAADVqbyf3wFxZik7O1sul8sblCSpa9eucrlc2rBhQ6l99u/fL7fbrZSUFG+b0+lUcnJymX0keRfMFpTOnDkjj8fj8wIAANemgAhLbrdbTZo08Wtv0qSJ3G53mX0kKTIy0qc9MjKyzD5Hjx7Vs88+W+ZZpxIZGRnee6dcLpeaN29enmkAAIAAVKNhKT09XQ6Hw/rasmWLJMnhcPj1N8aU2n6hi7eX1cfj8eiOO+5QXFycJk2aZN3nxIkTlZ+f730dOnToUlMFAAABqnw35VSRRx55RPfcc4+1pmXLlvrss890+PBhv23ffvut35mjElFRUZLOn2Fq2rSptz0vL8+vT0FBgXr16qV69epp6dKlCg4Oto7J6XTK6XRaawAAwLWhRsNSRESEIiIiLlmXmJio/Px8bd68WV26dJEkbdq0Sfn5+erWrVupfWJiYhQVFaXVq1erY8eOkqSzZ89q3bp1mj59urfO4/GoZ8+ecjqdWr58uUJDQythZgAA4FoREPcstW3bVr169dLDDz+sjRs3auPGjXr44Yd15513+nwTrk2bNlq6dKmk85ffRo8eralTp2rp0qX6/PPP9cADD6hOnTq69957JZ0/o5SSkqLvv/9emZmZ8ng8crvdcrvdKioqqpG5AgCAq0uNnlmqiEWLFmnUqFHeb7f9/Oc/1+zZs31q9u7d6/NAyfHjx+vUqVMaOXKkjh07poSEBK1atUr169eXJG3dulWbNm2SJN10000++9q/f79atmxZhTMCAACBICCes3S14zlLAAAEnmvqOUsAAAA1hbAEAABgQVgCAACwICwBAABYEJYAAAAsCEsAAAAWhCUAAAALwhIAAIAFYQkAAMCCsAQAAGBBWAIAALAgLAEAAFgQlgAAACwISwAAABaEJQAAAAvCEgAAgAVhCQAAwIKwBAAAYEFYAgAAsCAsAQAAWBCWAAAALAhLAAAAFoQlAAAAC8ISAACABWEJAADAgrAEAABgQVgCAACwICwBAABYEJYAAAAsCEsAAAAWhCUAAAALwhIAAIAFYQkAAMCCsAQAAGBBWAIAALAgLAEAAFgQlgAAACwISwAAABaEJQAAAAvCEgAAgAVhCQAAwIKwBAAAYEFYAgAAsCAsAQAAWBCWAAAALAhLAAAAFoQlAAAAC8ISAACABWEJAADAgrAEAABgQVgCAACwICwBAABYEJYAAAAsCEsAAAAWhCUAAAALwhIAAIBFwISlY8eOKTU1VS6XSy6XS6mpqTp+/Li1jzFG6enpio6OVu3atdW9e3ft2rWrzNrevXvL4XBo2bJllT8BAAAQkAImLN17773avn27Vq5cqZUrV2r79u1KTU219pkxY4Zmzpyp2bNn65NPPlFUVJR69OihgoICv9pZs2bJ4XBU1fABAECACqrpAZRHTk6OVq5cqY0bNyohIUGSNH/+fCUmJmrv3r2KjY3162OM0axZs/TUU09p4MCBkqTXXntNkZGRev311zVixAhv7Y4dOzRz5kx98sknatq0afVMCgAABISAOLOUnZ0tl8vlDUqS1LVrV7lcLm3YsKHUPvv375fb7VZKSoq3zel0Kjk52afPyZMnNWTIEM2ePVtRUVHlGs+ZM2fk8Xh8XgAA4NoUEGHJ7XarSZMmfu1NmjSR2+0us48kRUZG+rRHRkb69BkzZoy6deumfv36lXs8GRkZ3nunXC6XmjdvXu6+AAAgsNRoWEpPT5fD4bC+tmzZIkml3k9kjLnkfUYXb7+wz/Lly7VmzRrNmjWrQuOeOHGi8vPzva9Dhw5VqD8AAAgcNXrP0iOPPKJ77rnHWtOyZUt99tlnOnz4sN+2b7/91u/MUYmSS2put9vnPqS8vDxvnzVr1ujLL79UgwYNfPoOGjRISUlJWrt2ban7djqdcjqd1nEDAIBrQ42GpYiICEVERFyyLjExUfn5+dq8ebO6dOkiSdq0aZPy8/PVrVu3UvvExMQoKipKq1evVseOHSVJZ8+e1bp16zR9+nRJ0oQJEzR8+HCffu3bt9cf/vAH9e3b90qmBgAArhEB8W24tm3bqlevXnr44Yf1P//zP5KkX/3qV7rzzjt9vgnXpk0bZWRkaMCAAXI4HBo9erSmTp2q1q1bq3Xr1po6darq1Kmje++9V9L5s0+l3dR9ww03KCYmpnomBwAArmoBEZYkadGiRRo1apT3220///nPNXv2bJ+avXv3Kj8/3/t+/PjxOnXqlEaOHKljx44pISFBq1atUv369at17AAAIHA5jDGmpgcR6Dwej1wul/Lz8xUWFlbTwwEAAOVQ3s/vgHh0AAAAQE0hLAEAAFgQlgAAACwISwAAABaEJQAAAAvCEgAAgAVhCQAAwIKwBAAAYEFYAgAAsCAsAQAAWBCWAAAALAhLAAAAFoQlAAAAC8ISAACABWEJAADAgrAEAABgQVgCAACwICwBAABYEJYAAAAsCEsAAAAWhCUAAAALwhIAAIAFYQkAAMCCsAQAAGBBWAIAALAgLAEAAFgQlgAAACwISwAAABaEJQAAAAvCEgAAgAVhCQAAwIKwBAAAYEFYAgAAsCAsAQAAWBCWAAAALAhLAAAAFoQlAAAAC8ISAACABWEJAADAgrAEAABgQVgCAACwICwBAABYEJYAAAAsgmp6ANcCY4wkyePx1PBIAABAeZV8bpd8jpeFsFQJCgoKJEnNmzev4ZEAAICKKigokMvlKnO7w1wqTuGSiouL9c0336h+/fpyOBw1PZwa5/F41Lx5cx06dEhhYWE1PZxrFutcPVjn6sE6Vw/W2ZcxRgUFBYqOjtZ115V9ZxJnlirBddddp+uvv76mh3HVCQsL4/+M1YB1rh6sc/VgnasH6/z/2c4oleAGbwAAAAvCEgAAgAVhCZXO6XRq0qRJcjqdNT2UaxrrXD1Y5+rBOlcP1vnycIM3AACABWeWAAAALAhLAAAAFoQlAAAAC8ISAACABWEJFXbs2DGlpqbK5XLJ5XIpNTVVx48ft/Yxxig9PV3R0dGqXbu2unfvrl27dpVZ27t3bzkcDi1btqzyJxAgqmKdv/vuOz366KOKjY1VnTp1dMMNN2jUqFHKz8+v4tlcPebOnauYmBiFhoYqPj5e69evt9avW7dO8fHxCg0NVatWrTRv3jy/msWLFysuLk5Op1NxcXFaunRpVQ0/YFT2Os+fP19JSUkKDw9XeHi4br/9dm3evLkqpxAwquJ3usSbb74ph8Oh/v37V/KoA4wBKqhXr16mXbt2ZsOGDWbDhg2mXbt25s4777T2mTZtmqlfv75ZvHix2blzpxk8eLBp2rSp8Xg8frUzZ840vXv3NpLM0qVLq2gWV7+qWOedO3eagQMHmuXLl5svvvjCfPjhh6Z169Zm0KBB1TGlGvfmm2+a4OBgM3/+fLN7927z2GOPmbp165qvvvqq1Pp9+/aZOnXqmMcee8zs3r3bzJ8/3wQHB5t3333XW7NhwwZTq1YtM3XqVJOTk2OmTp1qgoKCzMaNG6trWledqljne++918yZM8ds27bN5OTkmAcffNC4XC7z9ddfV9e0rkpVsdYlDhw4YJo1a2aSkpJMv379qngmVzfCEipk9+7dRpLPB0F2draRZPbs2VNqn+LiYhMVFWWmTZvmbTt9+rRxuVxm3rx5PrXbt283119/vcnNzf1Bh6WqXucLvf322yYkJMScO3eu8iZwlerSpYtJS0vzaWvTpo2ZMGFCqfXjx483bdq08WkbMWKE6dq1q/f93XffbXr16uVT07NnT3PPPfdU0qgDT1Ws88UKCwtN/fr1zWuvvXblAw5gVbXWhYWF5ic/+YlZsGCBuf/++3/wYYnLcKiQ7OxsuVwuJSQkeNu6du0ql8ulDRs2lNpn//79crvdSklJ8bY5nU4lJyf79Dl58qSGDBmi2bNnKyoqquomEQCqcp0vlp+fr7CwMAUFXdt/KvLs2bPaunWrz/pIUkpKSpnrk52d7Vffs2dPbdmyRefOnbPW2Nb8WlZV63yxkydP6ty5c2rYsGHlDDwAVeVaT548WY0bN9awYcMqf+ABiLCECnG73WrSpIlfe5MmTeR2u8vsI0mRkZE+7ZGRkT59xowZo27duqlfv36VOOLAVJXrfKGjR4/q2Wef1YgRI65wxFe/I0eOqKioqELr43a7S60vLCzUkSNHrDVl7fNaV1XrfLEJEyaoWbNmuv322ytn4AGoqtb6448/VmZmpubPn181Aw9AhCVIktLT0+VwOKyvLVu2SJIcDodff2NMqe0Xunj7hX2WL1+uNWvWaNasWZUzoatUTa/zhTwej+644w7FxcVp0qRJVzCrwFLe9bHVX9xe0X3+EFTFOpeYMWOG3njjDS1ZskShoaGVMNrAVplrXVBQoKFDh2r+/PmKiIio/MEGqGv7vDvK7ZFHHtE999xjrWnZsqU+++wzHT582G/bt99+6/evlRIll9TcbreaNm3qbc/Ly/P2WbNmjb788ks1aNDAp++gQYOUlJSktWvXVmA2V6+aXucSBQUF6tWrl+rVq6elS5cqODi4olMJOBEREapVq5bfv7hLW58SUVFRpdYHBQWpUaNG1pqy9nmtq6p1LvH73/9eU6dO1QcffKAOHTpU7uADTFWs9a5du3TgwAH17dvXu724uFiSFBQUpL179+rGG2+s5JkEgBq6VwoBquTG402bNnnbNm7cWK4bj6dPn+5tO3PmjM+Nx7m5uWbnzp0+L0nmhRdeMPv27avaSV2FqmqdjTEmPz/fdO3a1SQnJ5vvv/++6iZxFerSpYv59a9/7dPWtm1b682wbdu29WlLS0vzu8G7d+/ePjW9evX6wd/gXdnrbIwxM2bMMGFhYSY7O7tyBxzAKnutT5065fff4n79+pnbbrvN7Ny505w5c6ZqJnKVIyyhwnr16mU6dOhgsrOzTXZ2tmnfvr3fV9pjY2PNkiVLvO+nTZtmXC6XWbJkidm5c6cZMmRImY8OKKEf8LfhjKmadfZ4PCYhIcG0b9/efPHFFyY3N9f7KiwsrNb51YSSr1lnZmaa3bt3m9GjR5u6deuaAwcOGGOMmTBhgklNTfXWl3zNesyYMWb37t0mMzPT72vWH3/8salVq5aZNm2aycnJMdOmTePRAVWwztOnTzchISHm3Xff9fm9LSgoqPb5XU2qYq0vxrfhCEu4DEePHjW//OUvTf369U39+vXNL3/5S3Ps2DGfGknmlVde8b4vLi42kyZNMlFRUcbpdJr//M//NDt37rQe54celqpinbOysoykUl/79++vnonVsDlz5pgWLVqYkJAQ06lTJ7Nu3Trvtvvvv98kJyf71K9du9Z07NjRhISEmJYtW5qXX37Zb5/vvPOOiY2NNcHBwaZNmzZm8eLFVT2Nq15lr3OLFi1K/b2dNGlSNczm6lYVv9MXIiwZ4zDm33d2AQAAwA/fhgMAALAgLAEAAFgQlgAAACwISwAAABaEJQAAAAvCEgAAgAVhCQAAwIKwBOAHy+12q0ePHqpbt67f3yUEgBL8IV0AP1h/+MMflJubq+3bt8vlctX0cABcpQhLAH6wvvzyS8XHx6t169Y1PRQAVzEuwwG4ZnXv3l2jRo3S+PHj1bBhQ0VFRSk9PV2S1LJlSy1evFh/+tOf5HA49MADD0iSZs6cqfbt26tu3bpq3ry5Ro4cqRMnTvjs9+OPP1ZycrLq1Kmj8PBw9ezZU8eOHZMkGWM0Y8YMtWrVSrVr19aPfvQjvfvuu9U5bQCVjDNLAK5pr732msaOHatNmzYpOztbDzzwgH7yk5/ok08+0X333aewsDC98MILql27tiTpuuuu04svvqiWLVtq//79GjlypMaPH6+5c+dKkrZv366f/exneuihh/Tiiy8qKChIWVlZKioqkiQ9/fTTWrJkiV5++WW1bt1a//d//6ehQ4eqcePGSk5OrrF1AHD5+EO6AK5Z3bt3V1FRkdavX+9t69Kli2677TZNmzZN/fv3V4MGDfTqq6+WuY933nlHv/71r3XkyBFJ0r333quDBw/qo48+8qv9/vvvFRERoTVr1igxMdHbPnz4cJ08eVKvv/565U0OQLXhzBKAa1qHDh183jdt2lR5eXll1mdlZWnq1KnavXu3PB6PCgsLdfr0aX3//feqW7eutm/frrvuuqvUvrt379bp06fVo0cPn/azZ8+qY8eOVz4ZADWCsATgmhYcHOzz3uFwqLi4uNTar776Sn369FFaWpqeffZZNWzYUB999JGGDRumc+fOSZL3cl1pSvb7t7/9Tc2aNfPZ5nQ6r2QaAGoQYQkA/m3Lli0qLCzUf//3f+u6685//+Xtt9/2qenQoYM+/PBDPfPMM3794+Li5HQ6dfDgQe5PAq4hhCUA+Lcbb7xRhYWFeumll9S3b199/PHHmjdvnk/NxIkT1b59e40cOVJpaWkKCQlRVlaW7rrrLkVERGjcuHEaM2aMiouLdeutt8rj8WjDhg2qV6+e7r///hqaGYArwaMDAODfbrnlFs2cOVPTp09Xu3bttGjRImVkZPjU/Md//IdWrVqlHTt2qEuXLkpMTNR7772noKDz//Z89tln9bvf/U4ZGRlq27atevbsqb/+9a+KiYmpiSkBqAR8Gw4AAMCCM0sAAAAWhCUAAAALwhIAAIAFYQkAAMCCsAQAAGBBWAIAALAgLAEAAFgQlgAAACwISwAAABaEJQAAAAvCEgAAgAVhCQAAwOL/ATnGLa9zzTNlAAAAAElFTkSuQmCC",
+      "text/plain": [
+       "<Figure size 640x480 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "transport_model.mesh.Ap.isel(time=5000).plot()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 34,
+   "id": "d0c630a5-339a-495d-a2a0-91e4735869e5",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[<matplotlib.lines.Line2D at 0x1c1ef9e3dd0>]"
+      ]
+     },
+     "execution_count": 34,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAkoAAAHFCAYAAAANLdYJAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjguNCwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8fJSN1AAAACXBIWXMAAA9hAAAPYQGoP6dpAABIw0lEQVR4nO39e1iVVeL//7+2yFkgEQR3ApLHEicTHdI84KiklYqVmZVKmaPvRHPId2XmqB2kmj4dHW2yEjt4yFHST1rKJxVzHBs1MTEzVAwN0FBjIxkort8ffdm/dnAjmMphno/ruq+rve51r3utvbD9Yt33vrEZY4wAAABQQaPa7gAAAEBdRVACAACwQFACAACwQFACAACwQFACAACwQFACAACwQFACAACwQFACAACwQFACAACwQFBCvbVs2TJ17NhR3t7estlsysjIqO0u1XmHDx+WzWardFu6dGm12jh9+rSmTJkiu90uLy8vde7c2fLYL7/8Uv3791eTJk101VVX6fbbb9ehQ4cq1MvPz1diYqKuueYaeXt7KyIiQmPHjlVOTs7vGu/FqO74EhISKn0fO3To8LvO//rrr6tNmzby8PCQzWbTjz/++Lva+2/xn//8RzfffLP8/PzUpEkT9e3bV//6178q1KvpvL3++uvq0KGDPD09FRkZqdmzZ+vs2bPV6tPZs2c1e/ZstWrVSp6enurQoYNef/313zVOXHmNa7sDwMX44YcfNGrUKA0cOFDz5s2Tp6en2rVrV9vdqjcmTZqke+65x6Wsbdu21Tr29ttv1/bt2/Xcc8+pXbt2Wrx4sUaOHKnz58+7tPnNN98oNjZWnTt31ocffqiff/5Zf/3rX9WrVy9lZGQoODhYklRSUqLevXvr1KlTmj17tq677jrt379fM2fO1Lp167Rv3z75+fldusFfovFJkre3tzZs2FCh7GJlZGRo8uTJevDBBzVmzBg1btz4io69vtq+fbt69+6tP/7xj3rvvfdkjNELL7ygfv36aePGjerevbtL/erO27PPPqsZM2bo8ccfV1xcnLZv364nn3xS33//vd58880L9uuhhx7Se++9p6efflrdunXTunXr9PDDD6uoqEhPPPHE7xs0rhwD1ENbtmwxksyyZctquyv1SnZ2tpFk/va3v13U8WvWrDGSzOLFi13KBwwYYOx2uzl37pyzbPjw4SYoKMgUFhY6yw4fPmzc3d3No48+6ixLS0szksxbb73l0ubixYuNJLNy5cqL6utvjRkzxvTp06fKOjUZ35gxY4yvr+8l6Vu5999/30gyX3zxxSVtt6G7+eabTUhIiCkuLnaWORwOExQUZHr06OFSt7rzVlBQYLy8vMyf//xnl/Jnn33W2Gw2s3fv3iqPz8zMNDabzcyZM8elfNy4ccbb29ucOHHign1A3cClN9Q7CQkJ6tmzpyRpxIgRstlsio2NlSTt2LFDd999t1q1aiVvb2+1atVKI0eO1HfffVehne+//15//vOfFRYWJg8PD9ntdt155506duyYs47D4dDUqVMVGRkpDw8PXX311ZoyZYqKi4ur3d+CggKFhYWpR48eLkv2X3/9tXx9fTVq1KiLfCeuvNTUVDVp0kTDhw93Kb///vuVm5urL774QpJ07tw5ffzxx7rjjjvk7+/vrBcREaG+ffsqNTXVWebu7i5JCggIcGnzqquukiR5eXm5lO/YsUNDhgxRYGCgvLy8dMMNN+jDDz+8ouO7HGJjY3XfffdJkmJiYmSz2ZSQkCBJSktL09ChQ9WyZUt5eXmpTZs2Gj9+vAoKCiq0880332jkyJEKCQmRp6enwsPDNXr0aJWUlDjr5Ofna/z48WrZsqU8PDycl5TOnTtX7f4+/fTTaty4sY4cOVJh3wMPPKBmzZrp559/ruG7cHH+9a9/KTY2Vj4+Ps4yPz8/9e7dW1u3blVeXl6N2/z000/1888/6/7773cpv//++2WM0UcffVTl8R999JGMMZUef+bMGX366ac17hNqB0EJ9c6MGTP097//XZI0Z84c/fvf/9a8efMk/XIPTvv27fXKK69o3bp1ev7555WXl6du3bq5fKh8//336tatm1JTU5WUlKRPPvlEr7zyigICAnTq1ClJ0k8//aQ+ffpo0aJFmjx5sj755BM99thjSklJ0ZAhQ2SMqVZ/g4KCtHTpUm3fvl2PPfaYs+3hw4crPDxcb7zxRpXHG2N07ty5am3V9dxzz8nDw0M+Pj7q2bOnVq9eXa3jMjMzde2116pxY9er9n/4wx+c+yXp4MGDOnPmjLP8t3UPHDjg/BC96aabFB0drVmzZmn79u06ffq0vvzySz3xxBPq0qWL+vfv7zx248aNuummm/Tjjz/qjTfe0KpVq9S5c2eNGDFCKSkp1R7/7x1fuTNnzig0NFRubm5q2bKlEhMTdfLkyYs697x58/Tkk09KkhYuXKh///vfmjFjhqRf3s/u3btr/vz5Wr9+vf7617/qiy++UM+ePV3C9+7du9WtWzdt27ZNTz31lD755BMlJyerpKREpaWlkn4JSX/84x+1bt06/fWvf9Unn3yisWPHKjk5WePGjat2f8ePH6/GjRvrH//4h0v5yZMntXTpUo0dO7ZCyP21S/lzXVpaKk9Pzwrl5WV79uxxKa/OvJXPdadOnVzKW7RooaCgoAo/C7+VmZmp4OBghYaGupRb/SyhDqvV9SzgIm3cuNFIMsuXL6+y3rlz58zp06eNr6+vefXVV53lDzzwgHF3dzdff/215bHJycmmUaNGZvv27S7l//znP40ks3bt2hr1+fnnnzeSTGpqqhkzZozx9vY2X3311QWPKx9rdbbs7Owq28rNzTXjxo0zH374ofn888/NBx98YG688UYjySxYsOCCfWnbtq25+eabK21XkvMyw7/+9S8jySxZsqRC3Tlz5hhJJjc311nmcDjM4MGDXcYSGxtb4fJEhw4dzA033GDOnj3rUn7bbbeZFi1amLKyMmfZ2bNnXbbRo0eb3r17Vyg/f/58jcdnjDEvvfSSeemll8z69evN+vXrzfTp042Pj4/p0KGDKSoqutBbWamFCxcaSRV+5n7t/Pnz5uzZs+a7774zksyqVauc+/70pz+Zq666yhw/ftzy+PHjx5smTZqY7777zqX8xRdfNJIueEnp18aMGWOaN29uSkpKnGXPP/+8adSo0QV/FsvHWp3tQjp37mzatWtXYf6vueaaCpdSqztv48aNM56enpWer127diYuLq7KPg0YMMC0b9++0n0eHh4VLumh7uJmbjQop0+f1tNPP60VK1bo8OHDKisrc+7bt2+f878/+eQT9e3bV9dee61lWx9//LGioqLUuXNnl99qb775ZtlsNm3atEmDBg2qdt/+93//V5s3b9bIkSP1888/66233qrw22ploqOjtX379mqdw263V7m/RYsWFW5CHT58uGJiYvT4448rISGhwmrKb9lstmrvq07ds2fPasSIEcrMzNSCBQvUvn17ZWdn65lnntGAAQO0YcMGBQQE6MCBA/rmm2/04osvSpLLnNxyyy36+OOPtX//fl177bU6fPiwIiMjKz1v+aW+chs3bnReuq3J+P7yl7+47BswYIBuuOEG3XnnnVqwYEGF/b/H8ePH9de//lVr1qxRbm6uzp8/79y3b98+DRkyRD/99JPS09M1duxY543ylfn444/Vt29f2e12l/dw0KBBmjp1qtLT03XddddVq18PP/ywFi1apOXLl+vee+/V+fPnNX/+fN16661q1apVlccOHjy42j/XFzJp0iSNHTtWiYmJmj59us6fP6/Zs2c7L7k3avT/v3hSk3mryc96TetU53jUDQQlNCj33HOPPvvsM82YMUPdunWTv7+/bDabbrnlFp05c8ZZ74cfflDLli2rbOvYsWM6cOBAhQ/WcpXdH1KV8ntO1qxZo9DQ0Grfm9SkSRN17ty5WnUvFHIq4+7urhEjRujxxx9XVlZWleGxWbNmOnHiRIXy8ssWgYGBznqSLOvabDbnPUhvv/22PvnkE23fvl1du3aVJPXq1Us9e/ZU69at9corr2jmzJnOe8emTp2qqVOnVtq/8jmx2+0VPoRnz56t3NzcCpeK2rdvX+PxWRk2bJh8fX21bdu2KuvVxPnz5xUXF6fc3FzNmDFDnTp1kq+vr86fP68bb7zR+XN96tQplZWVVevn+v/+3/97SX6ub7jhBvXq1Ut///vfde+99+rjjz/W4cOHK7zHlQkMDKxwX9rFeuCBB/TDDz/omWee0fz58yVJ3bt319SpU/X888/r6quvrvL4yuat/B6rn376yeXeJ+mXn4fo6Ogq22zWrFmljywpLi5WaWnpBX+WUHcQlNBgFBYW6uOPP9bMmTP1+OOPO8tLSkoq3H8QHByso0ePVtleUFCQvL299c4771jur4m8vDxNnDhRnTt31t69ezV16lS99tprFzwuPT1dffv2rdY5srOzL/ibfGXM/3e/1a9/865Mp06dtGTJEp07d84llJXfAxIVFSVJat26tby9vSvcG1Jet02bNs77VzIyMuTm5qYuXbq41LvmmmvUrFkz570c5e/3tGnTdPvtt1fav/LQ4+Hh4Qxd5Zo1a6aioqIK5RczvqoYYy74PtZEZmamdu/erZSUFI0ZM8ZZfuDAAZd6gYGBcnNzq9bP9R/+8Ac9++yzle6/0Krkb02ePFnDhw/Xl19+qblz56pdu3YaMGDABY9btGhRhRudrZhq3A/42GOPacqUKcrKypKfn58iIiI0fvx4+fr6XjDUlJ/j1/NWvtq7Z88excTEOMvz8/NVUFBwwZ+FTp06aenSpcrPz3e5T6kmP0uoGwhKaDBsNpuMMRVu6nzrrbdcLsFJv1xmeO+997R//36XFYVfu+222zRnzhw1a9bM8jJOdZWVlWnkyJGy2Wz65JNP9MEHH2jq1KmKjY21/NAvdykvvVXm7NmzWrZsmYKCgtSmTZsq6w4bNkwLFizQihUrNGLECGf5okWLZLfbnR8ojRs31uDBg7Vy5Uq98MILzmcB5eTkaOPGjS6XN+x2u8rKyrR9+3aXD6Rvv/1WJ06ccK6QtG/fXm3bttXu3bs1Z86cGo+zOqo7Piv//Oc/9dNPP+nGG2+8ZH0qv0Tz25/r367aeHt7q0+fPlq+fLmeffZZyyB/2223ae3atWrdurWaNm36u/s3bNgwhYeH65FHHlF6erpefvnlal1WupSX3sp5eno6A0hOTo6WLVumcePGXfDZVpXN28CBA+Xl5aWUlBSXeU9JSZHNZlN8fHyVbQ4dOlRPPvmkFi1a5PwSR/nx3t7eGjhw4EWMELWiVu+QAi6S1c3cvXv3NoGBgWbBggUmLS3NPPnkk6ZFixbmqquuMmPGjHHWO3r0qGnRooVp3ry5eeWVV8xnn31mVqxYYcaNG2f27dtnjDHm9OnT5oYbbjAtW7Y0/+f//B+TlpZm1q1bZxYsWGCGDx9utm3bVu3+Tp8+3TRq1Mj8v//3/5xlgwcPNldddZU5dOjQ73szauAvf/mLSUxMNEuWLDEbN2407777runWrZuRZBYuXOhSd/bs2cbNzc1s2rTJpXzAgAGmadOm5s033zQbNmww48aNM5LM+++/71Jv3759pkmTJqZ3795m7dq1ZuXKlSYqKsrY7XaXm41zcnLMVVddZa6++mozf/58s2HDBvPWW2+Za665xvj6+ppvvvnGWXfDhg3G09PTxMXFmcWLF5v09HSTmppq5syZY+68884qx16d5yhVd3yHDx82PXr0MK+99ppZu3at+eSTT8zjjz9uvLy8TMeOHc3p06dd2uzTp0+1bkqu7Gbu0tJS07p1axMREWEWL15sPv30UzNx4kTTrl07I8nMnDnTWTcjI8M0adLEXHPNNc7+L1myxIwcOdI4HA5jzC83pkdERJgOHTqYefPmmc8++8ysWbPG/P3vfze33nqrOXLkyAX7+VvlX1Tw9fU1P/74Y42P/7327NljZs2aZT7++GOTlpZmXnzxRRMUFGS6du3qcoN2TeftmWeeMTabzTzxxBNm06ZN5m9/+5vx9PQ048aNc6m3aNEi4+bmZhYtWuRS/uCDDxpPT0/zt7/9zWzatMk88cQTxmazmWefffbyvRm45AhKqJesgtLRo0fNHXfcYZo2bWr8/PzMwIEDTWZmpomIiHAJSsYYc+TIEfPAAw+Y0NBQ4+7ubux2u7nrrrvMsWPHnHVOnz5tnnzySdO+fXvj4eFhAgICTKdOncxf/vIXk5+fX62+rl+/3jRq1MjlA80YY06cOGHCw8NNt27dXL41dDm9/fbb5o9//KMJDAw0jRs3Nk2bNjU333yzWbduXYW6M2fONJLMxo0bXcqLiorM5MmTTWhoqPHw8DB/+MMfKv12mzHG7Nixw/Tr18/4+PgYf39/Ex8fbw4cOFChXlZWlhk1apRp1aqV8fT0NOHh4WbEiBGVfgNr9+7d5q677jLNmzc37u7uJjQ01PzpT38yb7zxRpVjr25Qqs74Tp48aYYNG2ZatWplvL29jYeHh2nbtq159NFHKw0K0dHRJjQ09ILntvrW29dff20GDBhg/Pz8TNOmTc3w4cNNTk5OhaBUXnf48OGmWbNmxsPDw4SHh5uEhATz888/O+v88MMPZvLkySYyMtK4u7ubwMBAEx0dbaZPn14hLFTH4cOHjSQzYcKEGh97Kezfv9/5S5KHh4dp06aNefLJJyuMpabzZowxr776qmnXrp3zvZw5c6YpLS11qVM+b7/9ZaO0tNTMnDnThIeHGw8PD9OuXTvz2muvXdKx4/KzGVPNh8EAAGqsqKhIgYGBeuWVVzRx4sTa7s5l8frrr2vy5MnKzMxUx44da7s7wCXFPUoAcBlt3rxZV199dY0e5lhf7Nq1S9nZ2Xrqqac0dOhQQhIaJFaUgN/h/PnzLs+0qczFfGUfqE1lZWVVftPMZrPJzc1NrVq1Un5+vnr16qX33nuvwlOogYaAoAT8DgkJCVq0aFGVdfgnhvomNjZW6enplvsjIiJ0+PDhK9choBYRlIDf4fDhwxd8QF9Vz+0B6qL9+/erqKjIcr+np2e1nioPNAQEJQAAAAuX7vGxAAAADQx3mV6k8+fPKzc3V35+fvxxQwAA6gljjIqKimS326v154YIShcpNzdXYWFhtd0NAABwEY4cOXLBPyItEZQuWvnfrjpy5Ij8/f1ruTcAAKA6HA6HwsLCnJ/jF0JQukjll9v8/f0JSgAA1DPVvW2Gm7kBAAAsEJQAAAAsEJQAAAAsEJQAAAAsEJQAAAAsEJQAAAAsEJQAAAAsEJQAAAAsEJQAAAAsEJQAAAAs1GpQSk5OVrdu3eTn56fmzZsrPj5e+/fvd6mzcuVK3XzzzQoKCpLNZlNGRkaFdkpKSjRp0iQFBQXJ19dXQ4YM0dGjRy94/nnz5ikyMlJeXl6Kjo7W559/fqmGBgAAGoBaDUrp6emaOHGitm3bprS0NJ07d05xcXEqLi521ikuLtZNN92k5557zrKdKVOmKDU1VUuXLtWWLVt0+vRp3XbbbSorK7M8ZtmyZZoyZYqmT5+uXbt2qVevXho0aJBycnIu6RgBAED9ZTPGmNruRLkffvhBzZs3V3p6unr37u2y7/Dhw4qMjNSuXbvUuXNnZ3lhYaGCg4P13nvvacSIEZKk3NxchYWFae3atbr55psrPVdMTIy6dOmi+fPnO8uuvfZaxcfHKzk5+YJ9dTgcCggIUGFhIX8UFwCAeqKmn9916h6lwsJCSVJgYGC1j9m5c6fOnj2ruLg4Z5ndbldUVJS2bt1a6TGlpaXauXOnyzGSFBcXZ3lMSUmJHA6HywYAABq2OhOUjDFKSkpSz549FRUVVe3j8vPz5eHhoaZNm7qUh4SEKD8/v9JjCgoKVFZWppCQkGofk5ycrICAAOcWFhZW7T4CAID6qc4EpcTERH311VdasmTJJWnPGCObzVZlnd/ur+qYadOmqbCw0LkdOXLkkvQTAADUXXUiKE2aNEmrV6/Wxo0b1bJlyxodGxoaqtLSUp06dcql/Pjx4xVWjMoFBQXJzc2twupRVcd4enrK39/fZQMAAA1brQYlY4wSExO1cuVKbdiwQZGRkTVuIzo6Wu7u7kpLS3OW5eXlKTMzUz169Kj0GA8PD0VHR7scI0lpaWmWxwAAgP8+jWvz5BMnTtTixYu1atUq+fn5OVd4AgIC5O3tLUk6efKkcnJylJubK0nO5yyFhoYqNDRUAQEBGjt2rB555BE1a9ZMgYGBmjp1qjp16qT+/fs7z9WvXz8NGzZMiYmJkqSkpCSNGjVKXbt2Vffu3fXmm28qJydHEyZMuJJvAQAAqMNqNSiVfzU/NjbWpXzhwoVKSEiQJK1evVr333+/c9/dd98tSZo5c6ZmzZolSXr55ZfVuHFj3XXXXTpz5oz69eunlJQUubm5OY87ePCgCgoKnK9HjBihEydO6KmnnlJeXp6ioqK0du1aRUREXIaRAgCA+qhOPUepPuE5SgAA1D/1+jlKAAAAdQlBCQAAwAJBCQAAwAJBCQAAwAJBCQAAwAJBCQAAwAJBCQAAwAJBCQAAwAJBCQAAwAJBCQAAwAJBCQAAwAJBCQAAwAJBCQAAwAJBCQAAwAJBCQAAwAJBCQAAwAJBCQAAwAJBCQAAwAJBCQAAwAJBCQAAwAJBCQAAwAJBCQAAwAJBCQAAwAJBCQAAwAJBCQAAwAJBCQAAwAJBCQAAwAJBCQAAwAJBCQAAwAJBCQAAwAJBCQAAwEKtBqXk5GR169ZNfn5+at68ueLj47V//36XOsYYzZo1S3a7Xd7e3oqNjdXevXud+w8fPiybzVbptnz5cstzz5o1q0L90NDQyzZWAABQ/9RqUEpPT9fEiRO1bds2paWl6dy5c4qLi1NxcbGzzgsvvKCXXnpJc+fO1fbt2xUaGqoBAwaoqKhIkhQWFqa8vDyXbfbs2fL19dWgQYOqPH/Hjh1djtuzZ89lHS8AAKhfGtfmyT/99FOX1wsXLlTz5s21c+dO9e7dW8YYvfLKK5o+fbpuv/12SdKiRYsUEhKixYsXa/z48XJzc6uwEpSamqoRI0aoSZMmVZ6/cePGrCIBAABLdeoepcLCQklSYGCgJCk7O1v5+fmKi4tz1vH09FSfPn20devWStvYuXOnMjIyNHbs2AueLysrS3a7XZGRkbr77rt16NAhy7olJSVyOBwuGwAAaNjqTFAyxigpKUk9e/ZUVFSUJCk/P1+SFBIS4lI3JCTEue+33n77bV177bXq0aNHleeLiYnRu+++q3Xr1mnBggXKz89Xjx49dOLEiUrrJycnKyAgwLmFhYXVdIgAAKCeqTNBKTExUV999ZWWLFlSYZ/NZnN5bYypUCZJZ86c0eLFi6u1mjRo0CDdcccd6tSpk/r37681a9ZI+uXSXmWmTZumwsJC53bkyJHqDAsAANRjtXqPUrlJkyZp9erV2rx5s1q2bOksL79/KD8/Xy1atHCWHz9+vMIqkyT985//1E8//aTRo0fXuA++vr7q1KmTsrKyKt3v6ekpT0/PGrcLAADqr1pdUTLGKDExUStXrtSGDRsUGRnpsj8yMlKhoaFKS0tzlpWWlio9Pb3SS2tvv/22hgwZouDg4Br3paSkRPv27XMJZAAA4L9brQaliRMn6v3339fixYvl5+en/Px85efn68yZM5J+ueQ2ZcoUzZkzR6mpqcrMzFRCQoJ8fHx0zz33uLR14MABbd68WQ8++GCl5+rXr5/mzp3rfD116lSlp6crOztbX3zxhe688045HA6NGTPm8g0YAADUK7V66W3+/PmSpNjYWJfyhQsXKiEhQZL06KOP6syZM3rooYd06tQpxcTEaP369fLz83M55p133tHVV1/t8g25Xzt48KAKCgqcr48ePaqRI0eqoKBAwcHBuvHGG7Vt2zZFRERcugECAIB6zWaMMbXdifrI4XAoICBAhYWF8vf3r+3uAACAaqjp53ed+dYbAABAXUNQAgAAsEBQAgAAsEBQAgAAsEBQAgAAsEBQAgAAsEBQAgAAsEBQAgAAsEBQAgAAsEBQAgAAsEBQAgAAsEBQAgAAsEBQAgAAsEBQAgAAsEBQAgAAsEBQAgAAsEBQAgAAsEBQAgAAsEBQAgAAsEBQAgAAsEBQAgAAsEBQAgAAsEBQAgAAsEBQAgAAsEBQAgAAsEBQAgAAsEBQAgAAsEBQAgAAsEBQAgAAsEBQAgAAsEBQAgAAsFCrQSk5OVndunWTn5+fmjdvrvj4eO3fv9+ljjFGs2bNkt1ul7e3t2JjY7V3716XOrGxsbLZbC7b3XfffcHzz5s3T5GRkfLy8lJ0dLQ+//zzSzo+AABQv9VqUEpPT9fEiRO1bds2paWl6dy5c4qLi1NxcbGzzgsvvKCXXnpJc+fO1fbt2xUaGqoBAwaoqKjIpa1x48YpLy/Puf3jH/+o8tzLli3TlClTNH36dO3atUu9evXSoEGDlJOTc1nGCgAA6h+bMcbUdifK/fDDD2revLnS09PVu3dvGWNkt9s1ZcoUPfbYY5KkkpIShYSE6Pnnn9f48eMl/bKi1LlzZ73yyivVPldMTIy6dOmi+fPnO8uuvfZaxcfHKzk5+YLHOxwOBQQEqLCwUP7+/jUbKAAAqBU1/fyuU/coFRYWSpICAwMlSdnZ2crPz1dcXJyzjqenp/r06aOtW7e6HPvBBx8oKChIHTt21NSpUyusOP1aaWmpdu7c6dKuJMXFxVVot1xJSYkcDofLBgAAGrbGtd2BcsYYJSUlqWfPnoqKipIk5efnS5JCQkJc6oaEhOi7775zvr733nsVGRmp0NBQZWZmatq0adq9e7fS0tIqPVdBQYHKysoqbbf8nL+VnJys2bNnX/T4AABA/VNnglJiYqK++uorbdmypcI+m83m8toY41I2btw4539HRUWpbdu26tq1q7788kt16dLF8pwXavfXpk2bpqSkJOdrh8OhsLCwqgcFAADqtTpx6W3SpElavXq1Nm7cqJYtWzrLQ0NDJanCKs/x48crrAb9WpcuXeTu7q6srKxK9wcFBcnNza1G7Xp6esrf399lAwAADVutBiVjjBITE7Vy5Upt2LBBkZGRLvvLL6f9+hJaaWmp0tPT1aNHD8t29+7dq7Nnz6pFixaV7vfw8FB0dHSFS3NpaWlVtgsAAP671Oqlt4kTJ2rx4sVatWqV/Pz8nCs8AQEB8vb2ls1m05QpUzRnzhy1bdtWbdu21Zw5c+Tj46N77rlHknTw4EF98MEHuuWWWxQUFKSvv/5ajzzyiG644QbddNNNznP169dPw4YNU2JioiQpKSlJo0aNUteuXdW9e3e9+eabysnJ0YQJE678GwEAAOqkWg1K5V/Nj42NdSlfuHChEhISJEmPPvqozpw5o4ceekinTp1STEyM1q9fLz8/P0m/rA599tlnevXVV3X69GmFhYXp1ltv1cyZM+Xm5uZs8+DBgyooKHC+HjFihE6cOKGnnnpKeXl5ioqK0tq1axUREXF5Bw0AAOqNOvUcpfqE5ygBAFD/1OvnKAEAANQlBCUAAAALBCUAAAALBCUAAAALBCUAAAALBCUAAAALBCUAAAALBCUAAAALBCUAAAALBCUAAAALBCUAAAALBCUAAAALBCUAAAALBCUAAAALBCUAAAALBCUAAAALBCUAAAALBCUAAAALBCUAAAALBCUAAAALBCUAAAALBCUAAAALBCUAAAALBCUAAAALBCUAAAALBCUAAAALBCUAAAALBCUAAAALBCUAAAALBCUAAAALBCUAAAALtRqUkpOT1a1bN/n5+al58+aKj4/X/v37XeoYYzRr1izZ7XZ5e3srNjZWe/fude4/efKkJk2apPbt28vHx0fh4eGaPHmyCgsLqzz3rFmzZLPZXLbQ0NDLMk4AAFA/1WpQSk9P18SJE7Vt2zalpaXp3LlziouLU3FxsbPOCy+8oJdeeklz587V9u3bFRoaqgEDBqioqEiSlJubq9zcXL344ovas2ePUlJS9Omnn2rs2LEXPH/Hjh2Vl5fn3Pbs2XPZxgoAAOofmzHG1HYnyv3www9q3ry50tPT1bt3bxljZLfbNWXKFD322GOSpJKSEoWEhOj555/X+PHjK21n+fLluu+++1RcXKzGjRtXWmfWrFn66KOPlJGRcVF9dTgcCggIUGFhofz9/S+qDQAAcGXV9PO7Tt2jVH65LDAwUJKUnZ2t/Px8xcXFOet4enqqT58+2rp1a5Xt+Pv7W4akcllZWbLb7YqMjNTdd9+tQ4cOWdYtKSmRw+Fw2QAAQMNWZ4KSMUZJSUnq2bOnoqKiJEn5+fmSpJCQEJe6ISEhzn2/deLECT399NOWq03lYmJi9O6772rdunVasGCB8vPz1aNHD504caLS+snJyQoICHBuYWFhNR0iAACoZ+pMUEpMTNRXX32lJUuWVNhns9lcXhtjKpRJvyyn3Xrrrbruuus0c+bMKs83aNAg3XHHHerUqZP69++vNWvWSJIWLVpUaf1p06apsLDQuR05cqS6QwMAAPVU1demrpBJkyZp9erV2rx5s1q2bOksL/8WWn5+vlq0aOEsP378eIVVpqKiIg0cOFBNmjRRamqq3N3da9QHX19fderUSVlZWZXu9/T0lKenZ43aBAAA9VutrigZY5SYmKiVK1dqw4YNioyMdNkfGRmp0NBQpaWlOctKS0uVnp6uHj16OMscDofi4uLk4eGh1atXy8vLq8Z9KSkp0b59+1wCGQAA+O9Wq0Fp4sSJev/997V48WL5+fkpPz9f+fn5OnPmjKRfLrlNmTJFc+bMUWpqqjIzM5WQkCAfHx/dc889kn5ZSSp/pMDbb78th8PhbKesrMx5rn79+mnu3LnO11OnTlV6erqys7P1xRdf6M4775TD4dCYMWOu7JsAAADqrFq99DZ//nxJUmxsrEv5woULlZCQIEl69NFHdebMGT300EM6deqUYmJitH79evn5+UmSdu7cqS+++EKS1KZNG5d2srOz1apVK0nSwYMHVVBQ4Nx39OhRjRw5UgUFBQoODtaNN96obdu2KSIi4jKMFAAA1Ed16jlK9QnPUQIAoP6p189RAgAAqEsISgAAABYISgAAABYISgAAABYISgAAABYISgAAABYISgAAABYISgAAABYISgAAABYISgAAABYISgAAABYISgAAABYISgAAABYISgAAABYISgAAABYISgAAABYISgAAABYISgAAABYISgAAABYISgAAABYISgAAABYISgAAABYISgAAABYISgAAABYISgAAABYISgAAABYISgAAABYISgAAABYaX8xBZWVlSk1N1b59+2Sz2dShQwfFx8erceOLag4AAKBOqnGyyczM1NChQ5Wfn6/27dtLkr799lsFBwdr9erV6tSp0yXvJAAAQG2o8aW3Bx98UB07dtTRo0f15Zdf6ssvv9SRI0f0hz/8QX/+858vRx8BAABqRY2D0u7du5WcnKymTZs6y5o2bapnn31WGRkZNWorOTlZ3bp1k5+fn5o3b674+Hjt37/fpY4xRrNmzZLdbpe3t7diY2O1d+9elzolJSWaNGmSgoKC5OvrqyFDhujo0aMXPP+8efMUGRkpLy8vRUdH6/PPP69R/wEAQMNW46DUvn17HTt2rEL58ePH1aZNmxq1lZ6erokTJ2rbtm1KS0vTuXPnFBcXp+LiYmedF154QS+99JLmzp2r7du3KzQ0VAMGDFBRUZGzzpQpU5SamqqlS5dqy5YtOn36tG677TaVlZVZnnvZsmWaMmWKpk+frl27dqlXr14aNGiQcnJyajQGAADQgJkaWrNmjenYsaNZvny5OXLkiDly5IhZvny56dSpk1mzZo0pLCx0bjV1/PhxI8mkp6cbY4w5f/68CQ0NNc8995yzzs8//2wCAgLMG2+8YYwx5scffzTu7u5m6dKlzjrff/+9adSokfn0008tz/XHP/7RTJgwwaWsQ4cO5vHHH69WXwsLC42kixonAACoHTX9/K7xzdy33XabJOmuu+6SzWYrD1uSpMGDBztf22y2Kld0KlNYWChJCgwMlCRlZ2crPz9fcXFxzjqenp7q06ePtm7dqvHjx2vnzp06e/asSx273a6oqCht3bpVN998c4XzlJaWaufOnXr88cddyuPi4rR169ZK+1ZSUqKSkhLna4fDUaOxAQCA+qfGQWnjxo2W+7788kt16dLlojpijFFSUpJ69uypqKgoSVJ+fr4kKSQkxKVuSEiIvvvuO2cdDw8Pl3umyuuUH/9bBQUFKisrq7Rdq2OSk5M1e/bsmg8MAADUWzUOSn369HF5XVhYqA8++EBvvfWWdu/eXeNVpHKJiYn66quvtGXLlgr7yleuypWvWFWlOnVq0u60adOUlJTkfO1wOBQWFlZl+wAAoH676Cdzb9iwQffdd59atGih119/Xbfccot27NhxUW1NmjRJq1ev1saNG9WyZUtneWhoqCRVWOU5fvy4czUoNDRUpaWlOnXqlGWd3woKCpKbm1uV7f6Wp6en/P39XTYAANCw1SgoHT16VM8884yuueYajRw5Uk2bNtXZs2e1YsUKPfPMM7rhhhtqdHJjjBITE7Vy5Upt2LBBkZGRLvsjIyMVGhqqtLQ0Z1lpaanS09PVo0cPSVJ0dLTc3d1d6uTl5SkzM9NZ57c8PDwUHR3tcowkpaWlWR4DAAD++1Q7KN1yyy267rrr9PXXX+v1119Xbm6uXn/99d918okTJ+r999/X4sWL5efnp/z8fOXn5+vMmTOSfrk0NmXKFM2ZM0epqanKzMxUQkKCfHx8dM8990iSAgICNHbsWD3yyCP67LPPtGvXLt13333q1KmT+vfv7zxXv379NHfuXOfrpKQkvfXWW3rnnXe0b98+/eUvf1FOTo4mTJjwu8YEAAAajmrfo7R+/XpNnjxZ//M//6O2bdtekpPPnz9fkhQbG+tSvnDhQiUkJEiSHn30UZ05c0YPPfSQTp06pZiYGK1fv15+fn7O+i+//LIaN26su+66S2fOnFG/fv2UkpIiNzc3Z52DBw+qoKDA+XrEiBE6ceKEnnrqKeXl5SkqKkpr165VRETEJRkbAACo/2ym/Lv9F/Dvf/9b77zzjj788EN16NBBo0aN0ogRI2S327V7925dd911l7uvdYrD4VBAQIAKCwu5XwkAgHqipp/f1b701r17dy1YsEB5eXkaP368li5dqquvvlrnz59XWlqay5OyAQAAGoJqryhVZv/+/Xr77bf13nvv6ccff9SAAQO0evXqS9m/OosVJQAA6p/LtqJUmfbt2+uFF17Q0aNHtWTJkt/TFAAAQJ3zu1aU/puxogQAQP1zRVeUAAAAGjKCEgAAgAWCEgAAgAWCEgAAgAWCEgAAgAWCEgAAgAWCEgAAgAWCEgAAgAWCEgAAgAWCEgAAgAWCEgAAgAWCEgAAgAWCEgAAgAWCEgAAgAWCEgAAgAWCEgAAgAWCEgAAgAWCEgAAgAWCEgAAgAWCEgAAgAWCEgAAgAWCEgAAgAWCEgAAgAWCEgAAgAWCEgAAgAWCEgAAgAWCEgAAgIVaDUqbN2/W4MGDZbfbZbPZ9NFHH7nsP3bsmBISEmS32+Xj46OBAwcqKyvLuf/w4cOy2WyVbsuXL7c876xZsyrUDw0NvVzDBAAA9VStBqXi4mJdf/31mjt3boV9xhjFx8fr0KFDWrVqlXbt2qWIiAj1799fxcXFkqSwsDDl5eW5bLNnz5avr68GDRpU5bk7duzoctyePXsuyxgBAED91bg2Tz5o0CDLQJOVlaVt27YpMzNTHTt2lCTNmzdPzZs315IlS/Tggw/Kzc2twkpQamqqRowYoSZNmlR57saNG7OKBAAAqlRn71EqKSmRJHl5eTnL3Nzc5OHhoS1btlR6zM6dO5WRkaGxY8desP2srCzZ7XZFRkbq7rvv1qFDhy7YH4fD4bIBAICGrc4GpQ4dOigiIkLTpk3TqVOnVFpaqueee075+fnKy8ur9Ji3335b1157rXr06FFl2zExMXr33Xe1bt06LViwQPn5+erRo4dOnDhheUxycrICAgKcW1hY2O8aHwAAqPvqbFByd3fXihUr9O233yowMFA+Pj7atGmTBg0aJDc3twr1z5w5o8WLF1drNWnQoEG644471KlTJ/Xv319r1qyRJC1atMjymGnTpqmwsNC5HTly5OIHBwAA6oVavUfpQqKjo5WRkaHCwkKVlpYqODhYMTEx6tq1a4W6//znP/XTTz9p9OjRNT6Pr6+vOnXq5PKNut/y9PSUp6dnjdsGAAD1V51dUfq1gIAABQcHKysrSzt27NDQoUMr1Hn77bc1ZMgQBQcH17j9kpIS7du3Ty1atLgU3QUAAA1Era4onT59WgcOHHC+zs7OVkZGhgIDAxUeHq7ly5crODhY4eHh2rNnjx5++GHFx8crLi7OpZ0DBw5o8+bNWrt2baXn6devn4YNG6bExERJ0tSpUzV48GCFh4fr+PHjeuaZZ+RwODRmzJjLN1gAAFDv1GpQ2rFjh/r27et8nZSUJEkaM2aMUlJSlJeXp6SkJB07dkwtWrTQ6NGjNWPGjArtvPPOO7r66qsrBKhyBw8eVEFBgfP10aNHNXLkSBUUFCg4OFg33nijtm3bpoiIiEs8QgAAUJ/ZjDGmtjtRHzkcDgUEBKiwsFD+/v613R0AAFANNf38rhf3KAEAANQGghIAAIAFghIAAIAFghIAAIAFghIAAIAFghIAAIAFghIAAIAFghIAAIAFghIAAIAFghIAAIAFghIAAIAFghIAAIAFghIAAIAFghIAAIAFghIAAIAFghIAAIAFghIAAIAFghIAAIAFghIAAIAFghIAAIAFghIAAIAFghIAAIAFghIAAIAFghIAAIAFghIAAIAFghIAAIAFghIAAIAFghIAAIAFghIAAIAFghIAAIAFghIAAICFWg1Kmzdv1uDBg2W322Wz2fTRRx+57D927JgSEhJkt9vl4+OjgQMHKisry6VObGysbDaby3b33Xdf8Nzz5s1TZGSkvLy8FB0drc8///xSDg0AADQAtRqUiouLdf3112vu3LkV9hljFB8fr0OHDmnVqlXatWuXIiIi1L9/fxUXF7vUHTdunPLy8pzbP/7xjyrPu2zZMk2ZMkXTp0/Xrl271KtXLw0aNEg5OTmXdHwAAKB+sxljTG13QpJsNptSU1MVHx8vSfr222/Vvn17ZWZmqmPHjpKksrIyNW/eXM8//7wefPBBSb+sKHXu3FmvvPJKtc8VExOjLl26aP78+c6ya6+9VvHx8UpOTq5WGw6HQwEBASosLJS/v3+1zw0AAGpPTT+/6+w9SiUlJZIkLy8vZ5mbm5s8PDy0ZcsWl7offPCBgoKC1LFjR02dOlVFRUWW7ZaWlmrnzp2Ki4tzKY+Li9PWrVur7I/D4XDZAABAw1Zng1KHDh0UERGhadOm6dSpUyotLdVzzz2n/Px85eXlOevde++9WrJkiTZt2qQZM2ZoxYoVuv322y3bLSgoUFlZmUJCQlzKQ0JClJ+fb3lccnKyAgICnFtYWNjvHyQAAKjTGtd2B6y4u7trxYoVGjt2rAIDA+Xm5qb+/ftr0KBBLvXGjRvn/O+oqCi1bdtWXbt21ZdffqkuXbpYtm+z2VxeG2MqlP3atGnTlJSU5HztcDgISwAANHB1NihJUnR0tDIyMlRYWKjS0lIFBwcrJiZGXbt2tTymS5cucnd3V1ZWVqVBKSgoSG5ubhVWj44fP15hlenXPD095enpefGDAQAA9U6dvfT2awEBAQoODlZWVpZ27NihoUOHWtbdu3evzp49qxYtWlS638PDQ9HR0UpLS3MpT0tLU48ePS5pvwEAQP1WqytKp0+f1oEDB5yvs7OzlZGRocDAQIWHh2v58uUKDg5WeHi49uzZo4cffljx8fHOG7EPHjyoDz74QLfccouCgoL09ddf65FHHtENN9ygm266ydluv379NGzYMCUmJkqSkpKSNGrUKHXt2lXdu3fXm2++qZycHE2YMOHKvgEAAKBOq9WgtGPHDvXt29f5uvweoDFjxiglJUV5eXlKSkrSsWPH1KJFC40ePVozZsxw1vfw8NBnn32mV199VadPn1ZYWJhuvfVWzZw5U25ubs56Bw8eVEFBgfP1iBEjdOLECT311FPKy8tTVFSU1q5dq4iIiCswagAAUF/Umeco1Tc8RwkAgPqnwTxHCQAAoLYRlAAAACwQlAAAACwQlAAAACwQlAAAACwQlAAAACwQlAAAACwQlAAAACwQlAAAACwQlAAAACwQlAAAACwQlAAAACwQlAAAACwQlAAAACwQlAAAACwQlAAAACwQlAAAACwQlAAAACwQlAAAACwQlAAAACwQlAAAACwQlAAAACwQlAAAACwQlAAAACwQlAAAACwQlAAAACwQlAAAACwQlAAAACwQlAAAACwQlAAAACwQlAAAACzUalDavHmzBg8eLLvdLpvNpo8++shl/7Fjx5SQkCC73S4fHx8NHDhQWVlZzv0nT57UpEmT1L59e/n4+Cg8PFyTJ09WYWFhleedNWuWbDabyxYaGno5hggAAOqxWg1KxcXFuv766zV37twK+4wxio+P16FDh7Rq1Srt2rVLERER6t+/v4qLiyVJubm5ys3N1Ysvvqg9e/YoJSVFn376qcaOHXvBc3fs2FF5eXnObc+ePZd8fAAAoH5rXJsnHzRokAYNGlTpvqysLG3btk2ZmZnq2LGjJGnevHlq3ry5lixZogcffFBRUVFasWKF85jWrVvr2Wef1X333adz586pcWPr4TVu3JhVJAAAUKU6e49SSUmJJMnLy8tZ5ubmJg8PD23ZssXyuMLCQvn7+1cZkqRfgpjdbldkZKTuvvtuHTp06IL9cTgcLhsAAGjY6mxQ6tChgyIiIjRt2jSdOnVKpaWleu6555Sfn6+8vLxKjzlx4oSefvppjR8/vsq2Y2Ji9O6772rdunVasGCB8vPz1aNHD504ccLymOTkZAUEBDi3sLCw3zU+AABQ99mMMaa2OyFJNptNqampio+Pd5bt3LlTY8eO1e7du+Xm5qb+/furUaNfst3atWtdjnc4HIqLi1PTpk21evVqubu7V/vcxcXFat26tR599FElJSVVWqekpMS5ylV+vrCwMOcKFgAAqPscDocCAgKq/fldq/coXUh0dLQyMjJUWFio0tJSBQcHKyYmRl27dnWpV1RUpIEDB6pJkyZKTU2tUUiSJF9fX3Xq1MnlG3W/5enpKU9Pz4saBwAAqJ/q7KW3XwsICFBwcLCysrK0Y8cODR061LmvfCXJw8NDq1evdrmnqbpKSkq0b98+tWjR4lJ2GwAA1HO1uqJ0+vRpHThwwPk6OztbGRkZCgwMVHh4uJYvX67g4GCFh4drz549evjhhxUfH6+4uDhJv6wkxcXF6aefftL777/vcpN1cHCw3NzcJEn9+vXTsGHDlJiYKEmaOnWqBg8erPDwcB0/flzPPPOMHA6HxowZc4XfAQAAUJfValDasWOH+vbt63xdfn/QmDFjlJKSory8PCUlJenYsWNq0aKFRo8erRkzZjjr79y5U1988YUkqU2bNi5tZ2dnq1WrVpKkgwcPqqCgwLnv6NGjGjlypAoKChQcHKwbb7xR27ZtU0RExOUaKgAAqIfqzM3c9U1NbwYDAAC1r6af3/XiHiUAAIDaQFACAACwQFACAACwQFACAACwQFACAACwQFACAACwQFACAACwQFACAACwQFACAACwQFACAACwQFACAACwQFACAACwQFACAACwQFACAACwQFACAACwQFACAACwQFACAACwQFACAACwQFACAACwQFACAACwQFACAACwQFACAACwQFACAACwQFACAACwQFACAACwQFACAACwQFACAACwQFACAACwQFACAACwQFACAACwQFACAACwUKtBafPmzRo8eLDsdrtsNps++ugjl/3Hjh1TQkKC7Ha7fHx8NHDgQGVlZbnUKSkp0aRJkxQUFCRfX18NGTJER48eveC5582bp8jISHl5eSk6Olqff/75pRwaAABoAGo1KBUXF+v666/X3LlzK+wzxig+Pl6HDh3SqlWrtGvXLkVERKh///4qLi521psyZYpSU1O1dOlSbdmyRadPn9Ztt92msrIyy/MuW7ZMU6ZM0fTp07Vr1y716tVLgwYNUk5OzmUZJwAAqJ9sxhhT252QJJvNptTUVMXHx0uSvv32W7Vv316ZmZnq2LGjJKmsrEzNmzfX888/rwcffFCFhYUKDg7We++9pxEjRkiScnNzFRYWprVr1+rmm2+u9FwxMTHq0qWL5s+f7yy79tprFR8fr+Tk5Gr11+FwKCAgQIWFhfL39/8dIwcAAFdKTT+/6+w9SiUlJZIkLy8vZ5mbm5s8PDy0ZcsWSdLOnTt19uxZxcXFOevY7XZFRUVp69atlbZbWlqqnTt3uhwjSXFxcZbHlPfH4XC4bAAAoGGrs0GpQ4cOioiI0LRp03Tq1CmVlpbqueeeU35+vvLy8iRJ+fn58vDwUNOmTV2ODQkJUX5+fqXtFhQUqKysTCEhIdU+RpKSk5MVEBDg3MLCwn7nCAEAQF1XZ4OSu7u7VqxYoW+//VaBgYHy8fHRpk2bNGjQILm5uVV5rDFGNputyjq/3X+hY6ZNm6bCwkLnduTIkeoPBgAA1EuNa7sDVYmOjlZGRoYKCwtVWlqq4OBgxcTEqGvXrpKk0NBQlZaW6tSpUy6rSsePH1ePHj0qbTMoKEhubm4VVo+OHz9eYZXp1zw9PeXp6XkJRgUAAOqLOrui9GsBAQEKDg5WVlaWduzYoaFDh0r6JUi5u7srLS3NWTcvL0+ZmZmWQcnDw0PR0dEux0hSWlqa5TEAAOC/U62uKJ0+fVoHDhxwvs7OzlZGRoYCAwMVHh6u5cuXKzg4WOHh4dqzZ48efvhhxcfHO2/EDggI0NixY/XII4+oWbNmCgwM1NSpU9WpUyf179/f2W6/fv00bNgwJSYmSpKSkpI0atQode3aVd27d9ebb76pnJwcTZgw4cq+AQAAoE6r1aC0Y8cO9e3b1/k6KSlJkjRmzBilpKQoLy9PSUlJOnbsmFq0aKHRo0drxowZLm28/PLLaty4se666y6dOXNG/fr1U0pKist9TAcPHlRBQYHz9YgRI3TixAk99dRTysvLU1RUlNauXauIiIjLPGIAAFCf1JnnKNU3PEcJAID6p8E8RwkAAKC2EZQAAAAsEJQAAAAsEJQAAAAsEJQAAAAsEJQAAAAsEJQAAAAsEJQAAAAsEJQAAAAs1OqfMKnPyh9o7nA4arknAACguso/t6v7h0kIShepqKhIkhQWFlbLPQEAADVVVFSkgICAC9bjb71dpPPnzys3N1d+fn6y2Wy13R0nh8OhsLAwHTlypMH+DbqGPkbGV7819PFJDX+MDX18UsMfY1XjM8aoqKhIdrtdjRpd+A4kVpQuUqNGjdSyZcva7oYlf3//BvnD/2sNfYyMr35r6OOTGv4YG/r4pIY/RqvxVWclqRw3cwMAAFggKAEAAFggKDUwnp6emjlzpjw9PWu7K5dNQx8j46vfGvr4pIY/xoY+Pqnhj/FSjo+buQEAACywogQAAGCBoAQAAGCBoAQAAGCBoPRfwmaz6aOPPqrtbuB3YA7rN+av/mMO67+LmUOCUj2VkJCg+Pj42u7GRUlOTla3bt3k5+en5s2bKz4+Xvv373epY4zRrFmzZLfb5e3trdjYWO3du9e5/+TJk5o0aZLat28vHx8fhYeHa/LkySosLHRp59lnn1WPHj3k4+Ojq6666koMr9qYwwvP4eHDhzV27FhFRkbK29tbrVu31syZM1VaWnrFxmqF+avev8EhQ4YoPDxcXl5eatGihUaNGqXc3NwrMs4LYQ6rN4flSkpK1LlzZ9lsNmVkZFzO4VXblZhDghKuuPT0dE2cOFHbtm1TWlqazp07p7i4OBUXFzvrvPDCC3rppZc0d+5cbd++XaGhoRowYIDzb+zl5uYqNzdXL774ovbs2aOUlBR9+umnGjt2rMu5SktLNXz4cP3P//zPFR1jQ3el5vCbb77R+fPn9Y9//EN79+7Vyy+/rDfeeENPPPHEFR9zQ3Il/w327dtXH374ofbv368VK1bo4MGDuvPOO6/oeBuiKzmH5R599FHZ7fYrMr46xaBeGjNmjBk6dKgxxpiIiAjz8ssvu+y//vrrzcyZM52vJZnU1NQr1r+aOH78uJFk0tPTjTHGnD9/3oSGhprnnnvOWefnn382AQEB5o033rBs58MPPzQeHh7m7NmzFfYtXLjQBAQEXPK+/x7MYUVVzWG5F154wURGRl66zl8k5q+i6szfqlWrjM1mM6WlpZduABeJOazIag7Xrl1rOnToYPbu3WskmV27dl2WcdTUlZhDVpRQ68qXeQMDAyVJ2dnZys/PV1xcnLOOp6en+vTpo61bt1bZjr+/vxo35k8YXmlXcg4LCwud58GlcaXm7+TJk/rggw/Uo0cPubu7X8IR4HLO4bFjxzRu3Di999578vHxuUwjqLsISqhVxhglJSWpZ8+eioqKkiTl5+dLkkJCQlzqhoSEOPf91okTJ/T0009r/Pjxl7fDqOBKzuHBgwf1+uuva8KECZeo97gS8/fYY4/J19dXzZo1U05OjlatWnWJR/Hf7XLOoTFGCQkJmjBhgrp27XqZRlC3EZRQqxITE/XVV19pyZIlFfbZbDaX18aYCmWS5HA4dOutt+q6667TzJkzL1tfUbkrNYe5ubkaOHCghg8frgcffPDSdB5XZP7+93//V7t27dL69evl5uam0aNHy/BHIS6ZyzmHr7/+uhwOh6ZNm3bpO15PEJQagEaNGlX4n87Zs2drqTfVN2nSJK1evVobN25Uy5YtneWhoaGSVOG3nuPHj1f47aioqEgDBw5UkyZNlJqaWm+X85nDqucwNzdXffv2Vffu3fXmm29ehpH8Psxf1fMXFBSkdu3aacCAAVq6dKnWrl2rbdu2XYYRXTzmsPI53LBhg7Zt2yZPT081btxYbdq0kSR17dpVY8aMuVzDuiiXaw4JSg1AcHCw8vLynK8dDoeys7NrsUdVM8YoMTFRK1eu1IYNGxQZGemyPzIyUqGhoUpLS3OWlZaWKj09XT169HCWORwOxcXFycPDQ6tXr5aXl9cVG8Olxhxaz+H333+v2NhYdenSRQsXLlSjRnXvf1vMX/X/DZZ/kJWUlFyi0VwazGHlc/jaa69p9+7dysjIUEZGhtauXStJWrZsmZ599tnLOMKau1xzyF2vDcCf/vQnpaSkaPDgwWratKlmzJghNze32u6WpYkTJ2rx4sVatWqV/Pz8nL/xBAQEyNvbWzabTVOmTNGcOXPUtm1btW3bVnPmzJGPj4/uueceSb/8BhQXF6effvpJ77//vhwOhxwOh6Rf/rGUjz8nJ0cnT55UTk6OysrKnM/+aNOmjZo0aXLlB2+BOax8DnNzcxUbG6vw8HC9+OKL+uGHH5x9KP+NuS5g/iqfv//85z/6z3/+o549e6pp06Y6dOiQ/vrXv6p169bq3r17rY2/Msxh5XMYHh7uct7y/2+2bt3aZQWrLrhsc1ij78ihzhg1apS54447jDHGFBYWmrvuusv4+/ubsLAwk5KSUqe/1iqp0m3hwoXOOufPnzczZ840oaGhxtPT0/Tu3dvs2bPHuX/jxo2W7WRnZzvrjRkzptI6GzduvHIDtsAcXngOFy5caFmntjF/F56/r776yvTt29cEBgYaT09P06pVKzNhwgRz9OjRKzziyjGH1fv/6K9lZ2fXqccDXIk5tP1/B6KeGThwoNq0aaO5c+fWdldwkZjD+o35q/+Yw/rvSsxh3bvYjyqdOnVKa9as0aZNm9S/f//a7g4uAnNYvzF/9R9zWP9dyTnkHqV65oEHHtD27dv1yCOPaOjQobXdHVwE5rB+Y/7qP+aw/ruSc8ilNwAAAAtcegMAALBAUAIAALBAUAIAALBAUAIAALBAUALwX2XTpk2y2Wz68ccfa7srAOoBvvUGoEGLjY1V586d9corr0j65e9dnTx5UiEhIZX+FXUA+DWeowTgv4qHh0ed+jtxAOo2Lr0BaLASEhKUnp6uV199VTabTTabTSkpKS6X3lJSUnTVVVfp448/Vvv27eXj46M777xTxcXFWrRokVq1aqWmTZtq0qRJKisrc7ZdWlqqRx99VFdffbV8fX0VExOjTZs21c5AAVw2rCgBaLBeffVVffvtt4qKitJTTz0lSdq7d2+Fej/99JNee+01LV26VEVFRbr99tt1++2366qrrtLatWt16NAh3XHHHerZs6dGjBghSbr//vt1+PBhLV26VHa7XampqRo4cKD27Nmjtm3bXtFxArh8CEoAGqyAgAB5eHjIx8fHebntm2++qVDv7Nmzmj9/vlq3bi1JuvPOO/Xee+/p2LFjatKkia677jr17dtXGzdu1IgRI3Tw4EEtWbJER48eld1ulyRNnTpVn376qRYuXKg5c+ZcuUECuKwISgD+6/n4+DhDkiSFhISoVatWatKkiUvZ8ePHJUlffvmljDFq166dSzslJSVq1qzZlek0gCuCoATgv567u7vLa5vNVmnZ+fPnJUnnz5+Xm5ubdu7cKTc3N5d6vw5XAOo/ghKABs3Dw8PlJuxL4YYbblBZWZmOHz+uXr16XdK2AdQtfOsNQIPWqlUrffHFFzp8+LAKCgqcq0K/R7t27XTvvfdq9OjRWrlypbKzs7V9+3Y9//zzWrt27SXoNYC6gqAEoEGbOnWq3NzcdN111yk4OFg5OTmXpN2FCxdq9OjReuSRR9S+fXsNGTJEX3zxhcLCwi5J+wDqBp7MDQAAYIEVJQAAAAsEJQAAAAsEJQAAAAsEJQAAAAsEJQAAAAsEJQAAAAsEJQAAAAsEJQAAAAsEJQAAAAsEJQAAAAsEJQAAAAsEJQAAAAv/P0cj8zEUMifFAAAAAElFTkSuQmCC",
+      "text/plain": [
+       "<Figure size 640x480 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "transport_model.mesh.Ap.isel(nface=151).plot()#, time=slice(0, TIME_STEPS)).plot()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 35,
+   "id": "5c81a38a",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[<matplotlib.lines.Line2D at 0x1c25c6abdd0>]"
+      ]
+     },
+     "execution_count": 35,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAjgAAAHFCAYAAAD/kYOsAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjguNCwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8fJSN1AAAACXBIWXMAAA9hAAAPYQGoP6dpAAA92klEQVR4nO3deVxV1R738e8BBEEF54EEwZEiu3bLSjOHrlMOWSkZdhVEzZ40myylHNJC0sw0K723DFFzyBIr03K2rCy8Dqk5ZImYoGYqB7NQYD1/9HieTgweFDiw/bxfr/N6ddZee+/fYmHny97rnGMzxhgBAABYiIe7CwAAAChuBBwAAGA5BBwAAGA5BBwAAGA5BBwAAGA5BBwAAGA5BBwAAGA5BBwAAGA5BBwAAGA5BBy4xZIlSxQeHi5fX1/ZbDbt2LHD3SWVeSkpKbLZbPk+Fi9e7NIxzp49q8cff1yBgYGqWLGiWrRoUeC+27ZtU8eOHVW5cmVVrVpV9913n3766ac8/Y4dO6bhw4erYcOG8vX1VYMGDTRo0CClpqZe0Xgvh6vji46OzvfnGBYWdkXnnzlzpho3bixvb2/ZbDadOXPmio53tfj222/VpUsXValSRZUrV1aHDh305Zdf5ulX1HmbOXOmwsLC5OPjo9DQUE2YMEEXLlxwqaYLFy5owoQJCgkJkY+Pj8LCwjRz5swrGidKl5e7C8DV55dfflH//v3VtWtXvfnmm/Lx8VHTpk3dXVa58eijj6pfv35ObU2aNHFp3/vuu0/Jycl66aWX1LRpUy1cuFCRkZHKzc11Oua+ffvUvn17tWjRQu+9957++OMPjRs3TnfccYd27NihWrVqSZKysrLUtm1bnT59WhMmTNB1112n/fv3a/z48frss8+0d+9eValSpfgGX0zjkyRfX1+tX78+T9vl2rFjh0aMGKHBgwcrKipKXl5epTr28io5OVlt27bVLbfcovnz58sYoylTpuhf//qXNmzYoFatWjn1d3Xe4uLiNHbsWI0ePVqdO3dWcnKyxowZo6NHj+q///3vJet65JFHNH/+fL3wwgtq2bKlPvvsMz322GPKzMzUs88+e2WDRukwQCnbvHmzkWSWLFni7lLKlUOHDhlJ5uWXX76s/T/55BMjySxcuNCpvVOnTiYwMNBkZ2c72iIiIkzNmjVNRkaGoy0lJcVUqFDBPPPMM462NWvWGEnm7bffdjrmwoULjSSzbNmyy6r176Kioky7du0K7VOU8UVFRZlKlSoVS20XLViwwEgy33zzTbEe1+q6dOli6tSpY3777TdHm91uNzVr1jStW7d26uvqvJ08edJUrFjRPPTQQ07tcXFxxmazmT179hS6/+7du43NZjOTJk1yah8yZIjx9fU1v/766yVrgPtxiwqlKjo6Wm3atJEk9e3bVzabTe3bt5ckbd26VQ888IBCQkLk6+urkJAQRUZG6vDhw3mOc/ToUT300EMKCgqSt7e3AgMD1adPHx0/ftzRx263a+TIkQoNDZW3t7euueYaPf744/rtt99crvfkyZMKCgpS69atnS5tf//996pUqZL69+9/mT+J0peUlKTKlSsrIiLCqX3gwIFKS0vTN998I0nKzs7WihUr1Lt3b/n7+zv6NWjQQB06dFBSUpKjrUKFCpKkgIAAp2NWrVpVklSxYkWn9q1bt+ruu+9W9erVVbFiRd1444167733SnV8JaF9+/b697//LUm69dZbZbPZFB0dLUlas2aNevXqpfr166tixYpq3Lixhg4dqpMnT+Y5zr59+xQZGak6derIx8dHwcHBGjBggLKyshx9jh07pqFDh6p+/fry9vZ23HrJzs52ud4XXnhBXl5eOnLkSJ5tMTExqlGjhv74448i/hQuz5dffqn27dvLz8/P0ValShW1bdtWX331ldLT04t8zE8//VR//PGHBg4c6NQ+cOBAGWO0fPnyQvdfvny5jDH57v/777/r008/LXJNKH0EHJSqsWPH6o033pAkTZo0SV9//bXefPNNSX+uMWnWrJmmT5+uzz77TJMnT1Z6erpatmzp9GJw9OhRtWzZUklJSXryySe1atUqTZ8+XQEBATp9+rQk6dy5c2rXrp0SExM1YsQIrVq1SqNGjdLcuXN19913yxjjUr01a9bU4sWLlZycrFGjRjmOHRERoeDgYM2ePbvQ/Y0xys7Odunhqpdeekne3t7y8/NTmzZt9NFHH7m03+7du3XttdfKy8v5zvQNN9zg2C5JP/74o37//XdH+9/7Hjx40PHid/vtt+umm27S888/r+TkZJ09e1bbtm3Ts88+q3/+85/q2LGjY98NGzbo9ttv15kzZzR79mx9+OGHatGihfr27au5c+e6PP4rHd9Fv//+u+rWrStPT0/Vr19fw4cP16lTpy7r3G+++abGjBkjSUpISNDXX3+tsWPHSvrz59mqVSvNmjVLq1ev1rhx4/TNN9+oTZs2TqF5586datmypbZs2aKJEydq1apVio+PV1ZWls6fPy/pz3Bzyy236LPPPtO4ceO0atUqDRo0SPHx8RoyZIjL9Q4dOlReXl76z3/+49R+6tQpLV68WIMGDcoTTv+qOH+vz58/Lx8fnzztF9t27drl1O7KvF2c6+bNmzu116tXTzVr1szzu/B3u3fvVq1atVS3bl2n9oJ+l1BGufX6Ea5KGzZsMJLM0qVLC+2XnZ1tzp49aypVqmRmzJjhaI+JiTEVKlQw33//fYH7xsfHGw8PD5OcnOzU/v777xtJZuXKlUWqefLkyUaSSUpKMlFRUcbX19d89913l9zv4lhdeRw6dKjQY6WlpZkhQ4aY9957z3zxxRfm3XffNbfddpuRZN56661L1tKkSRPTpUuXfI8ryXE5/ssvvzSSzKJFi/L0nTRpkpFk0tLSHG12u9307NnTaSzt27fPcxk/LCzM3HjjjebChQtO7T169DD16tUzOTk5jrYLFy44PQYMGGDatm2bpz03N7fI4zPGmGnTpplp06aZ1atXm9WrV5vnnnvO+Pn5mbCwMJOZmXmpH2W+EhISjKQ8v3N/lZubay5cuGAOHz5sJJkPP/zQse3OO+80VatWNSdOnChw/6FDh5rKlSubw4cPO7VPnTrVSLrkrZe/ioqKMrVr1zZZWVmOtsmTJxsPD49L/i5eHKsrj0tp0aKFadq0aZ75b9iwYZ5bjq7O25AhQ4yPj0++52vatKnp3LlzoTV16tTJNGvWLN9t3t7eeW59oWxikTHKjLNnz+qFF17QBx98oJSUFOXk5Di27d271/Hfq1atUocOHXTttdcWeKwVK1bo+uuvV4sWLZz+iuzSpYtsNps2btyou+66y+Xann76aX3++eeKjIzUH3/8obfffjvPX4f5uemmm5ScnOzSOQIDAwvdXq9evTyLIyMiInTrrbdq9OjRio6OznP14u9sNpvL21zpe+HCBfXt21e7d+/WW2+9pWbNmunQoUN68cUX1alTJ61fv14BAQE6ePCg9u3bp6lTp0qS05x069ZNK1as0P79+3XttdcqJSVFoaGh+Z734i2xizZs2OC4xVmU8T3xxBNO2zp16qQbb7xRffr00VtvvZVn+5U4ceKExo0bp08++URpaWnKzc11bNu7d6/uvvtunTt3Tps2bdKgQYMcC7jzs2LFCnXo0EGBgYFOP8O77rpLI0eO1KZNm3Tddde5VNdjjz2mxMRELV26VA8++KByc3M1a9Ysde/eXSEhIYXu27NnT5d/ry/l0Ucf1aBBgzR8+HA999xzys3N1YQJExy3pj08/v+NhqLMW1F+14vax5X94X4EHJQZ/fr107p16zR27Fi1bNlS/v7+stls6tatm37//XdHv19++UX169cv9FjHjx/XwYMH87wgXpTf+ofCXFxT8cknn6hu3bour72pXLmyWrRo4VLfS4WT/FSoUEF9+/bV6NGj9cMPPxQa+mrUqKFff/01T/vFy/vVq1d39JNUYF+bzeZYYzNnzhytWrVKycnJuvnmmyVJd9xxh9q0aaNGjRpp+vTpGj9+vGNt1MiRIzVy5Mh867s4J4GBgXlePCdMmKC0tLQ8t1SaNWtW5PEV5N5771WlSpW0ZcuWQvsVRW5urjp37qy0tDSNHTtWzZs3V6VKlZSbm6vbbrvN8Xt9+vRp5eTkuPR7/fHHHxfL7/WNN96oO+64Q2+88YYefPBBrVixQikpKXl+xvmpXr16nnVXlysmJka//PKLXnzxRc2aNUuS1KpVK40cOVKTJ0/WNddcU+j++c3bxTVE586dc1rbI/35+3DTTTcVeswaNWrk+9EVv/32m86fP3/J3yWUDQQclAkZGRlasWKFxo8fr9GjRzvas7Ky8txfr1Wrln7++edCj1ezZk35+vrqnXfeKXB7UaSnp2vYsGFq0aKF9uzZo5EjR+q111675H6bNm1Shw4dXDrHoUOHLvmXc37M/1tP9Ne/dPPTvHlzLVq0SNnZ2U5h6uIah+uvv16S1KhRI/n6+uZZ+3Cxb+PGjR3rM3bs2CFPT0/985//dOrXsGFD1ahRw7FW4eLPOzY2Vvfdd1++9V0MK97e3o6wdFGNGjWUmZmZp/1yxlcYY8wlf45FsXv3bu3cuVNz585VVFSUo/3gwYNO/apXry5PT0+Xfq9vuOEGxcXF5bv9UlcB/27EiBGKiIjQtm3b9Prrr6tp06bq1KnTJfdLTEzMswC3IMaF9W6jRo3S448/rh9++EFVqlRRgwYNNHToUFWqVOmSYeTiOf46bxevru7atUu33nqro/3YsWM6efLkJX8XmjdvrsWLF+vYsWNO63CK8rsE9yPgoEyw2WwyxuRZbPj222873aqS/rwcP3/+fO3fv9/pL/i/6tGjhyZNmqQaNWoUeLvDVTk5OYqMjJTNZtOqVav07rvvauTIkWrfvn2BL9YXFectqvxcuHBBS5YsUc2aNdW4ceNC+957771666239MEHH6hv376O9sTERAUGBjpeCLy8vNSzZ08tW7ZMU6ZMcXyWS2pqqjZs2OB0GyAwMFA5OTlKTk52eiE5cOCAfv31V8cViWbNmqlJkybauXOnJk2aVORxusLV8RXk/fff17lz53TbbbcVW00Xb2X8/ff671dJfH191a5dOy1dulRxcXEFBvAePXpo5cqVatSokapVq3bF9d17770KDg7WU089pU2bNunVV1916fZLcd6iusjHx8cRHFJTU7VkyRINGTLkkp9NlN+8de3aVRUrVtTcuXOd5n3u3Lmy2Wy65557Cj1mr169NGbMGCUmJjreXHBxf19fX3Xt2vUyRohS59YVQLgqFbTIuG3btqZ69ermrbfeMmvWrDFjxowx9erVM1WrVjVRUVGOfj///LOpV6+eqV27tpk+fbpZt26d+eCDD8yQIUPM3r17jTHGnD171tx4442mfv365pVXXjFr1qwxn332mXnrrbdMRESE2bJli8v1Pvfcc8bDw8OsXbvW0dazZ09TtWpV89NPP13ZD6MInnjiCTN8+HCzaNEis2HDBjNv3jzTsmVLI8kkJCQ49Z0wYYLx9PQ0GzdudGrv1KmTqVatmvnvf/9r1q9fb4YMGWIkmQULFjj127t3r6lcubJp27atWblypVm2bJm5/vrrTWBgoNMi2NTUVFO1alVzzTXXmFmzZpn169ebt99+2zRs2NBUqlTJ7Nu3z9F3/fr1xsfHx3Tu3NksXLjQbNq0ySQlJZlJkyaZPn36FDp2Vz4Hx9XxpaSkmNatW5vXXnvNrFy50qxatcqMHj3aVKxY0YSHh5uzZ886HbNdu3YuLZbNb5Hx+fPnTaNGjUyDBg3MwoULzaeffmqGDRtmmjZtaiSZ8ePHO/ru2LHDVK5c2TRs2NBR/6JFi0xkZKSx2+3GmD8XTDdo0MCEhYWZN99806xbt8588skn5o033jDdu3c3R44cuWSdf3dxAX2lSpXMmTNnirz/ldq1a5d5/vnnzYoVK8yaNWvM1KlTTc2aNc3NN9/stHC4qPP24osvGpvNZp599lmzceNG8/LLLxsfHx8zZMgQp36JiYnG09PTJCYmOrUPHjzY+Pj4mJdfftls3LjRPPvss8Zms5m4uLiS+2GgWBFwUOoKCjg///yz6d27t6lWrZqpUqWK6dq1q9m9e7dp0KCBU8AxxpgjR46YmJgYU7duXVOhQgUTGBho7r//fnP8+HFHn7Nnz5oxY8aYZs2aGW9vbxMQEGCaN29unnjiCXPs2DGXal29erXx8PBweiEyxphff/3VBAcHm5YtWzq9C6UkzZkzx9xyyy2mevXqxsvLy1SrVs106dLFfPbZZ3n6jh8/3kgyGzZscGrPzMw0I0aMMHXr1jXe3t7mhhtuyPfdUsYYs3XrVvOvf/3L+Pn5GX9/f3PPPfeYgwcP5un3ww8/mP79+5uQkBDj4+NjgoODTd++ffN9R8/OnTvN/fffb2rXrm0qVKhg6tata+68804ze/bsQsfuasBxZXynTp0y9957rwkJCTG+vr7G29vbNGnSxDzzzDP5vsDfdNNNpm7dupc8d0Hvovr+++9Np06dTJUqVUy1atVMRESESU1NzRNwLvaNiIgwNWrUMN7e3iY4ONhER0ebP/74w9Hnl19+MSNGjDChoaGmQoUKpnr16uamm24yzz33XJ4XeVekpKQYSebhhx8u8r7FYf/+/Y4/bry9vU3jxo3NmDFj8oylqPNmjDEzZswwTZs2dfwsx48fb86fP+/U5+K8/f2PhPPnz5vx48eb4OBg4+3tbZo2bWpee+21Yh07SpbNGBc/EAQArjKZmZmqXr26pk+frmHDhrm7nBIxc+ZMjRgxQrt371Z4eLi7ywGKDWtwAKAAn3/+ua655poifYheebF9+3YdOnRIEydOVK9evQg3sByu4OCqlZub6/SZJPm5nLduA+6Uk5NT6DuXbDabPD09FRISomPHjumOO+7Q/Pnz83xqL1DeEXBw1YqOjlZiYmKhffjngfKmffv22rRpU4HbGzRooJSUlNIrCHATAg6uWikpKZf8YLTCPncFKIv279+vzMzMArf7+Pi49CncQHlHwAEAAJbDt4kDAADLuepWUObm5iotLU1VqlThC9MAACgnjDHKzMxUYGCgS1+pctUFnLS0NAUFBbm7DAAAcBmOHDlyyS+mla7CgHPxe3WOHDkif39/N1cDAABcYbfbFRQU5Hgdv5SrLuBcvC3l7+9PwAEAoJxxdXkJi4wBAIDlEHAAAIDlEHAAAIDlEHAAAIDlEHAAAIDlEHAAAIDlEHAAAIDlEHAAAIDlEHAAAIDlEHAAAIDluDXgZGdna8yYMQoNDZWvr68aNmyoiRMnKjc316X9v/zyS3l5ealFixYlWygAAChX3PpdVJMnT9bs2bOVmJio8PBwbd26VQMHDlRAQIAee+yxQvfNyMjQgAED9K9//UvHjx8vpYoBAEB54NaA8/XXX6tXr17q3r27JCkkJESLFi3S1q1bL7nv0KFD1a9fP3l6emr58uUlXCkAAChP3HqLqk2bNlq3bp0OHDggSdq5c6c2b96sbt26FbpfQkKCfvzxR40fP/6S58jKypLdbnd6AAAAa3PrFZxRo0YpIyNDYWFh8vT0VE5OjuLi4hQZGVngPj/88INGjx6tL774Ql5ely4/Pj5eEyZMKM6yAQBAGefWKzhLlizRggULtHDhQm3btk2JiYmaOnWqEhMT8+2fk5Ojfv36acKECWratKlL54iNjVVGRobjceTIkeIcAgAAKINsxhjjrpMHBQVp9OjRGjZsmKPtxRdf1IIFC7Rv3748/c+cOaNq1arJ09PT0ZabmytjjDw9PbV69WrdeeedhZ7TbrcrICBAGRkZ8vf3L77BAACAElPU12+33qI6d+6cPDycLyJ5enoW+DZxf39/7dq1y6ntzTff1Pr16/X+++8rNDS0xGoFAADlh1sDTs+ePRUXF6fg4GCFh4dr+/btmjZtmmJiYhx9YmNjdfToUc2bN08eHh66/vrrnY5Ru3ZtVaxYMU87AAC4erk14MycOVNjx47VI488ohMnTigwMFBDhw7VuHHjHH3S09OVmprqxioBAEB549Y1OO7AGhwAAMqfor5+811UAADAcgg4AADAcgg4AADAcgg4AADAcgg4AADAcgg4AADAcgg4AADAcgg4AADAcgg4AADAcgg4AADAcgg4AADAcgg4AADAcgg4AADAcgg4AADAcgg4AADAcgg4AADAcgg4AADAcgg4AADAcgg4AADAcgg4AADAcgg4AADAcgg4AADAcgg4AADAcgg4AADAcgg4AADAcgg4AADAcgg4AADAcgg4AADAcgg4AADAcgg4AADAcgg4AADActwacLKzszVmzBiFhobK19dXDRs21MSJE5Wbm1vgPps3b9btt9+uGjVqyNfXV2FhYXr11VdLsWoAAFDWebnz5JMnT9bs2bOVmJio8PBwbd26VQMHDlRAQIAee+yxfPepVKmShg8frhtuuEGVKlXS5s2bNXToUFWqVEkPPfRQKY8AAACURTZjjHHXyXv06KE6depozpw5jrbevXvLz89P8+fPd/k49913nypVquTSPna7XQEBAcrIyJC/v/9l1Q0AAEpXUV+/3XqLqk2bNlq3bp0OHDggSdq5c6c2b96sbt26uXyM7du366uvvlK7du3y3Z6VlSW73e70AAAA1ubWW1SjRo1SRkaGwsLC5OnpqZycHMXFxSkyMvKS+9avX1+//PKLsrOz9fzzz2vw4MH59ouPj9eECROKu3QAAFCGufUKzpIlS7RgwQItXLhQ27ZtU2JioqZOnarExMRL7vvFF19o69atmj17tqZPn65Fixbl2y82NlYZGRmOx5EjR4p7GAAAoIxx6xqcoKAgjR49WsOGDXO0vfjii1qwYIH27dvn8nFefPFFzZ8/X/v3779kX9bgAABQ/pSrNTjnzp2Th4dzCZ6enoW+TTw/xhhlZWUVZ2kAAKAcc+sanJ49eyouLk7BwcEKDw/X9u3bNW3aNMXExDj6xMbG6ujRo5o3b54k6Y033lBwcLDCwsIk/fm5OFOnTtWjjz7qljEAAICyx60BZ+bMmRo7dqweeeQRnThxQoGBgRo6dKjGjRvn6JOenq7U1FTH89zcXMXGxurQoUPy8vJSo0aN9NJLL2no0KHuGAIAACiD3LoGxx1YgwMAQPlTrtbgAAAAlAQCDgAAsBwCDgAAsBwCDgAAsBwCDgAAsBwCDgAAsBwCDgAAsBwCDgAAsBwCDgAAsBwCDgAAsBwCDgAAsBwCDgAAsBwCDgAAsBwCDgAAsBwCDgAAsBwCDgAAsBwCDgAAsBwCDgAAsBwCDgAAsBwCDgAAsBwCDgAAsBwCDgAAsBwCDgAAsBwCDgAAsBwCDgAAsBwCDgAAsBwCDgAAsBwCDgAAsBwCDgAAsBwCDgAAsBwCDgAAsBy3Bpzs7GyNGTNGoaGh8vX1VcOGDTVx4kTl5uYWuM+yZcvUqVMn1apVS/7+/mrVqpU+++yzUqwaAACUdW4NOJMnT9bs2bP1+uuva+/evZoyZYpefvllzZw5s8B9Pv/8c3Xq1EkrV67U//73P3Xo0EE9e/bU9u3bS7FyAABQltmMMcZdJ+/Ro4fq1KmjOXPmONp69+4tPz8/zZ8/3+XjhIeHq2/fvho3btwl+9rtdgUEBCgjI0P+/v6XVTcAAChdRX39dusVnDZt2mjdunU6cOCAJGnnzp3avHmzunXr5vIxcnNzlZmZqerVq+e7PSsrS3a73ekBAACszcudJx81apQyMjIUFhYmT09P5eTkKC4uTpGRkS4f45VXXtFvv/2m+++/P9/t8fHxmjBhQnGVDAAAygG3XsFZsmSJFixYoIULF2rbtm1KTEzU1KlTlZiY6NL+ixYt0vPPP68lS5aodu3a+faJjY1VRkaG43HkyJHiHAIAACiD3HoF5+mnn9bo0aP1wAMPSJKaN2+uw4cPKz4+XlFRUYXuu2TJEg0aNEhLly5Vx44dC+zn4+MjHx+fYq0bAACUbW69gnPu3Dl5eDiX4OnpWejbxKU/r9xER0dr4cKF6t69e0mWCAAAyiG3XsHp2bOn4uLiFBwcrPDwcG3fvl3Tpk1TTEyMo09sbKyOHj2qefPmSfoz3AwYMEAzZszQbbfdpmPHjkmSfH19FRAQ4JZxAACAssWtbxPPzMzU2LFjlZSUpBMnTigwMFCRkZEaN26cvL29JUnR0dFKSUnRxo0bJUnt27fXpk2b8hwrKipKc+fOveQ5eZs4AADlT1Ffv90acNyBgAMAQPlTrj4HBwAAoCQQcAAAgOUQcAAAgOUQcAAAgOUQcAAAgOUQcAAAgOUQcAAAgOUQcAAAgOUQcAAAgOUQcAAAgOUQcAAAgOUQcAAAgOUQcAAAgOUQcAAAgOUQcAAAgOUQcAAAgOUQcAAAgOUQcAAAgOUQcAAAgOUQcAAAgOUQcAAAgOUQcAAAgOUQcAAAgOUQcAAAgOUQcAAAgOUQcAAAgOUQcAAAgOUQcAAAgOUQcAAAgOUQcAAAgOUQcAAAgOW4NeBkZ2drzJgxCg0Nla+vrxo2bKiJEycqNze3wH3S09PVr18/NWvWTB4eHnr88cdLr2AAAFAueLnz5JMnT9bs2bOVmJio8PBwbd26VQMHDlRAQIAee+yxfPfJyspSrVq19Nxzz+nVV18t5YoBAEB54NaA8/XXX6tXr17q3r27JCkkJESLFi3S1q1bC9wnJCREM2bMkCS98847pVInAAAoX9x6i6pNmzZat26dDhw4IEnauXOnNm/erG7duhXbObKysmS3250eAADA2tx6BWfUqFHKyMhQWFiYPD09lZOTo7i4OEVGRhbbOeLj4zVhwoRiOx4AACj73HoFZ8mSJVqwYIEWLlyobdu2KTExUVOnTlViYmKxnSM2NlYZGRmOx5EjR4rt2AAAoGxy6xWcp59+WqNHj9YDDzwgSWrevLkOHz6s+Ph4RUVFFcs5fHx85OPjUyzHAgAA5YNbr+CcO3dOHh7OJXh6ehb6NnEAAIBLcesVnJ49eyouLk7BwcEKDw/X9u3bNW3aNMXExDj6xMbG6ujRo5o3b56jbceOHZKks2fP6pdfftGOHTvk7e2t6667rrSHAAAAyiCbMca46+SZmZkaO3askpKSdOLECQUGBioyMlLjxo2Tt7e3JCk6OlopKSnauHGjYz+bzZbnWA0aNFBKSsolz2m32xUQEKCMjAz5+/sX11AAAEAJKurrt1sDjjsQcAAAKH+K+vrNd1EBAADLIeAAAADLIeAAAADLIeAAAADLIeAAAADLIeAAAADLIeAAAADLIeAAAADLIeAAAADLIeAAAADLIeAAAADLIeAAAADLIeAAAADLIeAAAADLIeAAAADLIeAAAADLIeAAAADLIeAAAADLIeAAAADLIeAAAADLIeAAAADLIeAAAADLIeAAAADLKVLAWbduXaHbc3Nz9eKLL15RQQAAAFeqSAHnrrvu0vDhw3Xu3Lk823bv3q2WLVtq1qxZxVYcAADA5ShSwPniiy+0bt063XDDDfryyy8l/f+rNjfddJOuvfZa7d69u0QKBQAAcJVXUTrfeuut2r59u0aPHq0OHTrooYce0pYtW3T06FG999576tWrV0nVCQAA4LIiBRxJqlixol599VWdOHFCb775pipVqqTk5GSFhYWVRH0AAABFVuR3Uf34449q27at1q9fr9mzZ6t58+Zq166dkpKSSqI+AACAIitSwHn99df1j3/8Q7Vr19auXbv00EMPafPmzXryySfVr18//fvf/9bp06dLqlYAAACX2IwxxtXONWrU0GuvvaYHH3wwz7Y9e/YoKipK6enpOnr0aLEWWZzsdrsCAgKUkZEhf39/d5cDAABcUNTX7yJdwdm9e3e+4UaSwsPD9c033+jhhx92+XjZ2dkaM2aMQkND5evrq4YNG2rixInKzc0tdL9NmzbppptuUsWKFdWwYUPNnj27KMMAAAAWV6RFxvXq1ZMkLV26VIsWLdKBAwdks9nUpEkT9evXT3369NHYsWNdPt7kyZM1e/ZsJSYmKjw8XFu3btXAgQMVEBCgxx57LN99Dh06pG7dumnIkCFasGCBvvzySz3yyCOqVauWevfuXZThAAAAiyrSLarc3FxFRkZq6dKlatq0qcLCwmSM0b59+3Tw4EFFRERo0aJFstlsLh2vR48eqlOnjubMmeNo6927t/z8/DR//vx89xk1apQ++ugj7d2719H28MMPa+fOnfr6668veU5uUQEAUP6U6C2q6dOna+3atfroo4+0b98+LV++XB9++KH279+vpKQkrVmzRjNmzHD5eG3atNG6det04MABSdLOnTu1efNmdevWrcB9vv76a3Xu3NmprUuXLtq6dasuXLiQp39WVpbsdrvTAwAAWFuRAs7cuXP18ssvq0ePHnm23X333ZoyZYrT1ZhLGTVqlCIjIxUWFqYKFSroxhtv1OOPP67IyMgC9zl27Jjq1Knj1FanTh1lZ2fr5MmTefrHx8crICDA8QgKCnK5PgAAUD4VKeD88MMP6tixY4HbO3bsqIMHD7p8vCVLlmjBggVauHChtm3bpsTERE2dOlWJiYmF7vf3W2AX77Lld2ssNjZWGRkZjseRI0dcrg8AAJRPRVpk7OvrqzNnzig4ODjf7Xa7Xb6+vi4f7+mnn9bo0aP1wAMPSJKaN2+uw4cPKz4+XlFRUfnuU7duXR07dsyp7cSJE/Ly8lKNGjXy9Pfx8ZGPj4/LNQEAgPKvSFdwWrVqVei3hb/xxhtq1aqVy8c7d+6cPDycS/D09Cz0beKtWrXSmjVrnNpWr16tm2++WRUqVHD53AAAwLqKdAXnueeeU/v27fXrr79q5MiRjndR7d27V6+88oo+/PBDbdiwweXj9ezZU3FxcQoODlZ4eLi2b9+uadOmKSYmxtEnNjZWR48e1bx58yT9+Y6p119/XU8++aSGDBmir7/+WnPmzNGiRYuKMhQAAGBhRXqbuCQlJSXpoYce0qlTpxxtxhhVr15d//nPf4r0WTSZmZkaO3askpKSdOLECQUGBioyMlLjxo2Tt7e3JCk6OlopKSnauHGjY79NmzbpiSee0J49exQYGKhRo0a5/AGDvE0cAIDyp6iv30UOONKft5ZWr17teHt306ZN1blzZ/n5+RW94lJGwAEAoPwp6ut3kW5RSX9+2N/ixYu1bNkypaSkyGazKTQ0VHa7Xf3793f5Q/4AAABKSpEWGRtjdPfdd2vw4ME6evSomjdvrvDwcB0+fFjR0dG69957S6pOAAAAlxXpCs7cuXP1+eefa926derQoYPTtvXr1+uee+7RvHnzNGDAgGItEgAAoCiKdAVn0aJFevbZZ/OEG0m68847NXr0aL377rvFVhwAAMDlKFLA+e6779S1a9cCt991113auXPnFRcFAABwJYoUcE6dOpXne6D+qk6dOjp9+vQVFwUAAHAlihRwcnJy5OVV8LIdT09PZWdnX3FRAAAAV6JIi4yNMYqOji7wu52ysrKKpSgAAIArUaSAU9AXYP4V76ACAADuVqSAk5CQUFJ1AAAAFJsircEBAAAoDwg4AADAcgg4AADAcgg4AADAcgg4AADAcgg4AADAcgg4AADAcgg4AADAcgg4AADAcgg4AADAcgg4AADAcgg4AADAcgg4AADAcgg4AADAcgg4AADAcgg4AADAcgg4AADAcgg4AADAcgg4AADAcgg4AADAcgg4AADActwacEJCQmSz2fI8hg0bVuA+b7zxhq699lr5+vqqWbNmmjdvXilWDAAAygMvd548OTlZOTk5jue7d+9Wp06dFBERkW//WbNmKTY2Vm+99ZZatmypb7/9VkOGDFG1atXUs2fP0iobAACUcTZjjHF3ERc9/vjjWrFihX744QfZbLY821u3bq3bb79dL7/8stM+W7du1ebNm106h91uV0BAgDIyMuTv719stQMAgJJT1Ndvt17B+avz589rwYIFevLJJ/MNN5KUlZWlihUrOrX5+vrq22+/1YULF1ShQoV898nKynI8t9vtxVs4AAAoc8rMIuPly5frzJkzio6OLrBPly5d9Pbbb+t///ufjDHaunWr3nnnHV24cEEnT57Md5/4+HgFBAQ4HkFBQSU0AgAAUFaUmVtUXbp0kbe3tz7++OMC+/z+++8aNmyY5s+fL2OM6tSpo3//+9+aMmWKjh8/rtq1a+fZJ78rOEFBQdyiAgCgHCnqLaoycQXn8OHDWrt2rQYPHlxoP19fX73zzjs6d+6cUlJSlJqaqpCQEFWpUkU1a9bMdx8fHx/5+/s7PQAAgLWViTU4CQkJql27trp37+5S/woVKqh+/fqSpMWLF6tHjx7y8CgTWQ0AAJQBbg84ubm5SkhIUFRUlLy8nMuJjY3V0aNHHZ91c+DAAX377be69dZbdfr0aU2bNk27d+9WYmKiO0oHAABllNsDztq1a5WamqqYmJg829LT05Wamup4npOTo1deeUX79+9XhQoV1KFDB3311VcKCQkpxYoBAEBZV2YWGZcWPgcHAIDyp1wuMgYAAChOBBwAAGA5BBwAAGA5BBwAAGA5BBwAAGA5BBwAAGA5BBwAAGA5BBwAAGA5BBwAAGA5BBwAAGA5BBwAAGA5BBwAAGA5BBwAAGA5BBwAAGA5BBwAAGA5BBwAAGA5BBwAAGA5BBwAAGA5BBwAAGA5BBwAAGA5BBwAAGA5BBwAAGA5BBwAAGA5BBwAAGA5BBwAAGA5BBwAAGA5BBwAAGA5BBwAAGA5BBwAAGA5BBwAAGA5BBwAAGA5bg04ISEhstlseR7Dhg0rcJ93331X//jHP+Tn56d69epp4MCB+vXXX0uxagAAUNa5NeAkJycrPT3d8VizZo0kKSIiIt/+mzdv1oABAzRo0CDt2bNHS5cuVXJysgYPHlyaZQMAgDLOy50nr1WrltPzl156SY0aNVK7du3y7b9lyxaFhIRoxIgRkqTQ0FANHTpUU6ZMKfFaAQBA+VFm1uCcP39eCxYsUExMjGw2W759WrdurZ9//lkrV66UMUbHjx/X+++/r+7duxd43KysLNntdqcHAACwtjITcJYvX64zZ84oOjq6wD6tW7fWu+++q759+8rb21t169ZV1apVNXPmzAL3iY+PV0BAgOMRFBRUAtUDAICyxGaMMe4uQpK6dOkib29vffzxxwX2+f7779WxY0c98cQT6tKli9LT0/X000+rZcuWmjNnTr77ZGVlKSsry/HcbrcrKChIGRkZ8vf3L/ZxAACA4me32xUQEODy63eZCDiHDx9Ww4YNtWzZMvXq1avAfv3799cff/yhpUuXOto2b96sO+64Q2lpaapXr94lz1XUHxAAAHC/or5+l4lbVAkJCapdu3aha2kk6dy5c/LwcC7Z09NTklQGchoAACgj3B5wcnNzlZCQoKioKHl5Ob+pKzY2VgMGDHA879mzp5YtW6ZZs2bpp59+0pdffqkRI0bolltuUWBgYGmXDgAAyii3vk1cktauXavU1FTFxMTk2Zaenq7U1FTH8+joaGVmZur111/XU089papVq+rOO+/U5MmTS7NkAABQxpWJNTiliTU4AACUP+VyDQ4AAEBxIuAAAADLIeAAAADLIeAAAADLIeAAAADLIeAAAADLIeAAAADLIeAAAADLIeAAAADLIeAAAADLIeAAAADLIeAAAADLIeAAAADLIeAAAADLIeAAAADLIeAAAADLIeAAAADLIeAAAADLIeAAAADLIeAAAADLIeAAAADLIeAAAADLIeAAAADLIeAAAADLIeAAAADLIeAAAADLIeAAAADLIeAAAADLIeAAAADLIeAAAADLIeAAAADLcWvACQkJkc1my/MYNmxYvv2jo6Pz7R8eHl7KlQMAgLLMrQEnOTlZ6enpjseaNWskSREREfn2nzFjhlP/I0eOqHr16gX2BwAAVycvd568Vq1aTs9feuklNWrUSO3atcu3f0BAgAICAhzPly9frtOnT2vgwIElWicAAChf3Bpw/ur8+fNasGCBnnzySdlsNpf2mTNnjjp27KgGDRoU2CcrK0tZWVmO53a7/YprBQAAZVuZWWS8fPlynTlzRtHR0S71T09P16pVqzR48OBC+8XHxzuu/AQEBCgoKKgYqgUAAGWZzRhj3F2EJHXp0kXe3t76+OOPXeofHx+vV155RWlpafL29i6wX35XcIKCgpSRkSF/f/8rrhsAAJQ8u92ugIAAl1+/y8QtqsOHD2vt2rVatmyZS/2NMXrnnXfUv3//QsONJPn4+MjHx6c4ygQAAOVEmbhFlZCQoNq1a6t79+4u9d+0aZMOHjyoQYMGlXBlAACgPHJ7wMnNzVVCQoKioqLk5eV8QSk2NlYDBgzIs8+cOXN066236vrrry+tMgEAQDni9oCzdu1apaamKiYmJs+29PR0paamOrVlZGTogw8+4OoNAAAoUJlZZFxairpICQAAuF9RX7/dfgUHAACguBFwAACA5RBwAACA5RBwAACA5RBwAACA5RBwAACA5RBwAACA5RBwAACA5RBwAACA5RBwAACA5RBwAACA5RBwAACA5RBwAACA5RBwAACA5RBwAACA5RBwAACA5RBwAACA5RBwAACA5RBwAACA5RBwAACA5RBwAACA5RBwAACA5RBwAACA5RBwAACA5RBwAACA5RBwAACA5RBwAACA5RBwAACA5RBwAACA5RBwAACA5RBwAACA5bg14ISEhMhms+V5DBs2rMB9srKy9Nxzz6lBgwby8fFRo0aN9M4775Ri1QAAoKzzcufJk5OTlZOT43i+e/duderUSREREQXuc//99+v48eOaM2eOGjdurBMnTig7O7s0ygUAAOWEWwNOrVq1nJ6/9NJLatSokdq1a5dv/08//VSbNm3STz/9pOrVq0v68yoQAADAX5WZNTjnz5/XggULFBMTI5vNlm+fjz76SDfffLOmTJmia665Rk2bNtXIkSP1+++/F3jcrKws2e12pwcAALA2t17B+avly5frzJkzio6OLrDPTz/9pM2bN6tixYpKSkrSyZMn9cgjj+jUqVMFrsOJj4/XhAkTSqhqAABQFtmMMcbdRUhSly5d5O3trY8//rjAPp07d9YXX3yhY8eOKSAgQJK0bNky9enTR7/99pt8fX3z7JOVlaWsrCzHc7vdrqCgIGVkZMjf37/4BwIAAIqd3W5XQECAy6/fZeIKzuHDh7V27VotW7as0H716tXTNddc4wg3knTttdfKGKOff/5ZTZo0ybOPj4+PfHx8ir1mAABQdpWJNTgJCQmqXbu2unfvXmi/22+/XWlpaTp79qyj7cCBA/Lw8FD9+vVLukwAAFBOuD3g5ObmKiEhQVFRUfLycr6gFBsbqwEDBjie9+vXTzVq1NDAgQP1/fff6/PPP9fTTz+tmJiYfG9PAQCAq5PbA87atWuVmpqqmJiYPNvS09OVmprqeF65cmWtWbNGZ86c0c0336wHH3xQPXv21GuvvVaaJQMAgDKuzCwyLi1FXaQEAADcr6iv326/ggMAAFDcCDgAAMByCDgAAMByCDgAAMByCDgAAMByCDgAAMByCDgAAMByCDgAAMByCDgAAMByysS3iZemix/cbLfb3VwJAABw1cXXbVe/gOGqCziZmZmSpKCgIDdXAgAAiiozM1MBAQGX7HfVfRdVbm6u0tLSVKVKFdlsNneX42C32xUUFKQjR45Y9juyrD5Gq49Psv4YGV/5ZvXxSdYfY2HjM8YoMzNTgYGB8vC49Aqbq+4KjoeHh+rXr+/uMgrk7+9vyV/av7L6GK0+Psn6Y2R85ZvVxydZf4wFjc+VKzcXscgYAABYDgEHAABYDgGnjPDx8dH48ePl4+Pj7lJKjNXHaPXxSdYfI+Mr36w+Psn6YyzO8V11i4wBAID1cQUHAABYDgEHAABYDgEHAABYDgGnjLPZbFq+fLm7y8AVYA7LP+awfGP+yr/LmUMCTimLjo7WPffc4+4yLkt8fLxatmypKlWqqHbt2rrnnnu0f/9+pz7GGD3//PMKDAyUr6+v2rdvrz179ji2nzp1So8++qiaNWsmPz8/BQcHa8SIEcrIyHA6TlxcnFq3bi0/Pz9VrVq1NIbnMubw0nOYkpKiQYMGKTQ0VL6+vmrUqJHGjx+v8+fPl9pYC8Mcuvbv8O6771ZwcLAqVqyoevXqqX///kpLSyuVcRaG+XNt/i7KyspSixYtZLPZtGPHjpIcnstKYw4JOHDZpk2bNGzYMG3ZskVr1qxRdna2OnfurN9++83RZ8qUKZo2bZpef/11JScnq27duurUqZPjO8DS0tKUlpamqVOnateuXZo7d64+/fRTDRo0yOlc58+fV0REhP7P//k/pTpGqyutOdy3b59yc3P1n//8R3v27NGrr76q2bNn69lnny31MVtNaf477NChg9577z3t379fH3zwgX788Uf16dOnVMdrNaU5fxc988wzCgwMLJXxlSkGpSoqKsr06tXLGGNMgwYNzKuvvuq0/R//+IcZP36847kkk5SUVGr1FcWJEyeMJLNp0yZjjDG5ubmmbt265qWXXnL0+eOPP0xAQICZPXt2gcd57733jLe3t7lw4UKebQkJCSYgIKDYa78SzGFehc3hRVOmTDGhoaHFV/wVYA7zcmUOP/zwQ2Oz2cz58+eLbwCXgfnLq6D5W7lypQkLCzN79uwxksz27dtLZBxFVRpzyBUcXLaLl0OrV68uSTp06JCOHTumzp07O/r4+PioXbt2+uqrrwo9jr+/v7y8rrqvRnO70pzDjIwMx3lQfEprDk+dOqV3331XrVu3VoUKFYpxBFe3kpy/48ePa8iQIZo/f778/PxKaARlFwEHl8UYoyeffFJt2rTR9ddfL0k6duyYJKlOnTpOfevUqePY9ne//vqrXnjhBQ0dOrRkC0YepTmHP/74o2bOnKmHH364mKqHVDpzOGrUKFWqVEk1atRQamqqPvzww2IexdWrJOfPGKPo6Gg9/PDDuvnmm0toBGUbAQeXZfjw4fruu++0aNGiPNtsNpvTc2NMnjZJstvt6t69u6677jqNHz++xGpF/kprDtPS0tS1a1dFRERo8ODBxVM8JJXOHD799NPavn27Vq9eLU9PTw0YMECGD8AvFiU5fzNnzpTdbldsbGzxF15OEHDcyMPDI8//KC5cuOCmalz36KOP6qOPPtKGDRtUv359R3vdunUlKc9fGSdOnMjz10hmZqa6du2qypUrKykpqdxe8mYOC5/DtLQ0dejQQa1atdJ///vfEhjJlWMOC5/DmjVrqmnTpurUqZMWL16slStXasuWLSUwosvD/OU/f+vXr9eWLVvk4+MjLy8vNW7cWJJ08803KyoqqqSGdVlKag4JOG5Uq1YtpaenO57b7XYdOnTIjRUVzhij4cOHa9myZVq/fr1CQ0OdtoeGhqpu3bpas2aNo+38+fPatGmTWrdu7Wiz2+3q3LmzvL299dFHH6lixYqlNobixhwWPIdHjx5V+/bt9c9//lMJCQny8Cib/7thDl3/d3jxRSgrK6uYRnPlmL/85++1117Tzp07tWPHDu3YsUMrV66UJC1ZskRxcXElOMKiK6k5ZFWnG915552aO3euevbsqWrVqmns2LHy9PR0d1kFGjZsmBYuXKgPP/xQVapUcfyFERAQIF9fX9lsNj3++OOaNGmSmjRpoiZNmmjSpEny8/NTv379JP35F0fnzp117tw5LViwQHa7XXa7XdKfv+QXx5+amqpTp04pNTVVOTk5js9uaNy4sSpXrlz6gy8Ac5j/HKalpal9+/YKDg7W1KlT9csvvzhquPgXalnBHOY/h99++62+/fZbtWnTRtWqVdNPP/2kcePGqVGjRmrVqpXbxv93zF/+8xccHOx03ov/32zUqJHTFaOyoMTmsEjvucIV69+/v+ndu7cxxpiMjAxz//33G39/fxMUFGTmzp1bpt/eKCnfR0JCgqNPbm6uGT9+vKlbt67x8fExbdu2Nbt27XJs37BhQ4HHOXTokKNfVFRUvn02bNhQegMuAHN46TlMSEgosE9ZwBxeeg6/++4706FDB1O9enXj4+NjQkJCzMMPP2x+/vnnUh5xXsyfa/8f/atDhw6VqbeJl8Yc2v7fjiglXbt2VePGjfX666+7uxRcJuaw/GMOyzfmr/wrjTksmzfFLej06dP65JNPtHHjRnXs2NHd5eAyMIflH3NYvjF/5V9pziFrcEpJTEyMkpOT9dRTT6lXr17uLgeXgTks/5jD8o35K/9Kcw65RQUAACyHW1QAAMByCDgAAMByCDgAAMByCDgAAMByCDgAyoWNGzfKZrPpzJkz7i4FQDnAu6gAlEnt27dXixYtNH36dEl/fh/PqVOnVKdOnXy/VRkA/orPwQFQLnh7e5e577ECUHZxiwpAmRMdHa1NmzZpxowZstlsstlsmjt3rtMtqrlz56pq1apasWKFmjVrJj8/P/Xp00e//fabEhMTFRISomrVqunRRx9VTk6O49jnz5/XM888o2uuuUaVKlXSrbfeqo0bN7pnoABKDFdwAJQ5M2bM0IEDB3T99ddr4sSJkqQ9e/bk6Xfu3Dm99tprWrx4sTIzM3XffffpvvvuU9WqVbVy5Ur99NNP6t27t9q0aaO+fftKkgYOHKiUlBQtXrxYgYGBSkpKUteuXbVr1y41adKkVMcJoOQQcACUOQEBAfL29pafn5/jttS+ffvy9Ltw4YJmzZqlRo0aSZL69Omj+fPn6/jx46pcubKuu+46dejQQRs2bFDfvn31448/atGiRfr5558VGBgoSRo5cqQ+/fRTJSQkaNKkSaU3SAAlioADoNzy8/NzhBtJqlOnjkJCQlS5cmWnthMnTkiStm3bJmOMmjZt6nScrKws1ahRo3SKBlAqCDgAyq0KFSo4PbfZbPm25ebmSpJyc3Pl6emp//3vf/L09HTq99dQBKD8I+AAKJO8vb2dFgcXhxtvvFE5OTk6ceKE7rjjjmI9NoCyhXdRASiTQkJC9M033yglJUUnT550XIW5Ek2bNtWDDz6oAQMGaNmyZTp06JCSk5M1efJkrVy5shiqBlBWEHAAlEkjR46Up6enrrvuOtWqVUupqanFctyEhAQNGDBATz31lJo1a6a7775b33zzjYKCgorl+ADKBj7JGAAAWA5XcAAAgOUQcAAAgOUQcAAAgOUQcAAAgOUQcAAAgOUQcAAAgOUQcAAAgOUQcAAAgOUQcAAAgOUQcAAAgOUQcAAAgOUQcAAAgOX8X64HnHJvZHelAAAAAElFTkSuQmCC",
+      "text/plain": [
+       "<Figure size 640x480 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "transport_model.mesh.DOX.isel(nface=151, time=slice(0, 5000)).plot()\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 36,
+   "id": "1dfaa667",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[<matplotlib.lines.Line2D at 0x1c25ca0bdd0>]"
+      ]
+     },
+     "execution_count": 36,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAjgAAAHFCAYAAAD/kYOsAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjguNCwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8fJSN1AAAACXBIWXMAAA9hAAAPYQGoP6dpAABABElEQVR4nO3deVxV1R738e8BBEEFxRnFQHNIsvSWmWY5lEOO19QMS0HU7MkyK7vKzSErRc1MM81bGaI4ZTmUmTlTlpbmcB1SG0RUUCyTg1kosJ4/ejyPXKaDAgd2n/frdV4vz95r7f1brCPnyx7OsRljjAAAACzEzdUFAAAAFDYCDgAAsBwCDgAAsBwCDgAAsBwCDgAAsBwCDgAAsBwCDgAAsBwCDgAAsBwCDgAAsBwCDnK1fPlyhYSEyNvbWzabTfv27XN1SSVefHy8bDZbjo9ly5Y5tY2LFy9q5MiRCggIUNmyZdW0adMc+27fvl1DhgzRHXfcIS8vL9lsNsXHx+e7/cOHDzva7969u6BDvGHOji88PDzHn2OjRo1uaP+zZ8/WzTffLE9PT9lsNl24cOGGtvd3sGXLFkVERKhRo0YqV66catWqpZ49e+q7775zqv+mTZvUoUMHBQQEyMvLS9WqVVP79u21bt26XNu3bNlSPj4+qlKlisLDw5WcnJzvPq6+Rn755ZcCj/FGJScnKzw8XFWqVJGPj49atmypzZs3Z2v34osvqlmzZvL391fZsmVVt25dPf744zpx4kSx12x1Hq4uACXTuXPnNGDAAHXu3Flz586Vl5eXGjRo4OqySo2nn35a/fv3z7Ksfv36TvV96KGHtGvXLk2ZMkUNGjTQkiVLFBoaqszMzCzb3Lx5szZt2qRmzZrJ19dX27Zty3fbGRkZioiIUJUqVZSYmFigMRUWZ8cnSd7e3tqyZUu2Zddr3759GjFihIYMGaKwsDB5eHioQoUK1729v4u3335bv/76q5555hk1btxY586d0+uvv667775bn3/+udq3b59n/19//VUhISEaMmSIatSoofPnz2vevHnq2rWrFi1apMcee8zRNi4uTg8++KC6du2qNWvWKDk5WaNHj9b999+v3bt3y8vLK9v2L168qKFDhyogIMAlr+u0tDTdf//9unDhgmbNmqVq1appzpw56ty5szZt2qQ2bdo42l64cEGhoaG65ZZbVKFCBR0+fFivvvqqPv74Yx06dEiVK1cu9votywA52L59u5Fkli9f7upSSpXjx48bSea11167rv6ffvqpkWSWLFmSZXmHDh1MQECASU9PdyzLyMhw/Pu1114zkszx48fz3P5rr71matWqZWbNmmUkmV27dl1XnTkJCwszbdq0ybNNQcYXFhZmypUrV2j1GWNMbGyskWS++eabQt2u1Z09ezbbstTUVFO9enVz//33X9c2L1++bGrVqmXuvffeLMubN29uGjdubK5cueJY9tVXXxlJZu7cuTlua/jw4aZZs2Zm7NixRpI5d+7cddWUkzZt2piwsLA828yZM8dIMl9//bVj2ZUrV0zjxo3NXXfdle8+1q1bZySZ+fPn32i5uAanqJBNeHi4WrduLUnq16+fbDab2rZtK0navXu3HnnkEQUFBcnb21tBQUEKDQ3N8fDq6dOn9fjjjyswMFCenp4KCAhQnz59dPbsWUcbu92uUaNGKTg4WJ6enqpVq5ZGjhyp33//3el6f/nlFwUGBqpVq1a6cuWKY/nhw4dVrlw5DRgw4Dp/EsVv1apVKl++vPr27Ztl+aBBg5SYmKhvvvnGsczNrWD/fX/44QeNHz9ec+fOla+vb67tdu/erR49ejgOoTdr1kwffPBBwQaSi4KMr7C1bdvWcaSgRYsWstlsCg8PlyRt3LhRPXv2VO3atVW2bFndfPPNGjZsWI6nOo4cOaLQ0FBVr15dXl5eqlOnjgYOHKi0tDRHmzNnzmjYsGGqXbu2PD09FRwcrIkTJyo9Pd3pel955RV5eHjo5MmT2dZFRESocuXK+vPPPwv4U7g+1apVy7asfPnyaty4cY71OaNMmTKqWLGiPDz+/4mE06dPa9euXRowYECW5a1atVKDBg20atWqbNv58ssv9c477+i9996Tu7t7rvvbtGmT7r//fvn6+srHx0f33HNPjqeQrseqVavUsGFDtWzZ0rHMw8NDjz32mL799ludPn06z/5Vq1Z19EHhIeAgm3HjxmnOnDmSpMmTJ2vHjh2aO3eupL+uMWnYsKFmzpypzz//XFOnTlVSUpKaN2+e5c3g9OnTat68uVatWqXnnntOn332mWbOnCk/Pz/99ttvkqRLly6pTZs2iomJ0YgRI/TZZ59p9OjRWrBggXr06CHj5BfdV6lSRcuWLdOuXbs0evRox7b79u2rOnXqaN68eXn2N8YoPT3dqYezpkyZIk9PT/n4+Kh169b6+OOPnep38OBB3XLLLdl+0d12222O9dfDGKMhQ4aoW7du6tGjR67ttm7dqnvuuUcXLlzQvHnztGbNGjVt2lT9+vXTggULrmvf1yro+P744w/VqFFD7u7uql27tp566imdP3/+uvY9d+5cjR07VpIUHR2tHTt2aNy4cZKkn376SS1bttTbb7+tDRs2aPz48frmm2/UunXrLKF5//79at68uXbu3KmXX35Zn332maKiopSWlqbLly9L+ivc3HXXXfr88881fvx4ffbZZxo8eLCioqI0dOhQp+sdNmyYPDw89J///CfL8vPnz2vZsmUaPHiwypYtm2v/onhdXyslJUV79uxRSEiI030yMzOVnp6uxMRETZgwQceOHdPzzz/vWH91/q++Hq5122235fj6GDx4sEaOHKl//OMfue43NjZWHTt2lK+vr2JiYvTBBx/I399fnTp1KpSQc/DgwVxrlqRDhw5lW5eenq4//vhDe/fu1ciRI9WgQQM99NBDN1wLruHaA0goqbZu3WokmRUrVuTZLj093Vy8eNGUK1fOzJo1y7E8IiLClClTxhw+fDjXvlFRUcbNzS3baZIPP/zQSDLr1q0rUM1Tp041ksyqVatMWFiY8fb2Nv/973/z7Xd1rM488jsFlJiYaIYOHWo++OAD8+WXX5rFixebu+++20gy7777br611K9f33Tq1CnH7UoykydPzrFffqeoZs+ebSpVqmTOnDljjDEmOjo6x1NUjRo1Ms2aNctyesAYY7p162Zq1qyZ5bTYlStXsjwGDhxo7rvvvmzLMzMzr2t8M2bMMDNmzDAbNmwwGzZsMC+++KLx8fExjRo1MqmpqTmOMz+5jftamZmZ5sqVK+bEiRNGklmzZo1jXfv27U3FihVNcnJyrv2HDRtmypcvb06cOJFl+fTp040kc+jQIafrDQsLM9WqVTNpaWmOZVOnTjVubm75vhavjtWZx/V49NFHjYeHh9m9e7fTfTp16uTYp6+vr1m5cmWW9YsXLzaSzI4dO7L1ffzxx42np2eWZc8//7ypW7euuXTpkjHGmAkTJmQ7RfX7778bf39/07179yx9MzIyzO23357lFNLVub/2cd9995mBAwdmW36tMmXKmGHDhmWr+euvv87xlGxSUlKWn3+LFi3M6dOn8/rR4TpwPAwFcvHiRb3yyiv66KOPFB8fr4yMDMe677//3vHvzz77TO3atdMtt9yS67bWrl2rW2+9VU2bNs3yV2SnTp1ks9m0bds2Pfjgg07X9sILL+iLL75QaGio/vzzT7333ntq0qRJvv3uuOMO7dq1y6l9BAQE5Lm+Zs2aeuedd7Is69u3r1q0aKExY8YoPDw838PQNpvtutbl5sSJE4qMjNTMmTNVvXr1XNv9+OOPOnLkiKZPny5JWeakS5cuWrt2rY4ePapbbrlF8fHxCg4OznE7ZcqUyfJ869atjlOc+Y3h2nXPPvtslnUdOnRQs2bN1KdPH7377rvZ1t+I5ORkjR8/Xp9++qkSExOVmZnpWPf999+rR48eunTpkuLi4jR48GDHKYWcrF27Vu3atVNAQECWn+GDDz6oUaNGKS4uTo0bN3aqrmeeeUYxMTFasWKFHn30UWVmZurtt99W165dFRQUlGff7t27O/26Lqhx48Zp8eLFmj17tu644w6n+82ePVsXLlxQUlKSYmNj1a9fP8XExCg0NDRLu9xeI9cu//bbbzVz5kytX78+zwvPv/76a50/f15hYWHZjlZ17txZ06ZN0++//65y5copLi5O7dq1y7aNL774QgsXLsyy7Pjx41nmoCD/b6tUqaJdu3YpLS1N33//vaZNm6Z27dpp27ZtqlmzZq7bQcEQcFAg/fv31+bNmzVu3Dg1b95cvr6+stls6tKli/744w9Hu3Pnzql27dp5buvs2bP68ccfs70hXlXQWz2vXlPx6aefqkaNGk5fe1O+fHk1bdrUqbbXc468TJky6tevn8aMGaMffvghz9BXuXJl/frrr9mWXz0t4+/vX+D9Dx8+XLfeeqt69+7tuCX60qVLkv4KrCkpKfLz83NcGzVq1CiNGjUqx21dnZOAgIBsb54TJ05UYmJitlMqDRs2LLTx9erVS+XKldPOnTvzbFcQmZmZ6tixoxITEzVu3Dg1adJE5cqVU2Zmpu6++27H6/q3335TRkaGU6/rTz75pFBe182aNdO9996rOXPm6NFHH9XatWsVHx+f7WecE39/f/n5+Tm9L2dNnDhRr776qiZNmqSnnnqqQH2vvZOwR48eevDBBzV8+HD169dPbm5ujjuIcnuNXPv6iIiI0EMPPaQ777zT8bq+ek2S3W6Xl5eXKlSo4Hhd9+nTJ9e6zp8/r3LlyuX4x86wYcMUEBCgCRMmZFl+7R87BX1de3h46M4775Qk3XPPPercubOCg4M1ZcoUzZo1K9c6UTAEHDgtJSVFa9eu1YQJEzRmzBjH8rS0tGzXRVStWlWnTp3Kc3tVqlSRt7e33n///VzXF0RSUpKGDx+upk2b6tChQxo1apTefPPNfPvl9ldbTv73rzZnmf93PVF+FwY3adJES5cuVXp6epYwdeDAAUnSrbfeWuB9Hzx4UCdOnFClSpWyrWvXrp38/Px04cIFx887MjIy12sBroYVT09Pxy/oqypXrqzU1NRsy69VGOMzxhT4Auu8HDx4UPv379eCBQsUFhbmWP7jjz9maefv7y93d3enXte33XabJk2alOP6/I4C/q8RI0aob9++2rNnj9566y01aNBAHTp0yLdfTEyMBg0a5NQ+jJPXu02cOFEvvfSSXnrpJf373/92qk9e7rrrLq1fv17nzp1T9erVHfN/4MABdenSJUvbAwcOZHl9HDp0SIcOHdKKFSuybbdevXq6/fbbtW/fPsfrevbs2br77rtzrOPqkc0KFSpke/1WqFBBlStXzvd1ffU1/L81S/m/rmvXrq2AgAAdO3Ysz3YoGAIOnGaz2WSMyfY5FO+9916WU1XSX4fjFy1apKNHj2b5C/5a3bp10+TJk1W5cuVcT3c4KyMjQ6GhobLZbPrss8+0ePFijRo1Sm3bts33wr3CPEWVkytXrmj58uWqUqWKbr755jzb9urVS++++64++ugj9evXz7E8JiZGAQEBatGiRYH3v2zZsmx326xfv15Tp07VvHnzHBeJNmzYUPXr19f+/fs1efLkAu/HGTc6vg8//FCXLl3K9Y3qelw9ffC/r+v/PUri7e2tNm3aaMWKFZo0aVKuAbxbt25at26d6tWrl2OoLKhevXqpTp06ev755xUXF6c33njDqVOVhX2K6pVXXtFLL72ksWPHZjuacT2MMYqLi1PFihUdR25q1aqlu+66S7GxsRo1apTjrqidO3fq6NGjGjlypKP/1q1bs21zwYIFiomJ0erVq1WrVi1Jfx0hqVixog4fPlzgI07O6tWrl5588kl98803jtdwenq6YmNj1aJFi3x/b/z44486depUnjcA4Dq49AoglFi5XWR83333GX9/f/Puu++ajRs3mrFjx5qaNWuaihUrZvmsiFOnTpmaNWuaatWqmZkzZ5rNmzebjz76yAwdOtR8//33xhhjLl68aJo1a2Zq165tXn/9dbNx40bz+eefm3fffdf07dvX7Ny50+l6X3zxRePm5mY2bdrkWNa9e3dTsWJF8/PPP9/YD6MAnn32WfPUU0+ZpUuXmq1bt5qFCxea5s2bG0kmOjo6S9uJEycad3d3s23btizLO3ToYCpVqmTeeecds2XLFjN06FAjycTGxmZpl5ycbFasWGFWrFhhBg4c6PickBUrVmTb5v/K7WLbLVu2GC8vL9OxY0ezZMkSExcXZ1atWmUmT55s+vTpk+c2nfkcHGfHFx8fb1q1amXefPNNs27dOvPZZ5+ZMWPGmLJly5qQkBBz8eLFLNts06aNUxfL5jTuy5cvm3r16pmbbrrJLFmyxKxfv94MHz7cNGjQwEgyEyZMcLTdt2+fKV++vKlbt66j/qVLl5rQ0FBjt9uNMX9dMH3TTTeZRo0amblz55rNmzebTz/91MyZM8d07drVnDx5Mt86/9fVC+jLlStnLly4UOD+N+rqBdKdO3c2O3bsyPa4VkREhHF3dzfx8fGOZT169DDjxo0zH330kdm2bZtZsmSJ6dixo5Fk5syZk6X/1q1bjYeHh+nVq5fZuHGjWbx4sQkMDDS33nqr+fPPP/OsM6eLjI0xZtGiRcbNzc3069fPrFixwsTFxZkPP/zQjBs3zjzxxBN5btOZz8H5888/TUhIiAkMDDSLFy82GzduNL169TIeHh5Z/i/u37/ftG/f3sydO9esX7/ebNiwwbz++uumdu3apmrVqll+ZrhxBBzkKLeAc+rUKdO7d29TqVIlU6FCBdO5c2dz8OBBc9NNN2X7JXDy5EkTERFhatSoYcqUKWMCAgLMww8/nOVDwy5evGjGjh1rGjZsaDw9PY2fn59p0qSJefbZZx13/ORnw4YNxs3NLcsbkTHG/Prrr6ZOnTqmefPmWe5CKUrz5883d911l/H39zceHh6mUqVKplOnTubzzz/P1vbqL+OtW7dmWZ6ammpGjBhhatSoYTw9Pc1tt91mli5dmq1/Xnd/5Rc08rqbaP/+/ebhhx821apVM2XKlDE1atQw7du3N/Pmzctzm84GHGfGd/78edOrVy8TFBRkvL29jaenp6lfv77517/+leMb/B133GFq1KiR775zG/fhw4dNhw4dTIUKFUylSpVM3759TUJCQraAc7Vt3759TeXKlY2np6epU6eOCQ8Pz/Lme+7cOTNixAgTHBxsypQpY/z9/c0dd9xhXnzxxWzhzBnx8fFGUr5vxkXlaoDM7XGtsLCwbHf0TZ061TRv3txUqlTJuLu7m8qVK5tOnTqZtWvX5ri/DRs2mLvvvtuULVvW+Pv7m4EDB+b4YYP/K7eAY4wxcXFxpmvXrsbf39+UKVPG1KpVy3Tt2jXfO0WdCTjGGHPmzBkzcOBA4+/vb8qWLWvuvvtus3HjxmxtHnvsMVOvXj3j4+NjPD09Td26dc0TTzxhEhIS8t0HCsZmjJMnXwGgBEpNTZW/v79mzpyp4cOHu7qcIjF79myNGDFCBw8eLNDnzgB/Z1yDA6BU++KLL1SrVq0CfYheabF3714dP35cL7/8snr27Em4AQqAIzgo0TIzM7N8JklO+HhzlDYZGRl53rlks9nk7u6uoKAgnTlzRvfee68WLVqkGjVqFGOVQOlGwEGJFh4erpiYmDzb8BJGadO2bVvFxcXluv6mm25SfHx88RUEWBABByVafHx8vh+MltfnUwAl0dGjR5Wamprrei8vL6c+hRtA7gg4AADAcvg2cQAAYDl/u6szMzMzlZiYqAoVKlzXFxcCAIDiZ4xRamqqAgICnPq6lr9dwElMTFRgYKCrywAAANfh5MmT+X7prfQ3DDgVKlSQ9NcPyNfX18XVAAAAZ9jtdgUGBjrex/Pztws4V09L+fr6EnAAAChlnL28hIuMAQCA5RBwAACA5RBwAACA5RBwAACA5RBwAACA5RBwAACA5RBwAACA5RBwAACA5RBwAACA5RBwAACA5bg04KSnp2vs2LEKDg6Wt7e36tatq5dfflmZmZlO9f/qq6/k4eGhpk2bFm2hAACgVHHpd1FNnTpV8+bNU0xMjEJCQrR7924NGjRIfn5+euaZZ/Lsm5KSooEDB+r+++/X2bNni6liAABQGrg04OzYsUM9e/ZU165dJUlBQUFaunSpdu/enW/fYcOGqX///nJ3d9fq1auLuFIAAFCauPQUVevWrbV582YdO3ZMkrR//35t375dXbp0ybNfdHS0fvrpJ02YMCHffaSlpclut2d5AAAAa3PpEZzRo0crJSVFjRo1kru7uzIyMjRp0iSFhobm2ueHH37QmDFj9OWXX8rDI//yo6KiNHHixMIsGwAAlHAuPYKzfPlyxcbGasmSJdqzZ49iYmI0ffp0xcTE5Ng+IyND/fv318SJE9WgQQOn9hEZGamUlBTH4+TJk4U5BAAAUALZjDHGVTsPDAzUmDFjNHz4cMeyV199VbGxsTpy5Ei29hcuXFClSpXk7u7uWJaZmSljjNzd3bVhwwa1b98+z33a7Xb5+fkpJSVFvr6+hTcYAABQZAr6/u3SU1SXLl2Sm1vWg0ju7u653ibu6+urAwcOZFk2d+5cbdmyRR9++KGCg4OLrFYAAFB6uDTgdO/eXZMmTVKdOnUUEhKivXv3asaMGYqIiHC0iYyM1OnTp7Vw4UK5ubnp1ltvzbKNatWqqWzZstmWAwCAvy+XBpzZs2dr3LhxevLJJ5WcnKyAgAANGzZM48ePd7RJSkpSQkKCC6sEAACljUuvwXEFrsEBAKD0Kej7N99FBQAALIeAAwAALIeAAwAALIeAAwAALIeAAwAALIeAAwAALIeAAwAALIeAAwAALIeAAwAALIeAAwAALIeAAwAALIeAAwAALIeAAwAALIeAAwAALIeAAwAALIeAAwAALIeAAwAALIeAAwAALIeAAwAALIeAAwAALIeAAwAALIeAAwAALIeAAwAALIeAAwAALIeAAwAALIeAAwAALIeAAwAALIeAAwAALIeAAwAALIeAAwAALIeAAwAALMelASc9PV1jx45VcHCwvL29VbduXb388svKzMzMtc/27dt1zz33qHLlyvL29lajRo30xhtvFGPVAACgpPNw5c6nTp2qefPmKSYmRiEhIdq9e7cGDRokPz8/PfPMMzn2KVeunJ566inddtttKleunLZv365hw4apXLlyevzxx4t5BAAAoCSyGWOMq3berVs3Va9eXfPnz3cs6927t3x8fLRo0SKnt/PQQw+pXLlyTvWx2+3y8/NTSkqKfH19r6tuAABQvAr6/u3SU1StW7fW5s2bdezYMUnS/v37tX37dnXp0sXpbezdu1dff/212rRpk+P6tLQ02e32LA8AAGBtLj1FNXr0aKWkpKhRo0Zyd3dXRkaGJk2apNDQ0Hz71q5dW+fOnVN6erpeeuklDRkyJMd2UVFRmjhxYmGXDgAASjCXHsFZvny5YmNjtWTJEu3Zs0cxMTGaPn26YmJi8u375Zdfavfu3Zo3b55mzpyppUuX5tguMjJSKSkpjsfJkycLexgAAKCEcek1OIGBgRozZoyGDx/uWPbqq68qNjZWR44ccXo7r776qhYtWqSjR4/m25ZrcAAAKH1K1TU4ly5dkptb1hLc3d3zvE08J8YYpaWlFWZpAACgFHPpNTjdu3fXpEmTVKdOHYWEhGjv3r2aMWOGIiIiHG0iIyN1+vRpLVy4UJI0Z84c1alTR40aNZL01+fiTJ8+XU8//bRLxgAAAEoelwac2bNna9y4cXryySeVnJysgIAADRs2TOPHj3e0SUpKUkJCguN5ZmamIiMjdfz4cXl4eKhevXqaMmWKhg0b5oohAACAEsil1+C4AtfgAABQ+pSqa3AAAACKAgEHAABYDgEHAABYDgEHAABYDgEHAABYDgEHAABYDgEHAABYDgEHAABYDgEHAABYDgEHAABYDgEHAABYDgEHAABYDgEHAABYDgEHAABYDgEHAABYDgEHAABYDgEHAABYDgEHAABYDgEHAABYDgEHAABYDgEHAABYDgEHAABYDgEHAABYDgEHAABYDgEHAABYDgEHAABYDgEHAABYDgEHAABYDgEHAABYDgEHAABYDgEHAABYjksDTnp6usaOHavg4GB5e3urbt26evnll5WZmZlrn5UrV6pDhw6qWrWqfH191bJlS33++efFWDUAACjpXBpwpk6dqnnz5umtt97S999/r2nTpum1117T7Nmzc+3zxRdfqEOHDlq3bp2+++47tWvXTt27d9fevXuLsXIAAFCS2YwxxlU779atm6pXr6758+c7lvXu3Vs+Pj5atGiR09sJCQlRv379NH78+Hzb2u12+fn5KSUlRb6+vtdVNwAAKF4Fff926RGc1q1ba/PmzTp27Jgkaf/+/dq+fbu6dOni9DYyMzOVmpoqf3//HNenpaXJbrdneQAAAGvzcOXOR48erZSUFDVq1Eju7u7KyMjQpEmTFBoa6vQ2Xn/9df3+++96+OGHc1wfFRWliRMnFlbJAACgFHDpEZzly5crNjZWS5Ys0Z49exQTE6Pp06crJibGqf5Lly7VSy+9pOXLl6tatWo5tomMjFRKSorjcfLkycIcAgAAKIFcegTnhRde0JgxY/TII49Ikpo0aaITJ04oKipKYWFhefZdvny5Bg8erBUrVuiBBx7ItZ2Xl5e8vLwKtW4AAFCyufQIzqVLl+TmlrUEd3f3PG8Tl/46chMeHq4lS5aoa9euRVkiAAAohVx6BKd79+6aNGmS6tSpo5CQEO3du1czZsxQRESEo01kZKROnz6thQsXSvor3AwcOFCzZs3S3XffrTNnzkiSvL295efn55JxAACAksWlt4mnpqZq3LhxWrVqlZKTkxUQEKDQ0FCNHz9enp6ekqTw8HDFx8dr27ZtkqS2bdsqLi4u27bCwsK0YMGCfPfJbeIAAJQ+BX3/dmnAcQUCDgAApU+p+hwcAACAokDAAQAAlkPAAQAAlkPAAQAAlkPAAQAAlkPAAQAAlkPAAQAAlkPAAQAAlkPAAQAAlkPAAQAAlkPAAQAAlkPAAQAAlkPAAQAAlkPAAQAAlkPAAQAAlkPAAQAAlkPAAQAAlkPAAQAAlkPAAQAAlkPAAQAAlkPAAQAAlkPAAQAAlkPAAQAAlkPAAQAAlkPAAQAAlkPAAQAAlkPAAQAAlkPAAQAAlkPAAQAAlkPAAQAAlkPAAQAAluPSgJOenq6xY8cqODhY3t7eqlu3rl5++WVlZmbm2icpKUn9+/dXw4YN5ebmppEjRxZfwQAAoFTwcOXOp06dqnnz5ikmJkYhISHavXu3Bg0aJD8/Pz3zzDM59klLS1PVqlX14osv6o033ijmigEAQGng0oCzY8cO9ezZU127dpUkBQUFaenSpdq9e3eufYKCgjRr1ixJ0vvvv18sdQIAgNLFpaeoWrdurc2bN+vYsWOSpP3792v79u3q0qVLoe0jLS1Ndrs9ywMAAFibS4/gjB49WikpKWrUqJHc3d2VkZGhSZMmKTQ0tND2ERUVpYkTJxba9gAAQMnn0iM4y5cvV2xsrJYsWaI9e/YoJiZG06dPV0xMTKHtIzIyUikpKY7HyZMnC23bAACgZHLpEZwXXnhBY8aM0SOPPCJJatKkiU6cOKGoqCiFhYUVyj68vLzk5eVVKNsCAAClg0uP4Fy6dElubllLcHd3z/M2cQAAgPy49AhO9+7dNWnSJNWpU0chISHau3evZsyYoYiICEebyMhInT59WgsXLnQs27dvnyTp4sWLOnfunPbt2ydPT081bty4uIcAAABKIJsxxrhq56mpqRo3bpxWrVql5ORkBQQEKDQ0VOPHj5enp6ckKTw8XPHx8dq2bZujn81my7atm266SfHx8fnu0263y8/PTykpKfL19S2soQAAgCJU0PdvlwYcVyDgAABQ+hT0/ZvvogIAAJZDwAEAAJZDwAEAAJZDwAEAAJZDwAEAAJZDwAEAAJZDwAEAAJZDwAEAAJZDwAEAAJZDwAEAAJZDwAEAAJZDwAEAAJZDwAEAAJZDwAEAAJZDwAEAAJZDwAEAAJZDwAEAAJZDwAEAAJZDwAEAAJZDwAEAAJZDwAEAAJZDwAEAAJZDwAEAAJZToICzefPmPNdnZmbq1VdfvaGCAAAAblSBAs6DDz6op556SpcuXcq27uDBg2revLnefvvtQisOAADgehQo4Hz55ZfavHmzbrvtNn311VeS/v9RmzvuuEO33HKLDh48WCSFAgAAOMujII1btGihvXv3asyYMWrXrp0ef/xx7dy5U6dPn9YHH3ygnj17FlWdAAAATitQwJGksmXL6o033lBycrLmzp2rcuXKadeuXWrUqFFR1AcAAFBgBb6L6qefftJ9992nLVu2aN68eWrSpInatGmjVatWFUV9AAAABVaggPPWW2/p9ttvV7Vq1XTgwAE9/vjj2r59u5577jn1799fjz32mH777beiqhUAAMApNmOMcbZx5cqV9eabb+rRRx/Ntu7QoUMKCwtTUlKSTp8+XahFFia73S4/Pz+lpKTI19fX1eUAAAAnFPT9u0BHcA4ePJhjuJGkkJAQffPNN3riiSec3l56errGjh2r4OBgeXt7q27dunr55ZeVmZmZZ7+4uDjdcccdKlu2rOrWrat58+YVZBgAAMDiCnSRcc2aNSVJK1as0NKlS3Xs2DHZbDbVr19f/fv3V58+fTRu3Dintzd16lTNmzdPMTExCgkJ0e7duzVo0CD5+fnpmWeeybHP8ePH1aVLFw0dOlSxsbH66quv9OSTT6pq1arq3bt3QYYDAAAsqkCnqDIzMxUaGqoVK1aoQYMGatSokYwxOnLkiH788Uf17dtXS5culc1mc2p73bp1U/Xq1TV//nzHst69e8vHx0eLFi3Ksc/o0aP18ccf6/vvv3cse+KJJ7R//37t2LEj331yigoAgNKnSE9RzZw5U5s2bdLHH3+sI0eOaPXq1VqzZo2OHj2qVatWaePGjZo1a5bT22vdurU2b96sY8eOSZL279+v7du3q0uXLrn22bFjhzp27JhlWadOnbR7925duXIlW/u0tDTZ7fYsDwAAYG0FCjgLFizQa6+9pm7dumVb16NHD02bNi3L0Zj8jB49WqGhoWrUqJHKlCmjZs2aaeTIkQoNDc21z5kzZ1S9evUsy6pXr6709HT98ssv2dpHRUXJz8/P8QgMDHS6PgAAUDoVKOD88MMPeuCBB3Jd/8ADD+jHH390envLly9XbGyslixZoj179igmJkbTp09XTExMnv3+9xTY1bNsOZ0ai4yMVEpKiuNx8uRJp+sDAAClU4EuMvb29taFCxdUp06dHNfb7XZ5e3s7vb0XXnhBY8aM0SOPPCJJatKkiU6cOKGoqCiFhYXl2KdGjRo6c+ZMlmXJycny8PBQ5cqVs7X38vKSl5eX0zUBAIDSr0BHcFq2bJnnt4XPmTNHLVu2dHp7ly5dkptb1hLc3d3zvE28ZcuW2rhxY5ZlGzZs0J133qkyZco4vW8AAGBdBTqC8+KLL6pt27b69ddfNWrUKMddVN9//71ef/11rVmzRlu3bnV6e927d9ekSZNUp04dhYSEaO/evZoxY4YiIiIcbSIjI3X69GktXLhQ0l93TL311lt67rnnNHToUO3YsUPz58/X0qVLCzIUAABgYQW6TVySVq1apccff1znz593LDPGyN/fX//5z38K9Fk0qampGjdunFatWqXk5GQFBAQoNDRU48ePl6enpyQpPDxc8fHx2rZtm6NfXFycnn32WR06dEgBAQEaPXq00x8wyG3iAACUPgV9/y5wwJH+OrW0YcMGx+3dDRo0UMeOHeXj41PwiosZAQcAgNKnoO/fBTpFJf31YX/Lli3TypUrFR8fL5vNpuDgYNntdg0YMMDpD/kDAAAoKgW6yNgYox49emjIkCE6ffq0mjRpopCQEJ04cULh4eHq1atXUdUJAADgtAIdwVmwYIG++OILbd68We3atcuybsuWLfrnP/+phQsXauDAgYVaJAAAQEEU6AjO0qVL9e9//ztbuJGk9u3ba8yYMVq8eHGhFQcAAHA9ChRw/vvf/6pz5865rn/wwQe1f//+Gy4KAADgRhQo4Jw/fz7b90Bdq3r16vrtt99uuCgAAIAbUaCAk5GRIQ+P3C/bcXd3V3p6+g0XBQAAcCMKdJGxMUbh4eG5frdTWlpaoRQFAABwIwoUcHL7AsxrcQcVAABwtQIFnOjo6KKqAwAAoNAU6BocAACA0oCAAwAALIeAAwAALIeAAwAALIeAAwAALIeAAwAALIeAAwAALIeAAwAALIeAAwAALIeAAwAALIeAAwAALIeAAwAALIeAAwAALIeAAwAALIeAAwAALIeAAwAALIeAAwAALIeAAwAALIeAAwAALIeAAwAALIeAAwAALMelAScoKEg2my3bY/jw4bn2mTNnjm655RZ5e3urYcOGWrhwYTFWDAAASgMPV+58165dysjIcDw/ePCgOnTooL59++bY/u2331ZkZKTeffddNW/eXN9++62GDh2qSpUqqXv37sVVNgAAKOFsxhjj6iKuGjlypNauXasffvhBNpst2/pWrVrpnnvu0WuvvZalz+7du7V9+3an9mG32+Xn56eUlBT5+voWWu0AAKDoFPT926VHcK51+fJlxcbG6rnnnssx3EhSWlqaypYtm2WZt7e3vv32W125ckVlypTJsU9aWprjud1uL9zCAQBAiVNiLjJevXq1Lly4oPDw8FzbdOrUSe+9956+++47GWO0e/duvf/++7py5Yp++eWXHPtERUXJz8/P8QgMDCyiEQAAgJKixJyi6tSpkzw9PfXJJ5/k2uaPP/7Q8OHDtWjRIhljVL16dT322GOaNm2azp49q2rVqmXrk9MRnMDAQE5RAQBQihT0FFWJOIJz4sQJbdq0SUOGDMmznbe3t95//31dunRJ8fHxSkhIUFBQkCpUqKAqVark2MfLy0u+vr5ZHgAAwNpKxDU40dHRqlatmrp27epU+zJlyqh27dqSpGXLlqlbt25ycysRWQ0AAJQALg84mZmZio6OVlhYmDw8spYTGRmp06dPOz7r5tixY/r222/VokUL/fbbb5oxY4YOHjyomJgYV5QOAABKKJcHnE2bNikhIUERERHZ1iUlJSkhIcHxPCMjQ6+//rqOHj2qMmXKqF27dvr6668VFBRUjBUDAICSrsRcZFxc+BwcAABKn1J5kTEAAEBhIuAAAADLIeAAAADLIeAAAADLIeAAAADLIeAAAADLIeAAAADLIeAAAADLIeAAAADLIeAAAADLIeAAAADLIeAAAADLIeAAAADLIeAAAADLIeAAAADLIeAAAADLIeAAAADLIeAAAADLIeAAAADLIeAAAADLIeAAAADLIeAAAADLIeAAAADLIeAAAADLIeAAAADLIeAAAADLIeAAAADLIeAAAADLIeAAAADLIeAAAADLIeAAAADLcWnACQoKks1my/YYPnx4rn0WL16s22+/XT4+PqpZs6YGDRqkX3/9tRirBgAAJZ1LA86uXbuUlJTkeGzcuFGS1Ldv3xzbb9++XQMHDtTgwYN16NAhrVixQrt27dKQIUOKs2wAAFDCebhy51WrVs3yfMqUKapXr57atGmTY/udO3cqKChII0aMkCQFBwdr2LBhmjZtWpHXCgAASo8Scw3O5cuXFRsbq4iICNlsthzbtGrVSqdOndK6detkjNHZs2f14YcfqmvXrrluNy0tTXa7PcsDAABYW4kJOKtXr9aFCxcUHh6ea5tWrVpp8eLF6tevnzw9PVWjRg1VrFhRs2fPzrVPVFSU/Pz8HI/AwMAiqB4AAJQkNmOMcXURktSpUyd5enrqk08+ybXN4cOH9cADD+jZZ59Vp06dlJSUpBdeeEHNmzfX/Pnzc+yTlpamtLQ0x3O73a7AwEClpKTI19e30McBAAAKn91ul5+fn9Pv3yUi4Jw4cUJ169bVypUr1bNnz1zbDRgwQH/++adWrFjhWLZ9+3bde++9SkxMVM2aNfPdV0F/QAAAwPUK+v5dIk5RRUdHq1q1anleSyNJly5dkptb1pLd3d0lSSUgpwEAgBLC5QEnMzNT0dHRCgsLk4dH1pu6IiMjNXDgQMfz7t27a+XKlXr77bf1888/66uvvtKIESN01113KSAgoLhLBwAAJZRLbxOXpE2bNikhIUERERHZ1iUlJSkhIcHxPDw8XKmpqXrrrbf0/PPPq2LFimrfvr2mTp1anCUDAIASrkRcg1OcuAYHAIDSp1RegwMAAFCYCDgAAMByCDgAAMByCDgAAMByCDgAAMByCDgAAMByCDgAAMByCDgAAMByCDgAAMByCDgAAMByCDgAAMByCDgAAMByCDgAAMByCDgAAMByCDgAAMByCDgAAMByCDgAAMByCDgAAMByCDgAAMByCDgAAMByCDgAAMByCDgAAMByCDgAAMByCDgAAMByCDgAAMByCDgAAMByCDgAAMByCDgAAMByCDgAAMByCDgAAMByCDgAAMByXBpwgoKCZLPZsj2GDx+eY/vw8PAc24eEhBRz5QAAoCRzacDZtWuXkpKSHI+NGzdKkvr27Ztj+1mzZmVpf/LkSfn7++faHgAA/D15uHLnVatWzfJ8ypQpqlevntq0aZNjez8/P/n5+Tmer169Wr/99psGDRpUpHUCAIDSxaUB51qXL19WbGysnnvuOdlsNqf6zJ8/Xw888IBuuummXNukpaUpLS3N8dxut99wrQAAoGQrMRcZr169WhcuXFB4eLhT7ZOSkvTZZ59pyJAhebaLiopyHPnx8/NTYGBgIVQLAABKMpsxxri6CEnq1KmTPD099cknnzjVPioqSq+//roSExPl6emZa7ucjuAEBgYqJSVFvr6+N1w3AAAoena7XX5+fk6/f5eIU1QnTpzQpk2btHLlSqfaG2P0/vvva8CAAXmGG0ny8vKSl5dXYZQJAABKiRJxiio6OlrVqlVT165dnWofFxenH3/8UYMHDy7iygAAQGnk8oCTmZmp6OhohYWFycMj6wGlyMhIDRw4MFuf+fPnq0WLFrr11luLq0wAAFCKuDzgbNq0SQkJCYqIiMi2LikpSQkJCVmWpaSk6KOPPuLoDQAAyFWJuci4uBT0IiUAAOB6BX3/dvkRHAAAgMJGwAEAAJZDwAEAAJZDwAEAAJZDwAEAAJZDwAEAAJZDwAEAAJZDwAEAAJZDwAEAAJZDwAEAAJZDwAEAAJZDwAEAAJZDwAEAAJZDwAEAAJZDwAEAAJZDwAEAAJZDwAEAAJZDwAEAAJZDwAEAAJZDwAEAAJZDwAEAAJZDwAEAAJZDwAEAAJZDwAEAAJZDwAEAAJZDwAEAAJZDwAEAAJZDwAEAAJZDwAEAAJZDwAEAAJZDwAEAAJbj0oATFBQkm82W7TF8+PBc+6SlpenFF1/UTTfdJC8vL9WrV0/vv/9+MVYNAABKOg9X7nzXrl3KyMhwPD948KA6dOigvn375trn4Ycf1tmzZzV//nzdfPPNSk5OVnp6enGUCwAASgmXBpyqVatmeT5lyhTVq1dPbdq0ybH9+vXrFRcXp59//ln+/v6S/joKBAAAcK0Scw3O5cuXFRsbq4iICNlsthzbfPzxx7rzzjs1bdo01apVSw0aNNCoUaP0xx9/5LrdtLQ02e32LA8AAGBtLj2Cc63Vq1frwoULCg8Pz7XNzz//rO3bt6ts2bJatWqVfvnlFz355JM6f/58rtfhREVFaeLEiUVUNQAAKIlsxhjj6iIkqVOnTvL09NQnn3ySa5uOHTvqyy+/1JkzZ+Tn5ydJWrlypfr06aPff/9d3t7e2fqkpaUpLS3N8dxutyswMFApKSny9fUt/IEAAIBCZ7fb5efn5/T7d4k4gnPixAlt2rRJK1euzLNdzZo1VatWLUe4kaRbbrlFxhidOnVK9evXz9bHy8tLXl5ehV4zAAAouUrENTjR0dGqVq2aunbtmme7e+65R4mJibp48aJj2bFjx+Tm5qbatWsXdZkAAKCUcHnAyczMVHR0tMLCwuThkfWAUmRkpAYOHOh43r9/f1WuXFmDBg3S4cOH9cUXX+iFF15QREREjqenAADA35PLA86mTZuUkJCgiIiIbOuSkpKUkJDgeF6+fHlt3LhRFy5c0J133qlHH31U3bt315tvvlmcJQMAgBKuxFxkXFwKepESAABwvYK+f7v8CA4AAEBhI+AAAADLIeAAAADLIeAAAADLIeAAAADLIeAAAADLIeAAAADLIeAAAADLIeAAAADLKRHfJl6crn5ws91ud3ElAADAWVfft539Aoa/XcBJTU2VJAUGBrq4EgAAUFCpqany8/PLt93f7ruoMjMzlZiYqAoVKshms7m6HAe73a7AwECdPHnSst+RZfUxWn18kvXHyPhKN6uPT7L+GPManzFGqampCggIkJtb/lfY/O2O4Li5ual27dquLiNXvr6+lnzRXsvqY7T6+CTrj5HxlW5WH59k/THmNj5njtxcxUXGAADAcgg4AADAcgg4JYSXl5cmTJggLy8vV5dSZKw+RquPT7L+GBlf6Wb18UnWH2Nhju9vd5ExAACwPo7gAAAAyyHgAAAAyyHgAAAAyyHglHA2m02rV692dRm4Acxh6ccclm7MX+l3PXNIwClm4eHh+uc//+nqMq5LVFSUmjdvrgoVKqhatWr65z//qaNHj2ZpY4zRSy+9pICAAHl7e6tt27Y6dOiQY/358+f19NNPq2HDhvLx8VGdOnU0YsQIpaSkZNnOpEmT1KpVK/n4+KhixYrFMTynMYf5z2F8fLwGDx6s4OBgeXt7q169epowYYIuX75cbGPNC3Po3P/DHj16qE6dOipbtqxq1qypAQMGKDExsVjGmRfmz7n5uyotLU1NmzaVzWbTvn37inJ4TiuOOSTgwGlxcXEaPny4du7cqY0bNyo9PV0dO3bU77//7mgzbdo0zZgxQ2+99ZZ27dqlGjVqqEOHDo7vAEtMTFRiYqKmT5+uAwcOaMGCBVq/fr0GDx6cZV+XL19W37599X/+z/8p1jFaXXHN4ZEjR5SZman//Oc/OnTokN544w3NmzdP//73v4t9zFZTnP8P27Vrpw8++EBHjx7VRx99pJ9++kl9+vQp1vFaTXHO31X/+te/FBAQUCzjK1EMilVYWJjp2bOnMcaYm266ybzxxhtZ1t9+++1mwoQJjueSzKpVq4qtvoJITk42kkxcXJwxxpjMzExTo0YNM2XKFEebP//80/j5+Zl58+blup0PPvjAeHp6mitXrmRbFx0dbfz8/Aq99hvBHGaX1xxeNW3aNBMcHFx4xd8A5jA7Z+ZwzZo1xmazmcuXLxfeAK4D85ddbvO3bt0606hRI3Po0CEjyezdu7dIxlFQxTGHHMHBdbt6ONTf31+SdPz4cZ05c0YdO3Z0tPHy8lKbNm309ddf57kdX19feXj87b4azeWKcw5TUlIc+0HhKa45PH/+vBYvXqxWrVqpTJkyhTiCv7einL+zZ89q6NChWrRokXx8fIpoBCUXAQfXxRij5557Tq1bt9att94qSTpz5owkqXr16lnaVq9e3bHuf/3666965ZVXNGzYsKItGNkU5xz+9NNPmj17tp544olCqh5S8czh6NGjVa5cOVWuXFkJCQlas2ZNIY/i76so588Yo/DwcD3xxBO68847i2gEJRsBB9flqaee0n//+18tXbo02zqbzZbluTEm2zJJstvt6tq1qxo3bqwJEyYUWa3IWXHNYWJiojp37qy+fftqyJAhhVM8JBXPHL7wwgvau3evNmzYIHd3dw0cOFCGD8AvFEU5f7Nnz5bdbldkZGThF15KEHBcyM3NLdsviitXrrioGuc9/fTT+vjjj7V161bVrl3bsbxGjRqSlO2vjOTk5Gx/jaSmpqpz584qX768Vq1aVWoPeTOHec9hYmKi2rVrp5YtW+qdd94pgpHcOOYw7zmsUqWKGjRooA4dOmjZsmVat26ddu7cWQQjuj7MX87zt2XLFu3cuVNeXl7y8PDQzTffLEm68847FRYWVlTDui5FNYcEHBeqWrWqkpKSHM/tdruOHz/uworyZozRU089pZUrV2rLli0KDg7Osj44OFg1atTQxo0bHcsuX76suLg4tWrVyrHMbrerY8eO8vT01Mcff6yyZcsW2xgKG3OY+xyePn1abdu21T/+8Q9FR0fLza1k/rphDp3/f3j1TSgtLa2QRnPjmL+c5+/NN9/U/v37tW/fPu3bt0/r1q2TJC1fvlyTJk0qwhEWXFHNIVd1ulD79u21YMECde/eXZUqVdK4cePk7u7u6rJyNXz4cC1ZskRr1qxRhQoVHH9h+Pn5ydvbWzabTSNHjtTkyZNVv3591a9fX5MnT5aPj4/69+8v6a+/ODp27KhLly4pNjZWdrtddrtd0l8v8qvjT0hI0Pnz55WQkKCMjAzHZzfcfPPNKl++fPEPPhfMYc5zmJiYqLZt26pOnTqaPn26zp0756jh6l+oJQVzmPMcfvvtt/r222/VunVrVapUST///LPGjx+vevXqqWXLli4b//9i/nKevzp16mTZ79Xfm/Xq1ctyxKgkKLI5LNA9V7hhAwYMML179zbGGJOSkmIefvhh4+vrawIDA82CBQtK9O2NknJ8REdHO9pkZmaaCRMmmBo1ahgvLy9z3333mQMHDjjWb926NdftHD9+3NEuLCwsxzZbt24tvgHngjnMfw6jo6NzbVMSMIf5z+F///tf065dO+Pv72+8vLxMUFCQeeKJJ8ypU6eKecTZMX/O/R691vHjx0vUbeLFMYe2/9cRxaRz5866+eab9dZbb7m6FFwn5rD0Yw5LN+av9CuOOSyZJ8Ut6LffftOnn36qbdu26YEHHnB1ObgOzGHpxxyWbsxf6Vecc8g1OMUkIiJCu3bt0vPPP6+ePXu6uhxcB+aw9GMOSzfmr/QrzjnkFBUAALAcTlEBAADLIeAAAADLIeAAAADLIeAAAADLIeAAKBW2bdsmm82mCxcuuLoUAKUAd1EBKJHatm2rpk2baubMmZL++j6e8+fPq3r16jl+qzIAXIvPwQFQKnh6epa477ECUHJxigpAiRMeHq64uDjNmjVLNptNNptNCxYsyHKKasGCBapYsaLWrl2rhg0bysfHR3369NHvv/+umJgYBQUFqVKlSnr66aeVkZHh2Pbly5f1r3/9S7Vq1VK5cuXUokULbdu2zTUDBVBkOIIDoMSZNWuWjh07pltvvVUvv/yyJOnQoUPZ2l26dElvvvmmli1bptTUVD300EN66KGHVLFiRa1bt04///yzevfurdatW6tfv36SpEGDBik+Pl7Lli1TQECAVq1apc6dO+vAgQOqX79+sY4TQNEh4AAocfz8/OTp6SkfHx/HaakjR45ka3flyhW9/fbbqlevniSpT58+WrRokc6ePavy5curcePGateunbZu3ap+/frpp59+0tKlS3Xq1CkFBARIkkaNGqX169crOjpakydPLr5BAihSBBwApZaPj48j3EhS9erVFRQUpPLly2dZlpycLEnas2ePjDFq0KBBlu2kpaWpcuXKxVM0gGJBwAFQapUpUybLc5vNluOyzMxMSVJmZqbc3d313Xffyd3dPUu7a0MRgNKPgAOgRPL09MxycXBhaNasmTIyMpScnKx77723ULcNoGThLioAJVJQUJC++eYbxcfH65dffnEchbkRDRo00KOPPqqBAwdq5cqVOn78uHbt2qWpU6dq3bp1hVA1gJKCgAOgRBo1apTc3d3VuHFjVa1aVQkJCYWy3ejoaA0cOFDPP/+8GjZsqB49euibb75RYGBgoWwfQMnAJxkDAADL4QgOAACwHAIOAACwHAIOAACwHAIOAACwHAIOAACwHAIOAACwHAIOAACwHAIOAACwHAIOAACwHAIOAACwHAIOAACwHAIOAACwnP8LLWisyzr07n0AAAAASUVORK5CYII=",
+      "text/plain": [
+       "<Figure size 640x480 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "transport_model.mesh.DOX.isel(nface=217, time=slice(0, 5000)).plot()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 37,
+   "id": "ad9bf52d",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[<matplotlib.lines.Line2D at 0x1c25cba3dd0>]"
+      ]
+     },
+     "execution_count": 37,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAkEAAAHFCAYAAAD1zS3+AAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjguNCwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8fJSN1AAAACXBIWXMAAA9hAAAPYQGoP6dpAAA4cElEQVR4nO3de1hVVeL/8c8RBEEBQQ08iEqKmllpaaZZSqVZ3rI0R0swtWyyHCuncsrULExrGkszJ2vU8VpmpF/zRqWY4yUc0/FSNhZ4Q6VJBbyECuv3Rz/OeIY7cl/v1/Oc5/Gsvdbaa7G2nA9773OOwxhjBAAAYJlq5T0AAACA8kAIAgAAViIEAQAAKxGCAACAlQhBAADASoQgAABgJUIQAACwEiEIAABYiRAEAACsRAjCFfnoo4907bXXysfHRw6HQzt37izvIVV4SUlJcjgcuT6WLFlSqD7OnDmj0aNHy+l0qkaNGmrdunWubTdt2qThw4frpptukre3txwOh5KSkgrsf9++fa7627dvL+oUr1hh5zdkyJBcf44tWrS4ov1Pnz5dTZs2lZeXlxwOh06fPn1F/dngq6++0tChQ9WiRQvVrFlToaGh6tOnj/75z38Wqv0XX3yhrl27yul0ytvbW1dddZXuuOMOrVq1Ks/6HTp0kK+vr+rWrashQ4YoJSWlwH1kHyP/+c9/ijzHK5WSkqIhQ4aobt268vX1VYcOHfTll1/mqPfiiy+qTZs2CgoKUo0aNXT11Vfrscce08GDB8t8zFWdZ3kPAJXXzz//rMGDB6t79+6aOXOmvL291axZs/IeVqXx1FNPadCgQW5lERERhWp7//33KyEhQa+//rqaNWumRYsWaeDAgcrKynLr88svv9QXX3yhNm3ayN/fXxs2bCiw78zMTA0dOlR169ZVcnJykeZUUgo7P0ny8fHRV199laOsuHbu3KlRo0Zp+PDhio6Olqenp/z8/Irdny3ee+89/fLLL/rDH/6gli1b6ueff9af//xn3XLLLVq7dq3uuOOOfNv/8ssvuvbaazV8+HCFhITo5MmTmjVrlnr06KH58+fr4YcfdtWNj4/XPffcox49emj58uVKSUnR888/rzvvvFPbt2+Xt7d3jv7PnDmjRx99VE6ns1yO64yMDN155506ffq03n77bV111VV699131b17d33xxRfq3Lmzq+7p06c1cOBAXXPNNfLz89O+ffv06quvasWKFdq7d6/q1KlT5uOvsgxQTJs2bTKSzEcffVTeQ6lUEhMTjSTzxhtvFKv9559/biSZRYsWuZV37drVOJ1Oc+nSJVdZZmam699vvPGGkWQSExPz7f+NN94woaGh5u233zaSTEJCQrHGmZvo6GjTuXPnfOsUZX7R0dGmZs2aJTY+Y4xZsGCBkWS2bdtWov1WdSdOnMhRlp6eboKDg82dd95ZrD4vXLhgQkNDzW233eZW3q5dO9OyZUtz8eJFV9k//vEPI8nMnDkz175Gjhxp2rRpY1566SUjyfz888/FGlNuOnfubKKjo/Ot8+677xpJZvPmza6yixcvmpYtW5qbb765wH2sWrXKSDIffvjhlQ4Xl+FyGIplyJAh6tSpkyRpwIABcjgc6tKliyRp+/bt+t3vfqfGjRvLx8dHjRs31sCBA3M9lXv06FE99thjCgsLk5eXl5xOp/r166cTJ0646qSlpWnMmDEKDw+Xl5eXQkNDNXr0aJ09e7bQ4/3Pf/6jsLAwdezYURcvXnSV79u3TzVr1tTgwYOL+ZMoe7GxsapVq5b69+/vVv7II48oOTlZ27Ztc5VVq1a0/+L//ve/9fLLL2vmzJny9/fPs9727dvVu3dv1+n6Nm3a6OOPPy7aRPJQlPmVtC5durjOOLRv314Oh0NDhgyRJMXFxalPnz5q0KCBatSooaZNm2rEiBG5Xlb5/vvvNXDgQAUHB8vb21sNGzZUVFSUMjIyXHWOHz+uESNGqEGDBvLy8lJ4eLgmTpyoS5cuFXq8kyZNkqenpw4fPpxj29ChQ1WnTh39+uuvRfwpFM9VV12Vo6xWrVpq2bJlruMrjOrVq6t27dry9PzvRYujR48qISFBgwcPdivv2LGjmjVrptjY2Bz9fP3113r//ff1wQcfyMPDI8/9ffHFF7rzzjvl7+8vX19f3XrrrbleriqO2NhYNW/eXB06dHCVeXp66uGHH9Y333yjo0eP5tu+Xr16rjYoOYQgFMu4ceP07rvvSpJiYmK0ZcsWzZw5U9Jv97w0b95c06ZN09q1azVlyhQdO3ZM7dq1c3vBOHr0qNq1a6fY2Fg988wzWr16taZNm6aAgACdOnVKknTu3Dl17txZ8+bN06hRo7R69Wo9//zzmjt3rnr37i1jTKHGW7duXS1ZskQJCQl6/vnnXX33799fDRs21KxZs/Jtb4zRpUuXCvUorNdff11eXl7y9fVVp06dtGLFikK127Nnj6655pocvwyvv/561/biMMZo+PDh6tmzp3r37p1nvfXr1+vWW2/V6dOnNWvWLC1fvlytW7fWgAEDNHfu3GLt+3JFnd/58+cVEhIiDw8PNWjQQE8++aROnjxZrH3PnDlTL730kiRpzpw52rJli8aNGydJ+vHHH9WhQwe99957WrdunV5++WVt27ZNnTp1cgvWu3btUrt27bR161a98sorWr16tSZPnqyMjAxduHBB0m8B6Oabb9batWv18ssva/Xq1Ro2bJgmT56sRx99tNDjHTFihDw9PfXXv/7VrfzkyZNasmSJhg0bpho1auTZvjSO68ulpqZqx44duvbaawvdJisrS5cuXVJycrLGjx+vH374Qc8++6xre/b6Zx8Pl7v++utzPT6GDRum0aNH68Ybb8xzvwsWLFC3bt3k7++vefPm6eOPP1ZQUJDuvvvuEglCe/bsyXPMkrR3794c2y5duqTz58/r22+/1ejRo9WsWTPdf//9VzwWXKZ8T0ShMlu/fr2RZJYuXZpvvUuXLpkzZ86YmjVrmrfffttVPnToUFO9enWzb9++PNtOnjzZVKtWLcclmU8++cRIMqtWrSrSmKdMmWIkmdjYWBMdHW18fHzMv/71rwLbZc+1MI+CLjclJyebRx991Hz88cfm66+/NgsXLjS33HKLkWRmz55d4FgiIiLM3XffnWu/kkxMTEyu7Qq6HDZ9+nQTGBhojh8/bowxZs6cObleDmvRooVp06aN26UIY4zp2bOnqV+/vtsluIsXL7o9oqKizO23356jPCsrq1jze+utt8xbb71l1q1bZ9atW2defPFF4+vra1q0aGHS09NznWdB8pr35bKysszFixfNwYMHjSSzfPly17Y77rjD1K5d26SkpOTZfsSIEaZWrVrm4MGDbuVvvvmmkWT27t1b6PFGR0ebq666ymRkZLjKpkyZYqpVq1bgsZg918I8iuOhhx4ynp6eZvv27YVuc/fdd7v26e/vbz799FO37QsXLjSSzJYtW3K0feyxx4yXl5db2bPPPmuuvvpqc+7cOWOMMePHj89xOezs2bMmKCjI9OrVy61tZmamueGGG9wuV2Wv/eWP22+/3URFReUov1z16tXNiBEjcox58+bNuV7+PXbsmNvPv3379ubo0aP5/ehQDJxXQ4k7c+aMJk2apGXLlikpKUmZmZmubd99953r36tXr1ZkZKSuueaaPPtauXKlWrVqpdatW7v9NXr33XfL4XBow4YNuueeewo9tj/+8Y/auHGjBg4cqF9//VUffPCBrrvuugLb3XTTTUpISCjUPpxOZ77b69evr/fff9+trH///mrfvr1eeOEFDRkypMBT3g6Ho1jb8nLw4EGNHTtW06ZNU3BwcJ71Dhw4oO+//15vvvmmJLmtyb333quVK1dq//79uuaaa5SUlKTw8PBc+6levbrb8/Xr17supxY0h8u3Pf30027bunbtqjZt2qhfv36aPXt2ju1XIiUlRS+//LI+//xzJScnKysry7Xtu+++U+/evXXu3DnFx8dr2LBhrssXuVm5cqUiIyPldDrdfob33HOPxowZo/j4eLVs2bJQ4/rDH/6gefPmaenSpXrooYeUlZWl9957Tz169FDjxo3zbdurV69CH9dFNW7cOC1cuFDTp0/XTTfdVOh206dP1+nTp3Xs2DEtWLBAAwYM0Lx58zRw4EC3enkdI5eXf/PNN5o2bZrWrFmT783ymzdv1smTJxUdHZ3jrFf37t01depUnT17VjVr1lR8fLwiIyNz9LFx40b9/e9/dytLTEx0W4Oi/L+tW7euEhISlJGRoe+++05Tp05VZGSkNmzYoPr16+fZD4qGEIQSN2jQIH355ZcaN26c2rVrJ39/fzkcDt177706f/68q97PP/+sBg0a5NvXiRMndODAgRwvmtmK+jbX7Hs8Pv/8c4WEhBT6XqBatWqpdevWhapbnGv21atX14ABA/TCCy/o3//+d77BsE6dOvrll19ylGdfAgoKCiry/keOHKlWrVrpgQcecL0d/Ny5c5J+C7WpqakKCAhw3as1ZswYjRkzJte+stfE6XTmeIGdOHGikpOTc1y+ad68eYnNr2/fvqpZs6a2bt2ab72iyMrKUrdu3ZScnKxx48bpuuuuU82aNZWVlaVbbrnFdVyfOnVKmZmZhTqu/+///q9Ejus2bdrotttu07vvvquHHnpIK1euVFJSUo6fcW6CgoIUEBBQ6H0V1sSJE/Xqq6/qtdde05NPPlmktpe/Q7J379665557NHLkSA0YMEDVqlVzvTMqr2Pk8uNj6NChuv/++9W2bVvXcZ19j1RaWpq8vb3l5+fnOq779euX57hOnjypmjVr5voH0YgRI+R0OjV+/Hi38sv/ICrqce3p6am2bdtKkm699VZ1795d4eHhev311/X222/nOU4UDSEIJSo1NVUrV67U+PHj9cILL7jKMzIyctynUa9ePR05ciTf/urWrSsfHx/97W9/y3N7URw7dkwjR45U69attXfvXo0ZM0bvvPNOge3y+usvN//7119hmf9/f1NBNzNfd911Wrx4sS5duuQWuHbv3i1JatWqVZH3vWfPHh08eFCBgYE5tkVGRiogIECnT592/bzHjh2b570J2YHGy8vL9Us8W506dZSenp6j/HIlMT9jTJFvCs/Pnj17tGvXLs2dO1fR0dGu8gMHDrjVCwoKkoeHR6GO6+uvv16vvfZartsLOpv4v0aNGqX+/ftrx44dmjFjhpo1a6auXbsW2G7evHl65JFHCrUPU8j77yZOnKgJEyZowoQJ+tOf/lSoNvm5+eabtWbNGv38888KDg52rf/u3bt17733utXdvXu32/Gxd+9e7d27V0uXLs3Rb5MmTXTDDTdo586druN6+vTpuuWWW3IdR/YZUj8/vxzHr5+fn+rUqVPgcZ19DP/vmKWCj+sGDRrI6XTqhx9+yLceioYQhBLlcDhkjMnxOR0ffPCB22Ux6bdT//Pnz9f+/fvdzgRcrmfPnoqJiVGdOnXyvLRSWJmZmRo4cKAcDodWr16thQsXasyYMerSpUuBNxuW5OWw3Fy8eFEfffSR6tatq6ZNm+Zbt2/fvpo9e7aWLVumAQMGuMrnzZsnp9Op9u3bF3n/S5YsyfEuojVr1mjKlCmaNWuW68bW5s2bKyIiQrt27VJMTEyR91MYVzq/Tz75ROfOncvzxaw4si9V/O9x/b9nW3x8fNS5c2ctXbpUr732Wp4hvWfPnlq1apWaNGmSa/Asqr59+6phw4Z69tlnFR8fr7/85S+Fuixa0pfDJk2apAkTJuill17KcVakOIwxio+PV+3atV1ngEJDQ3XzzTdrwYIFGjNmjOvdXlu3btX+/fs1evRoV/v169fn6HPu3LmaN2+ePvvsM4WGhkr67UxL7dq1tW/fviKfuSqsvn376oknntC2bdtcx/ClS5e0YMECtW/fvsDfGwcOHNCRI0fyfdMCiqFc70hCpZbXjdG33367CQoKMrNnzzZxcXHmpZdeMvXr1ze1a9d2+yyNI0eOmPr165urrrrKTJs2zXz55Zdm2bJl5tFHHzXfffedMcaYM2fOmDZt2pgGDRqYP//5zyYuLs6sXbvWzJ492/Tv399s3bq10ON98cUXTbVq1cwXX3zhKuvVq5epXbu2+emnn67sh1EETz/9tHnyySfN4sWLzfr1683f//53065dOyPJzJkzx63uxIkTjYeHh9mwYYNbedeuXU1gYKB5//33zVdffWUeffRRI8ksWLDArV5KSopZunSpWbp0qYmKinJ9jsrSpUtz9Pm/8rpB+KuvvjLe3t6mW7duZtGiRSY+Pt7ExsaamJgY069fv3z7LMznBBV2fklJSaZjx47mnXfeMatWrTKrV682L7zwgqlRo4a59tprzZkzZ9z67Ny5c6Fu8M1t3hcuXDBNmjQxjRo1MosWLTJr1qwxI0eONM2aNTOSzPjx4111d+7caWrVqmWuvvpq1/gXL15sBg4caNLS0owxv93k3ahRI9OiRQszc+ZM8+WXX5rPP//cvPvuu6ZHjx7m8OHDBY7zf2Xf9F+zZk1z+vTpIre/Utk3dXfv3t1s2bIlx+NyQ4cONR4eHiYpKclV1rt3bzNu3DizbNkys2HDBrNo0SLTrVs3I8m8++67bu3Xr19vPD09Td++fU1cXJxZuHChCQsLM61atTK//vprvuPM7cZoY4yZP3++qVatmhkwYIBZunSpiY+PN5988okZN26cefzxx/PtszCfE/Trr7+aa6+91oSFhZmFCxeauLg407dvX+Pp6en2f3HXrl3mjjvuMDNnzjRr1qwx69atM3/+859NgwYNTL169dx+ZrhyhCAUW14h6MiRI+aBBx4wgYGBxs/Pz3Tv3t3s2bPHNGrUKMcvisOHD5uhQ4eakJAQU716deN0Os2DDz7o9sFrZ86cMS+99JJp3ry58fLyMgEBAea6664zTz/9tOudTAVZt26dqVatmtuLlTHG/PLLL6Zhw4amXbt2bu+uKU0ffvihufnmm01QUJDx9PQ0gYGB5u677zZr167NUTf7F/b69evdytPT082oUaNMSEiI8fLyMtdff71ZvHhxjvb5vautoDCS37ukdu3aZR588EFz1VVXmerVq5uQkBBzxx13mFmzZuXbZ2FDUGHmd/LkSdO3b1/TuHFj4+PjY7y8vExERIR57rnncg0BN910kwkJCSlw33nNe9++faZr167Gz8/PBAYGmv79+5tDhw7lCEHZdfv372/q1KljvLy8TMOGDc2QIUPcXqB//vlnM2rUKBMeHm6qV69ugoKCzE033WRefPHFHAGuMJKSkoykAl+wS0t2yMzrcbno6Ogc71ScMmWKadeunQkMDDQeHh6mTp065u677zYrV67MdX/r1q0zt9xyi6lRo4YJCgoyUVFRuX5g4//KKwQZY0x8fLzp0aOHCQoKMtWrVzehoaGmR48eBb4DtjAhyBhjjh8/bqKiokxQUJCpUaOGueWWW0xcXFyOOg8//LBp0qSJ8fX1NV5eXubqq682jz/+uDl06FCB+0DROIwp5IVeAKik0tPTFRQUpGnTpmnkyJHlPZxSMX36dI0aNUp79uwp0ufyADbjniAAVd7GjRsVGhpapA8irCy+/fZbJSYm6pVXXlGfPn0IQEARcCYIlV5WVpbbZ7bkho+aR2WTmZmZ7zuyHA6HPDw81LhxYx0/fly33Xab5s+fr5CQkDIcJVC5EYJQ6Q0ZMkTz5s3Ltw6HOSqbLl26KD4+Ps/tjRo1UlJSUtkNCKiCCEGo9JKSkgr8cLn8Pr8DqIj279+v9PT0PLd7e3sX6tPOAeSNEAQAAKzEt8gDAAArcbdoLrKyspScnCw/P79ifRklAAAoe8YYpaeny+l0FuqrcwhBuUhOTlZYWFh5DwMAABTD4cOHC/wiY4kQlCs/Pz9Jv/0Q/f39y3k0AACgMNLS0hQWFuZ6HS8IISgX2ZfA/P39CUEAAFQyhb2VhRujAQCAlQhBAADASoQgAABgJUIQAACwEiEIAABYiRAEAACsRAgCAABWIgQBAAArEYIAAICVCEEAAMBKhCAAAGAlQhAAALASIQgAAFiJEAQAAKxECAIAAFYiBAEAACsRggAAgJUIQQAAwEqEIAAAYCVCEAAAsBIhCAAAWIkQBAAArEQIAgAAViIEAQAAKxGCAACAlQhBAADASoQgAABgJUIQAACwEiEIAABYiRAEAACsRAgCAABWIgQBAAArEYIAAICVCEEAAMBKhCAAAGAlQhAAALASIQgAAFiJEAQAAKxECAIAAFYiBAEAACsRggAAgJUIQQAAwEqEIAAAYKVyDUEbN25Ur1695HQ65XA49Nlnn7ltN8ZowoQJcjqd8vHxUZcuXbR3795C979kyRI5HA7dd999JTtwAABQ6ZVrCDp79qxuuOEGzZgxI9ftU6dO1VtvvaUZM2YoISFBISEh6tq1q9LT0wvs++DBgxozZoxuu+22kh42AACoAjzLc+f33HOP7rnnnly3GWM0bdo0vfjii7r//vslSfPmzVNwcLAWLVqkESNG5NlvZmamHnroIU2cOFFff/21Tp8+XRrDBwAAlViFvScoMTFRx48fV7du3Vxl3t7e6ty5szZv3pxv21deeUX16tXTsGHDSnuYAACgkirXM0H5OX78uCQpODjYrTw4OFgHDx7Ms90//vEPffjhh9q5c2eh95WRkaGMjAzX87S0tKINFgAAVDoV9kxQNofD4fbcGJOjLFt6eroefvhhzZ49W3Xr1i30PiZPnqyAgADXIyws7IrGDAAAKr4KeyYoJCRE0m9nhOrXr+8qT0lJyXF2KNuPP/6opKQk9erVy1WWlZUlSfL09NT+/fvVpEmTHO3Gjh2rZ555xvU8LS2NIAQAQBVXYUNQeHi4QkJCFBcXpzZt2kiSLly4oPj4eE2ZMiXXNi1atNDu3bvdyl566SWlp6fr7bffzjPYeHt7y9vbu2QnAAAAKrRyDUFnzpzRgQMHXM8TExO1c+dOBQUFqWHDhho9erRiYmIUERGhiIgIxcTEyNfXV4MGDXK1iYqKUmhoqCZPnqwaNWqoVatWbvuoXbu2JOUoBwAAdivXELR9+3ZFRka6nmdfkoqOjtbcuXP13HPP6fz583riiSd06tQptW/fXuvWrZOfn5+rzaFDh1StWoW/tQkAAFQwDmOMKe9BVDRpaWkKCAhQamqq/P39y3s4AACgEIr6+s0pFAAAYCVCEAAAsBIhCAAAWIkQBAAArEQIAgAAViIEAQAAKxGCAACAlQhBAADASoQgAABgJUIQAACwEiEIAABYiRAEAACsRAgCAABWIgQBAAArEYIAAICVCEEAAMBKhCAAAGAlQhAAALASIQgAAFiJEAQAAKxECAIAAFYiBAEAACsRggAAgJUIQQAAwEqEIAAAYCVCEAAAsBIhCAAAWIkQBAAArEQIAgAAViIEAQAAKxGCAACAlQhBAADASoQgAABgJUIQAACwEiEIAABYiRAEAACsRAgCAABWIgQBAAArEYIAAICVCEEAAMBKhCAAAGAlQhAAALASIQgAAFiJEAQAAKxECAIAAFYiBAEAACsRggAAgJUIQQAAwEqEIAAAYCVCEAAAsBIhCAAAWIkQBAAArEQIAgAAViIEAQAAKxGCAACAlQhBAADASuUagjZu3KhevXrJ6XTK4XDos88+c9tujNGECRPkdDrl4+OjLl26aO/evfn2OXv2bN12220KDAxUYGCg7rrrLn3zzTelOAsAAFAZlWsIOnv2rG644QbNmDEj1+1Tp07VW2+9pRkzZighIUEhISHq2rWr0tPT8+xzw4YNGjhwoNavX68tW7aoYcOG6tatm44ePVpa0wAAAJWQwxhjynsQkuRwOBQbG6v77rtP0m9ngZxOp0aPHq3nn39ekpSRkaHg4GBNmTJFI0aMKFS/mZmZCgwM1IwZMxQVFVWoNmlpaQoICFBqaqr8/f2LNR8AAFC2ivr6XWHvCUpMTNTx48fVrVs3V5m3t7c6d+6szZs3F7qfc+fO6eLFiwoKCiqNYQIAgErKs7wHkJfjx49LkoKDg93Kg4ODdfDgwUL388ILLyg0NFR33XVXnnUyMjKUkZHhep6WllbE0QIAgMqmwp4JyuZwONyeG2NylOVl6tSpWrx4sT799FPVqFEjz3qTJ09WQECA6xEWFnZFYwYAABVfhQ1BISEhkv57RihbSkpKjrNDuXnzzTcVExOjdevW6frrr8+37tixY5Wamup6HD58uPgDBwAAlUKFDUHh4eEKCQlRXFycq+zChQuKj49Xx44d8237xhtvaNKkSVqzZo3atm1b4L68vb3l7+/v9gAAAFVbud4TdObMGR04cMD1PDExUTt37lRQUJAaNmyo0aNHKyYmRhEREYqIiFBMTIx8fX01aNAgV5uoqCiFhoZq8uTJkn67BDZu3DgtWrRIjRs3dp1JqlWrlmrVqlW2EwQAABVWuYag7du3KzIy0vX8mWeekSRFR0dr7ty5eu6553T+/Hk98cQTOnXqlNq3b69169bJz8/P1ebQoUOqVu2/J7RmzpypCxcuqF+/fm77Gj9+vCZMmFC6EwIAAJVGhfmcoIqEzwkCAKDyqTKfEwQAAFCaCEEAAMBKhCAAAGAlQhAAALASIQgAAFiJEAQAAKxECAIAAFYiBAEAACsRggAAgJUIQQAAwEqEIAAAYCVCEAAAsBIhCAAAWIkQBAAArEQIAgAAViIEAQAAKxGCAACAlQhBAADASoQgAABgJUIQAACwEiEIAABYiRAEAACsRAgCAABWIgQBAAArEYIAAICVCEEAAMBKhCAAAGAlQhAAALASIQgAAFiJEAQAAKxECAIAAFYiBAEAACsRggAAgJUIQQAAwEqEIAAAYCVCEAAAsBIhCAAAWIkQBAAArEQIAgAAViIEAQAAKxGCAACAlQhBAADASoQgAABgJUIQAACwEiEIAABYiRAEAACsRAgCAABWIgQBAAArEYIAAICVCEEAAMBKhCAAAGAlQhAAALASIQgAAFiJEAQAAKzkWZxGmZmZio2N1XfffSeHw6EWLVrovvvuk6dnsboDAAAoc0VOLXv27FGfPn10/PhxNW/eXJL0ww8/qF69elqxYoWuu+66Eh8kAABASSvy5bDhw4fr2muv1ZEjR7Rjxw7t2LFDhw8f1vXXX6/HHnusNMYIAABQ4oocgnbt2qXJkycrMDDQVRYYGKjXXntNO3fuLFJfGzduVK9eveR0OuVwOPTZZ5+5bTfGaMKECXI6nfLx8VGXLl20d+/eAvtdtmyZWrZsKW9vb7Vs2VKxsbFFGhcAAKj6ihyCmjdvrhMnTuQoT0lJUdOmTYvU19mzZ3XDDTdoxowZuW6fOnWq3nrrLc2YMUMJCQkKCQlR165dlZ6enmefW7Zs0YABAzR48GDt2rVLgwcP1oMPPqht27YVaWwAAKBqcxhjTFEarFq1Ss8995wmTJigW265RZK0detWvfLKK3r99dfVqVMnV11/f//CD8ThUGxsrO677z5Jv50FcjqdGj16tJ5//nlJUkZGhoKDgzVlyhSNGDEi134GDBigtLQ0rV692lXWvXt3BQYGavHixYUaS1pamgICApSamlqkOQAAgPJT1NfvIt8Y3bNnT0nSgw8+KIfDIem3wCJJvXr1cj13OBzKzMwsavcuiYmJOn78uLp16+Yq8/b2VufOnbV58+Y8Q9CWLVv09NNPu5XdfffdmjZtWp77ysjIUEZGhut5WlpasccNAAAqhyKHoPXr1+e5bceOHbrxxhuvaEDZjh8/LkkKDg52Kw8ODtbBgwfzbZdbm+z+cjN58mRNnDjxCkYLAAAqmyKHoM6dO7s9T01N1cKFC/XBBx9o165dV3T2JzfZZ5uyZZ9lKsk2Y8eO1TPPPON6npaWprCwsGKMFgAAVBbF/sTor776Sg8//LDq16+v6dOn695779X27dtLbGAhISGSlOMMTkpKSo4zPf/brqhtvL295e/v7/YAAABVW5FC0JEjR/Tqq6/q6quv1sCBAxUYGKiLFy9q2bJlevXVV9WmTZsSG1h4eLhCQkIUFxfnKrtw4YLi4+PVsWPHPNt16NDBrY0krVu3Lt82AADAPoW+HHbvvfdq06ZN6tmzp6ZPn67u3bvLw8NDs2bNKvbOz5w5owMHDrieJyYmaufOnQoKClLDhg01evRoxcTEKCIiQhEREYqJiZGvr68GDRrkahMVFaXQ0FBNnjxZkvSHP/xBt99+u6ZMmaI+ffpo+fLl+uKLL7Rp06ZijxMAAFQ9hQ5B69at06hRo/T73/9eERERJbLz7du3KzIy0vU8+76c6OhozZ07V88995zOnz+vJ554QqdOnVL79u21bt06+fn5udocOnRI1ar994RWx44dtWTJEr300ksaN26cmjRpoo8++kjt27cvkTEDAICqodCfE7Rlyxb97W9/08cff6wWLVpo8ODBGjBggJxOp3bt2qWWLVuW9ljLDJ8TBABA5VPU1+9C3xPUoUMHzZ49W8eOHdOIESO0ZMkShYaGKisrS3Fxcfl+ijMAAEBFU+RPjL7c/v379eGHH2r+/Pk6ffq0unbtqhUrVpTk+MoFZ4IAAKh8Su1MUG6aN2+uqVOn6siRI4X+SgoAAICK4IrOBFVVnAkCAKDyKdMzQQAAAJUVIQgAAFiJEAQAAKxECAIAAFYiBAEAACsRggAAgJUIQQAAwEqEIAAAYCVCEAAAsBIhCAAAWIkQBAAArEQIAgAAViIEAQAAKxGCAACAlQhBAADASoQgAABgJUIQAACwEiEIAABYiRAEAACsRAgCAABWIgQBAAArEYIAAICVCEEAAMBKhCAAAGAlQhAAALASIQgAAFiJEAQAAKxECAIAAFYiBAEAACsRggAAgJUIQQAAwEqEIAAAYCVCEAAAsBIhCAAAWIkQBAAArEQIAgAAViIEAQAAKxGCAACAlQhBAADASoQgAABgJUIQAACwEiEIAABYiRAEAACsRAgCAABWIgQBAAArEYIAAICVCEEAAMBKhCAAAGAlQhAAALASIQgAAFiJEAQAAKxECAIAAFaq8CEoPT1do0ePVqNGjeTj46OOHTsqISEh3zYLFy7UDTfcIF9fX9WvX1+PPPKIfvnllzIaMQAAqAwqfAgaPny44uLiNH/+fO3evVvdunXTXXfdpaNHj+Zaf9OmTYqKitKwYcO0d+9eLV26VAkJCRo+fHgZjxwAAFRkFToEnT9/XsuWLdPUqVN1++23q2nTppowYYLCw8P13nvv5dpm69ataty4sUaNGqXw8HB16tRJI0aM0Pbt28t49AAAoCKr0CHo0qVLyszMVI0aNdzKfXx8tGnTplzbdOzYUUeOHNGqVatkjNGJEyf0ySefqEePHnnuJyMjQ2lpaW4PAABQtVXoEOTn56cOHTpo0qRJSk5OVmZmphYsWKBt27bp2LFjubbp2LGjFi5cqAEDBsjLy0shISGqXbu2pk+fnud+Jk+erICAANcjLCystKYEAAAqiAodgiRp/vz5MsYoNDRU3t7eeueddzRo0CB5eHjkWn/fvn0aNWqUXn75Zf3zn//UmjVrlJiYqMcffzzPfYwdO1apqamux+HDh0trOgAAoIJwGGNMeQ+iMM6ePau0tDTVr19fAwYM0JkzZ/T555/nqDd48GD9+uuvWrp0qats06ZNuu2225ScnKz69esXuK+0tDQFBAQoNTVV/v7+JToPAABQOor6+l3hzwRlq1mzpurXr69Tp05p7dq16tOnT671zp07p2rV3KeVfdaokuQ9AABQBip8CFq7dq3rklZcXJwiIyPVvHlzPfLII5J+u5QVFRXlqt+rVy99+umneu+99/TTTz/pH//4h0aNGqWbb75ZTqezvKYBAAAqGM/yHkBBUlNTNXbsWB05ckRBQUF64IEH9Nprr6l69eqSpGPHjunQoUOu+kOGDFF6erpmzJihZ599VrVr19Ydd9yhKVOmlNcUAABABVRp7gkqS9wTBABA5VNl7wkCAAAoSYQgAABgJUIQAACwEiEIAABYiRAEAACsRAgCAABWIgQBAAArEYIAAICVCEEAAMBKhCAAAGAlQhAAALASIQgAAFiJEAQAAKxECAIAAFYiBAEAACsRggAAgJUIQQAAwEqEIAAAYCVCEAAAsBIhCAAAWIkQBAAArEQIAgAAViIEAQAAKxGCAACAlQhBAADASoQgAABgJUIQAACwEiEIAABYiRAEAACsRAgCAABWIgQBAAArEYIAAICVCEEAAMBKhCAAAGAlQhAAALASIQgAAFiJEAQAAKxECAIAAFYiBAEAACsRggAAgJUIQQAAwEqEIAAAYCVCEAAAsBIhCAAAWIkQBAAArEQIAgAAViIEAQAAKxGCAACAlQhBAADASoQgAABgJUIQAACwEiEIAABYiRAEAACsRAgCAABWIgQBAAArEYIAAICVKnwISk9P1+jRo9WoUSP5+PioY8eOSkhIyLdNRkaGXnzxRTVq1Eje3t5q0qSJ/va3v5XRiAEAQGXgWd4DKMjw4cO1Z88ezZ8/X06nUwsWLNBdd92lffv2KTQ0NNc2Dz74oE6cOKEPP/xQTZs2VUpKii5dulTGIwcAABWZwxhjynsQeTl//rz8/Py0fPly9ejRw1XeunVr9ezZU6+++mqONmvWrNHvfvc7/fTTTwoKCirWftPS0hQQEKDU1FT5+/sXe/wAAKDsFPX1u0JfDrt06ZIyMzNVo0YNt3IfHx9t2rQp1zYrVqxQ27ZtNXXqVIWGhqpZs2YaM2aMzp8/n+d+MjIylJaW5vYAAABVW4UOQX5+furQoYMmTZqk5ORkZWZmasGCBdq2bZuOHTuWa5uffvpJmzZt0p49exQbG6tp06bpk08+0ciRI/Pcz+TJkxUQEOB6hIWFldaUAABABVGhL4dJ0o8//qihQ4dq48aN8vDw0I033qhmzZppx44d2rdvX4763bp109dff63jx48rICBAkvTpp5+qX79+Onv2rHx8fHK0ycjIUEZGhut5WlqawsLCuBwGAEAlUqUuh0lSkyZNFB8frzNnzujw4cP65ptvdPHiRYWHh+dav379+goNDXUFIEm65pprZIzRkSNHcm3j7e0tf39/twcAAKjaKnwIylazZk3Vr19fp06d0tq1a9WnT59c6916661KTk7WmTNnXGU//PCDqlWrpgYNGpTVcAEAQAVX4UPQ2rVrtWbNGiUmJiouLk6RkZFq3ry5HnnkEUnS2LFjFRUV5ao/aNAg1alTR4888oj27dunjRs36o9//KOGDh2a66UwAABgpwofglJTUzVy5Ei1aNFCUVFR6tSpk9atW6fq1atLko4dO6ZDhw656teqVUtxcXE6ffq02rZtq4ceeki9evXSO++8U15TAAAAFVCFvzG6PPA5QQAAVD5V7sZoAACA0kAIAgAAViIEAQAAKxGCAACAlQhBAADASoQgAABgJUIQAACwEiEIAABYiRAEAACsRAgCAABWIgQBAAArEYIAAICVCEEAAMBKhCAAAGAlQhAAALASIQgAAFiJEAQAAKxECAIAAFYiBAEAACsRggAAgJUIQQAAwEqEIAAAYCVCEAAAsBIhCAAAWIkQBAAArEQIAgAAViIEAQAAKxGCAACAlQhBAADASoQgAABgJUIQAACwEiEIAABYiRAEAACsRAgCAABWIgQBAAArEYIAAICVCEEAAMBKhCAAAGAlQhAAALASIQgAAFiJEAQAAKxECAIAAFYiBAEAACt5lvcAKiJjjCQpLS2tnEcCAAAKK/t1O/t1vCCEoFykp6dLksLCwsp5JAAAoKjS09MVEBBQYD2HKWxcskhWVpaSk5Pl5+cnh8NR3sNxSUtLU1hYmA4fPix/f//yHk6pqOpzrOrzk6r2HKvy3LJV9TlW9flJVX+O+c3PGKP09HQ5nU5Vq1bwHT+cCcpFtWrV1KBBg/IeRp78/f2r5IF9uao+x6o+P6lqz7Eqzy1bVZ9jVZ+fVPXnmNf8CnMGKBs3RgMAACsRggAAgJUIQZWIt7e3xo8fL29v7/IeSqmp6nOs6vOTqvYcq/LcslX1OVb1+UlVf44lOT9ujAYAAFbiTBAAALASIQgAAFiJEAQAAKxECKoCHA6HPvvss/IeBq4Aa1i5sX6VH2tY+RVnDQlBFdCQIUN03333lfcwimXy5Mlq166d/Pz8dNVVV+m+++7T/v373eoYYzRhwgQ5nU75+PioS5cu2rt3r2v7yZMn9dRTT6l58+by9fVVw4YNNWrUKKWmprr189prr6ljx47y9fVV7dq1y2J6hcYaFryGSUlJGjZsmMLDw+Xj46MmTZpo/PjxunDhQpnNNS+sX+H+D/bu3VsNGzZUjRo1VL9+fQ0ePFjJycllMs+CsIaFW8NsGRkZat26tRwOh3bu3Fma0yu0slhDQhBKVHx8vEaOHKmtW7cqLi5Oly5dUrdu3XT27FlXnalTp+qtt97SjBkzlJCQoJCQEHXt2tX1nW3JyclKTk7Wm2++qd27d2vu3Llas2aNhg0b5ravCxcuqH///vr9739fpnOs6spqDb///ntlZWXpr3/9q/bu3au//OUvmjVrlv70pz+V+ZyrkrL8PxgZGamPP/5Y+/fv17Jly/Tjjz+qX79+ZTrfqqgs1zDbc889J6fTWSbzq1AMKpzo6GjTp08fY4wxjRo1Mn/5y1/ctt9www1m/PjxrueSTGxsbJmNryhSUlKMJBMfH2+MMSYrK8uEhISY119/3VXn119/NQEBAWbWrFl59vPxxx8bLy8vc/HixRzb5syZYwICAkp87FeCNcwpvzXMNnXqVBMeHl5ygy8m1i+nwqzf8uXLjcPhMBcuXCi5CRQTa5hTXmu4atUq06JFC7N3714jyXz77belMo+iKos15EwQSlX2qdegoCBJUmJioo4fP65u3bq56nh7e6tz587avHlzvv34+/vL05OvuytrZbmGqamprv2gZJTV+p08eVILFy5Ux44dVb169RKcAUpzDU+cOKFHH31U8+fPl6+vbynNoOIiBKHUGGP0zDPPqFOnTmrVqpUk6fjx45Kk4OBgt7rBwcGubf/rl19+0aRJkzRixIjSHTByKMs1/PHHHzV9+nQ9/vjjJTR6lMX6Pf/886pZs6bq1KmjQ4cOafny5SU8C7uV5hoaYzRkyBA9/vjjatu2bSnNoGIjBKHUPPnkk/rXv/6lxYsX59jmcDjcnhtjcpRJUlpamnr06KGWLVtq/PjxpTZW5K6s1jA5OVndu3dX//79NXz48JIZPMpk/f74xz/q22+/1bp16+Th4aGoqCgZvoigxJTmGk6fPl1paWkaO3ZsyQ+8kiAEVXDVqlXL8Qvl4sWL5TSawnvqqae0YsUKrV+/Xg0aNHCVh4SESFKOv1ZSUlJy/FWTnp6u7t27q1atWoqNja20p9hZw/zXMDk5WZGRkerQoYPef//9UpjJlWH98l+/unXrqlmzZuratauWLFmiVatWaevWraUwo+JjDXNfw6+++kpbt26Vt7e3PD091bRpU0lS27ZtFR0dXVrTKpbSWkNCUAVXr149HTt2zPU8LS1NiYmJ5Tii/Blj9OSTT+rTTz/VV199pfDwcLft4eHhCgkJUVxcnKvswoULio+PV8eOHV1laWlp6tatm7y8vLRixQrVqFGjzOZQ0ljDvNfw6NGj6tKli2688UbNmTNH1apVvF9JrF/h/w9mv0hlZGSU0GxKBmuY+xq+88472rVrl3bu3KmdO3dq1apVkqSPPvpIr732WinOsOhKaw25y7SCu+OOOzR37lz16tVLgYGBGjdunDw8PMp7WHkaOXKkFi1apOXLl8vPz8/1l0pAQIB8fHzkcDg0evRoxcTEKCIiQhEREYqJiZGvr68GDRok6be/XLp166Zz585pwYIFSktLU1pamqTf/iNkz//QoUM6efKkDh06pMzMTNdnWzRt2lS1atUq+8nngTXMfQ2Tk5PVpUsXNWzYUG+++aZ+/vln1xiy/9KtCFi/3Nfvm2++0TfffKNOnTopMDBQP/30k15++WU1adJEHTp0KLf554Y1zH0NGzZs6Lbf7N+bTZo0cTvzVBGU2hoW6b1kKBODBw82DzzwgDHGmNTUVPPggw8af39/ExYWZubOnVuh39opKdfHnDlzXHWysrLM+PHjTUhIiPH29ja333672b17t2v7+vXr8+wnMTHRVS86OjrXOuvXry+7CeeBNSx4DefMmZNnnfLG+hW8fv/6179MZGSkCQoKMt7e3qZx48bm8ccfN0eOHCnjGeeONSzc79HLJSYmVqi3yJfFGjr+f0NUIN27d1fTpk01Y8aM8h4Kiok1rNxYv8qPNaz8ymINK94FeIudOnVKn3/+uTZs2KC77rqrvIeDYmANKzfWr/JjDSu/slxD7gmqQIYOHaqEhAQ9++yz6tOnT3kPB8XAGlZurF/lxxpWfmW5hlwOAwAAVuJyGAAAsBIhCAAAWIkQBAAArEQIAgAAViIEAagyNmzYIIfDodOnT5f3UABUArw7DECl1aVLF7Vu3VrTpk2T9Nv3J508eVLBwcG5fps2AFyOzwkCUGV4eXlVqO8dA1CxcTkMQKU0ZMgQxcfH6+2335bD4ZDD4dDcuXPdLofNnTtXtWvX1sqVK9W8eXP5+vqqX79+Onv2rObNm6fGjRsrMDBQTz31lDIzM119X7hwQc8995xCQ0NVs2ZNtW/fXhs2bCifiQIoNZwJAlApvf322/rhhx/UqlUrvfLKK5KkvXv35qh37tw5vfPOO1qyZInS09N1//336/7771ft2rW1atUq/fTTT3rggQfUqVMnDRgwQJL0yCOPKCkpSUuWLJHT6VRsbKy6d++u3bt3KyIiokznCaD0EIIAVEoBAQHy8vKSr6+v6xLY999/n6PexYsX9d5776lJkyaSpH79+mn+/Pk6ceKEatWqpZYtWyoyMlLr16/XgAED9OOPP2rx4sU6cuSInE6nJGnMmDFas2aN5syZo5iYmLKbJIBSRQgCUKX5+vq6ApAkBQcHq3HjxqpVq5ZbWUpKiiRpx44dMsaoWbNmbv1kZGSoTp06ZTNoAGWCEASgSqtevbrbc4fDkWtZVlaWJCkrK0seHh765z//KQ8PD7d6lwcnAJUfIQhApeXl5eV2Q3NJaNOmjTIzM5WSkqLbbrutRPsGULHw7jAAlVbjxo21bds2JSUl6T//+Y/rbM6VaNasmR566CFFRUXp008/VWJiohISEjRlyhStWrWqBEYNoKIgBAGotMaMGSMPDw+1bNlS9erV06FDh0qk3zlz5igqKkrPPvusmjdvrt69e2vbtm0KCwsrkf4BVAx8YjQAALASZ4IAAICVCEEAAMBKhCAAAGAlQhAAALASIQgAAFiJEAQAAKxECAIAAFYiBAEAACsRggAAgJUIQQAAwEqEIAAAYCVCEAAAsNL/A2hb9KQAQcj1AAAAAElFTkSuQmCC",
+      "text/plain": [
+       "<Figure size 640x480 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "transport_model.mesh.Ap.isel(nface=217, time=slice(0, 5000)).plot()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 38,
+   "id": "826ba5be",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[<matplotlib.lines.Line2D at 0x1c25c5368d0>]"
+      ]
+     },
+     "execution_count": 38,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAkEAAAHFCAYAAAD1zS3+AAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjguNCwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8fJSN1AAAACXBIWXMAAA9hAAAPYQGoP6dpAAA5m0lEQVR4nO3deZzP5eL//+fb7JgZM5YZw4yxZEtFyJ6lDJKtSE4xDjmcjxJykiJtyFKRtZSliJJEGkViqoMs4djiKIOMaSyZsZzGmLl+f/Sd98+72TVmux732+19u3lfr+t1va7rfb3M+zmvbRzGGCMAAADLlCjoDgAAABQEQhAAALASIQgAAFiJEAQAAKxECAIAAFYiBAEAACsRggAAgJUIQQAAwEqEIAAAYCVCEP6SDz/8ULfeeqt8fHzkcDi0Z8+egu5SoRcTEyOHw5Hha/ny5Tlq49KlSxo+fLhCQkLk7e2t+vXrZ7jud999p8cee0wNGzaUl5eXHA6HYmJism3/4MGDzvo7d+7M7RD/spyOr3///hl+jrVr1/5L2585c6Zq1KghT09PORwOXbhw4S+1Z4Ovv/5aAwYMUO3atVWqVClVqlRJ3bp1065du3K0/ldffaX27dsrJCREXl5eqlChgtq1a6eoqKhM6zdr1kwlS5ZUuXLl1L9/f8XHx2e7jbR95OzZs7ke418VHx+v/v37q1y5cipZsqSaNWumjRs3pqv33HPPqUGDBgoMDJS3t7eqVaumf/zjHzp+/Hi+97m4cy/oDqDoOnPmjPr27auOHTtqzpw58vLyUs2aNQu6W0XGE088ob/97W8uZbfcckuO1n3ggQe0Y8cOvfrqq6pZs6Y++OAD9enTR6mpqS5tbty4UV999ZUaNGggPz8/bd68Odu2U1JSNGDAAJUrV06xsbG5GlNeyen4JMnHx0dff/11urIbtWfPHg0bNkyPPfaYIiMj5e7uLl9f3xtuzxZz587VuXPn9OSTT6pu3bo6c+aMXnvtNTVt2lRffvml2rVrl+X6586d06233qrHHntMwcHBOn/+vObNm6fOnTvr/fff16OPPuqsGx0drU6dOqlz585avXq14uPjNXr0aN1zzz3auXOnvLy80rV/6dIlDRo0SCEhIQWyXyclJemee+7RhQsXNGPGDFWoUEGzZ89Wx44d9dVXX6l169bOuhcuXFCfPn1Up04d+fr66uDBg3rllVe0Zs0aHThwQGXLls33/hdbBrhB3333nZFkPvzww4LuSpFy7NgxI8lMnTr1htb//PPPjSTzwQcfuJS3b9/ehISEmGvXrjnLUlJSnP+eOnWqkWSOHTuWZftTp041lSpVMjNmzDCSzI4dO26onxmJjIw0rVu3zrJObsYXGRlpSpUqlWf9M8aYJUuWGEnm+++/z9N2i7tff/01XdnFixdNUFCQueeee26ozatXr5pKlSqZVq1auZQ3btzY1K1b1yQnJzvL/v3vfxtJZs6cORm2NXToUNOgQQMzduxYI8mcOXPmhvqUkdatW5vIyMgs68yePdtIMlu2bHGWJScnm7p165q77ror221ERUUZSebdd9/9q93FdTgdhhvSv39/tWzZUpLUu3dvORwOtWnTRpK0c+dOPfzwwwoPD5ePj4/Cw8PVp0+fDA/lnjp1Sv/4xz8UGhoqT09PhYSEqGfPnvr111+ddRITEzVq1ChVrVpVnp6eqlSpkoYPH67Lly/nuL9nz55VaGiomjdvruTkZGf5wYMHVapUKfXt2/cGP4n8t2rVKpUuXVq9evVyKf/73/+u2NhYff/9986yEiVy91/8v//9r55//nnNmTNHfn5+mdbbuXOnunbt6jxc36BBA3300Ue5G0gmcjO+vNamTRvnEYcmTZrI4XCof//+kqQNGzaoW7duqly5sry9vVWjRg0NHjw4w9MqP/74o/r06aOgoCB5eXkpLCxM/fr1U1JSkrNOXFycBg8erMqVK8vT01NVq1bViy++qGvXruW4vy+//LLc3d118uTJdMsGDBigsmXL6vfff8/lp3BjKlSokK6sdOnSqlu3bob9ywkPDw+VKVNG7u7//0mLU6dOaceOHerbt69LefPmzVWzZk2tWrUqXTvffvut3n77bb3zzjtyc3PLdHtfffWV7rnnHvn5+alkyZJq0aJFhqerbsSqVatUq1YtNWvWzFnm7u6uRx99VNu3b9epU6eyXL98+fLOdZB3CEG4IePGjdPs2bMlSRMnTtTWrVs1Z84cSX9c81KrVi1Nnz5dX375pSZPnqzTp0+rcePGLl8Yp06dUuPGjbVq1SqNHDlS69at0/Tp0+Xv76/ffvtNknTlyhW1bt1aixcv1rBhw7Ru3TqNHj1aixYtUteuXWWMyVF/y5Urp+XLl2vHjh0aPXq0s+1evXopLCxM8+bNy3J9Y4yuXbuWo1dOvfrqq/L09FTJkiXVsmVLrVmzJkfr7d+/X3Xq1En3w/D22293Lr8Rxhg99thjuv/++9W1a9dM623atEktWrTQhQsXNG/ePK1evVr169dX7969tWjRohva9vVyO77//e9/Cg4OlpubmypXrqzHH39c58+fv6Ftz5kzR2PHjpUkLVy4UFu3btW4ceMkST/99JOaNWumuXPnav369Xr++ef1/fffq2XLli7Beu/evWrcuLG2bduml156SevWrdOkSZOUlJSkq1evSvojAN1111368ssv9fzzz2vdunUaOHCgJk2apEGDBuW4v4MHD5a7u7veeustl/Lz589r+fLlGjhwoLy9vTNd/2bs19dLSEjQDz/8oFtvvTXH66SmpuratWuKjY3V+PHjdeTIET311FPO5Wnzn7Y/XO/222/PcP8YOHCghg8frjvvvDPT7S5ZskQRERHy8/PT4sWL9dFHHykwMFAdOnTIkyC0f//+TPssSQcOHEi37Nq1a/rf//6n3bt3a/jw4apZs6YeeOCBv9wXXKdgD0ShKNu0aZORZFasWJFlvWvXrplLly6ZUqVKmRkzZjjLBwwYYDw8PMzBgwczXXfSpEmmRIkS6U7JfPzxx0aSiYqKylWfJ0+ebCSZVatWmcjISOPj42P+85//ZLte2lhz8srudFNsbKwZNGiQ+eijj8y3335rli5dapo2bWokmfnz52fbl1tuucV06NAhw3YlmYkTJ2a4Xnanw2bOnGkCAgJMXFycMcaYhQsXZng6rHbt2qZBgwYupyKMMeb+++83FStWdDkFl5yc7PLq16+fufvuu9OVp6am3tD4Xn/9dfP666+b9evXm/Xr15vnnnvOlCxZ0tSuXdtcvHgxw3FmJ7NxXy81NdUkJyeb48ePG0lm9erVzmXt2rUzZcqUMfHx8ZmuP3jwYFO6dGlz/Phxl/Jp06YZSebAgQM57m9kZKSpUKGCSUpKcpZNnjzZlChRItt9MW2sOXndiEceecS4u7ubnTt35nidDh06OLfp5+dnPvnkE5flS5cuNZLM1q1b0637j3/8w3h6erqUPfXUU6ZatWrmypUrxhhjxo8fn+502OXLl01gYKDp0qWLy7opKSnmjjvucDldlTb317/uvvtu069fv3Tl1/Pw8DCDBw9O1+ctW7ZkePr39OnTLp9/kyZNzKlTp7L66HADOK6GPHfp0iW9/PLLWrlypWJiYpSSkuJcdujQIee/161bp7Zt26pOnTqZtrV27VrVq1dP9evXd/lttEOHDnI4HNq8ebM6deqU477961//0jfffKM+ffro999/1zvvvKPbbrst2/UaNmyoHTt25GgbISEhWS6vWLGi3n77bZeyXr16qUmTJnrmmWfUv3//bA95OxyOG1qWmePHj2vMmDGaPn26goKCMq139OhR/fjjj5o2bZokuczJfffdp7Vr1+rw4cOqU6eOYmJiVLVq1Qzb8fDwcHm/adMm5+nU7MZw/bIRI0a4LGvfvr0aNGignj17av78+emW/xXx8fF6/vnn9fnnnys2NlapqanOZYcOHVLXrl115coVRUdHa+DAgc7TFxlZu3at2rZtq5CQEJfPsFOnTho1apSio6NVt27dHPXrySef1OLFi7VixQo98sgjSk1N1dy5c9W5c2eFh4dnuW6XLl1yvF/n1rhx47R06VLNnDlTDRs2zPF6M2fO1IULF3T69GktWbJEvXv31uLFi9WnTx+XepntI9eXb9++XdOnT9cXX3yR5cXyW7Zs0fnz5xUZGZnuqFfHjh01ZcoUXb58WaVKlVJ0dLTatm2bro1vvvlG7733nkvZsWPHXOYgN/9vy5Urpx07digpKUmHDh3SlClT1LZtW23evFkVK1bMtB3kDiEIee5vf/ubNm7cqHHjxqlx48by8/OTw+HQfffdp//973/OemfOnFHlypWzbOvXX3/V0aNH031ppsntba5p13h8/vnnCg4OzvG1QKVLl1b9+vVzVPdGztl7eHiod+/eeuaZZ/Tf//43y2BYtmxZnTt3Ll152imgwMDAXG9/6NChqlevnh588EHn7eBXrlyR9EeoTUhIkL+/v/NarVGjRmnUqFEZtpU2JyEhIem+YF988UXFxsamO31Tq1atPBtfjx49VKpUKW3bti3LermRmpqqiIgIxcbGaty4cbrttttUqlQppaamqmnTps79+rffflNKSkqO9uvPPvssT/brBg0aqFWrVpo9e7YeeeQRrV27VjExMek+44wEBgbK398/x9vKqRdffFGvvPKKJkyYoMcffzxX615/h2TXrl3VqVMnDR06VL1791aJEiWcd0Zlto9cv38MGDBADzzwgBo1auTcr9OukUpMTJSXl5d8fX2d+3XPnj0z7df58+dVqlSpDH8hGjx4sEJCQjR+/HiX8ut/Icrtfu3u7q5GjRpJklq0aKGOHTuqatWqevXVVzVjxoxM+4ncIQQhTyUkJGjt2rUaP368nnnmGWd5UlJSuus0ypcvr19++SXL9sqVKycfHx8tWLAg0+W5cfr0aQ0dOlT169fXgQMHNGrUKL355pvZrpfZb38Z+fNvfzll/t/1TdldzHzbbbdp2bJlunbtmkvg2rdvnySpXr16ud72/v37dfz4cQUEBKRb1rZtW/n7++vChQvOz3vMmDGZXpuQFmg8PT2dP8TTlC1bVhcvXkxXfr28GJ8xJtcXhWdl//792rt3rxYtWqTIyEhn+dGjR13qBQYGys3NLUf79e23364JEyZkuDy7o4l/NmzYMPXq1Us//PCDZs2apZo1a6p9+/bZrrd48WL9/e9/z9E2TA6vv3vxxRf1wgsv6IUXXtCzzz6bo3Wyctddd+mLL77QmTNnFBQU5Jz/ffv26b777nOpu2/fPpf948CBAzpw4IBWrFiRrt3q1avrjjvu0J49e5z79cyZM9W0adMM+5F2hNTX1zfd/uvr66uyZctmu1+n7cN/7rOU/X5duXJlhYSE6MiRI1nWQ+4QgpCnHA6HjDHpntPxzjvvuJwWk/449P/+++/r8OHDLkcCrnf//fdr4sSJKlu2bKanVnIqJSVFffr0kcPh0Lp167R06VKNGjVKbdq0yfZiw7w8HZaR5ORkffjhhypXrpxq1KiRZd0ePXpo/vz5WrlypXr37u0sX7x4sUJCQtSkSZNcb3/58uXp7iL64osvNHnyZM2bN895YWutWrV0yy23aO/evZo4cWKut5MTf3V8H3/8sa5cuZLpl9mNSDtV8ef9+s9HW3x8fNS6dWutWLFCEyZMyDSk33///YqKilL16tUzDJ651aNHD4WFhempp55SdHS03njjjRydFs3r02Evv/yyXnjhBY0dOzbdUZEbYYxRdHS0ypQp4zwCVKlSJd11111asmSJRo0a5bzba9u2bTp8+LCGDx/uXH/Tpk3p2ly0aJEWL16sTz/9VJUqVZL0x5GWMmXK6ODBg7k+cpVTPXr00P/93//p+++/d+7D165d05IlS9SkSZNsf24cPXpUv/zyS5Y3LeAGFOgVSSjSMrsw+u677zaBgYFm/vz5ZsOGDWbs2LGmYsWKpkyZMi7P0vjll19MxYoVTYUKFcz06dPNxo0bzcqVK82gQYPMoUOHjDHGXLp0yTRo0MBUrlzZvPbaa2bDhg3myy+/NPPnzze9evUy27Zty3F/n3vuOVOiRAnz1VdfOcu6dOliypQpY37++ee/9mHkwogRI8zjjz9uli1bZjZt2mTee+8907hxYyPJLFy40KXuiy++aNzc3MzmzZtdytu3b28CAgLM22+/bb7++mszaNAgI8ksWbLEpV58fLxZsWKFWbFihenXr5/zOSorVqxI1+afZXaB8Ndff228vLxMRESE+eCDD0x0dLRZtWqVmThxounZs2eWbebkOUE5HV9MTIxp3ry5efPNN01UVJRZt26deeaZZ4y3t7e59dZbzaVLl1zabN26dY4u8M1o3FevXjXVq1c3VapUMR988IH54osvzNChQ03NmjWNJDN+/Hhn3T179pjSpUubatWqOfu/bNky06dPH5OYmGiM+eMi7ypVqpjatWubOXPmmI0bN5rPP//czJ4923Tu3NmcPHky237+WdpF/6VKlTIXLlzI9fp/VdpF3R07djRbt25N97regAEDjJubm4mJiXGWde3a1YwbN86sXLnSbN682XzwwQcmIiLCSDKzZ892WX/Tpk3G3d3d9OjRw2zYsMEsXbrUhIaGmnr16pnff/89y35mdGG0Mca8//77pkSJEqZ3795mxYoVJjo62nz88cdm3LhxZsiQIVm2mZPnBP3+++/m1ltvNaGhoWbp0qVmw4YNpkePHsbd3d3l/+LevXtNu3btzJw5c8wXX3xh1q9fb1577TVTuXJlU758eZfPDH8dIQg3LLMQ9Msvv5gHH3zQBAQEGF9fX9OxY0ezf/9+U6VKlXQ/KE6ePGkGDBhggoODjYeHhwkJCTEPPfSQy4PXLl26ZMaOHWtq1aplPD09jb+/v7ntttvMiBEjnHcyZWf9+vWmRIkSLl9Wxhhz7tw5ExYWZho3buxyd83N9O6775q77rrLBAYGGnd3dxMQEGA6dOhgvvzyy3R1035gb9q0yaX84sWLZtiwYSY4ONh4enqa22+/3Sxbtizd+lnd1ZZdGMnqLqm9e/eahx56yFSoUMF4eHiY4OBg065dOzNv3rws28xpCMrJ+M6fP2969OhhwsPDjY+Pj/H09DS33HKLefrppzMMAQ0bNjTBwcHZbjuzcR88eNC0b9/e+Pr6moCAANOrVy9z4sSJdCEorW6vXr1M2bJljaenpwkLCzP9+/d3+YI+c+aMGTZsmKlatarx8PAwgYGBpmHDhua5555LF+ByIiYmxkjK9gv7ZkkLmZm9rhcZGZnuTsXJkyebxo0bm4CAAOPm5mbKli1rOnToYNauXZvh9tavX2+aNm1qvL29TWBgoOnXr1+GD2z8s8xCkDHGREdHm86dO5vAwEDj4eFhKlWqZDp37pztHbA5CUHGGBMXF2f69etnAgMDjbe3t2natKnZsGFDujqPPvqoqV69uilZsqTx9PQ01apVM0OGDDEnTpzIdhvIHYcxOTzRCwBF1MWLFxUYGKjp06dr6NChBd2dm2LmzJkaNmyY9u/fn6vn8gA245ogAMXeN998o0qVKuXqQYRFxe7du3Xs2DG99NJL6tatGwEIyAWOBKHIS01NdXlmS0Z41DyKmpSUlCzvyHI4HHJzc1N4eLji4uLUqlUrvf/++woODs7HXgJFGyEIRV7//v21ePHiLOuwm6OoadOmjaKjozNdXqVKFcXExORfh4BiiBCEIi8mJibbh8tl9fwOoDA6fPiwLl68mOlyLy+vHD3tHEDmCEEAAMBK/BV5AABgJa4WzUBqaqpiY2Pl6+t7Q3+MEgAA5D9jjC5evKiQkJAc/ekcQlAGYmNjFRoaWtDdAAAAN+DkyZPZ/iFjiRCUIV9fX0l/fIh+fn4F3BsAAJATiYmJCg0NdX6PZ4cQlIG0U2B+fn6EIAAAipicXsrChdEAAMBKhCAAAGAlQhAAALASIQgAAFiJEAQAAKxECAIAAFYiBAEAACsRggAAgJUIQQAAwEqEIAAAYCVCEAAAsBIhCAAAWIkQBAAArEQIAgAAViIEAQAAKxGCAACAlQhBAADASoQgAABgJUIQAACwEiEIAABYiRAEAACsRAgCAABWIgQBAAArEYIAAICVCEEAAMBKhCAAAGAlQhAAALASIQgAAFiJEAQAAKxECAIAAFYiBAEAACsRggAAgJUIQQAAwEqEIAAAYCVCEAAAsBIhCAAAWIkQBAAArEQIAgAAViIEAQAAKxGCAACAlQhBAADASoQgAABgJUIQAACwUoGGoG+++UZdunRRSEiIHA6HPv3002zXiY6OVsOGDeXt7a1q1app3rx5mdZdvny5HA6HunfvnnedBgAAxUKBhqDLly/rjjvu0KxZs3JU/9ixY7rvvvvUqlUr7d69W88++6yGDRumlStXpqt7/PhxjRo1Sq1atcrrbgMAgGLAvSA33qlTJ3Xq1CnH9efNm6ewsDBNnz5dklSnTh3t3LlT06ZN04MPPuisl5KSokceeUQvvviivv32W124cCGPew4AAIq6InVN0NatWxUREeFS1qFDB+3cuVPJycnOspdeeknly5fXwIED87uLAACgiCjQI0G5FRcXp6CgIJeyoKAgXbt2TWfPnlXFihX173//W++++6727NmT43aTkpKUlJTkfJ+YmJhXXQYAAIVUkToSJEkOh8PlvTHGWX7x4kU9+uijmj9/vsqVK5fjNidNmiR/f3/nKzQ0NE/7DAAACp8idSQoODhYcXFxLmXx8fFyd3dX2bJldeDAAcXExKhLly7O5ampqZIkd3d3HT58WNWrV0/X7pgxYzRy5Ejn+8TERIIQAADFXJEKQc2aNdNnn33mUrZ+/Xo1atRIHh4eql27tvbt2+eyfOzYsbp48aJmzJiRabDx8vKSl5fXTes3AAAofAo0BF26dElHjx51vj927Jj27NmjwMBAhYWFacyYMTp16pTee+89SdKQIUM0a9YsjRw5UoMGDdLWrVv17rvvatmyZZIkb29v1atXz2UbZcqUkaR05QAAwG4FGoJ27typtm3bOt+nnZKKjIzUokWLdPr0aZ04ccK5vGrVqoqKitKIESM0e/ZshYSE6M0333S5PR4AACAnHCbtymI4JSYmyt/fXwkJCfLz8yvo7gAAgBzI7fd3kbs7DAAAIC8QggAAgJUIQQAAwEqEIAAAYCVCEAAAsBIhCAAAWIkQBAAArEQIAgAAViIEAQAAKxGCAACAlQhBAADASoQgAABgJUIQAACwEiEIAABYiRAEAACsRAgCAABWIgQBAAArEYIAAICVCEEAAMBKhCAAAGAlQhAAALASIQgAAFiJEAQAAKxECAIAAFYiBAEAACsRggAAgJUIQQAAwEqEIAAAYCVCEAAAsBIhCAAAWIkQBAAArEQIAgAAViIEAQAAKxGCAACAlQhBAADASoQgAABgJUIQAACwEiEIAABYiRAEAACsRAgCAABWIgQBAAArEYIAAICVCEEAAMBKhCAAAGAlQhAAALASIQgAAFiJEAQAAKxECAIAAFYiBAEAACsRggAAgJUIQQAAwEqEIAAAYCVCEAAAsBIhCAAAWIkQBAAArEQIAgAAVirQEPTNN9+oS5cuCgkJkcPh0KeffprtOtHR0WrYsKG8vb1VrVo1zZs3z2X5/Pnz1apVKwUEBCggIED33nuvtm/ffpNGAAAAiqoCDUGXL1/WHXfcoVmzZuWo/rFjx3TfffepVatW2r17t5599lkNGzZMK1eudNbZvHmz+vTpo02bNmnr1q0KCwtTRESETp06dbOGAQAAiiCHMcYUdCckyeFwaNWqVerevXumdUaPHq01a9bo0KFDzrIhQ4Zo79692rp1a4brpKSkKCAgQLNmzVK/fv1y1JfExET5+/srISFBfn5+uRoHAAAoGLn9/i5S1wRt3bpVERERLmUdOnTQzp07lZycnOE6V65cUXJysgIDA/OjiwAAoIhwL+gO5EZcXJyCgoJcyoKCgnTt2jWdPXtWFStWTLfOM888o0qVKunee+/NtN2kpCQlJSU53ycmJuZdpwEAQKFUpI4ESX+cNrte2tm8P5dL0pQpU7Rs2TJ98skn8vb2zrTNSZMmyd/f3/kKDQ3N204DAIBCp0iFoODgYMXFxbmUxcfHy93dXWXLlnUpnzZtmiZOnKj169fr9ttvz7LdMWPGKCEhwfk6efJknvcdAAAULkXqdFizZs302WefuZStX79ejRo1koeHh7Ns6tSpeuWVV/Tll1+qUaNG2bbr5eUlLy+vPO8vAAAovAr0SNClS5e0Z88e7dmzR9Ift8Dv2bNHJ06ckPTHEZrr7+gaMmSIjh8/rpEjR+rQoUNasGCB3n33XY0aNcpZZ8qUKRo7dqwWLFig8PBwxcXFKS4uTpcuXcrXsQEAgMKtQG+R37x5s9q2bZuuPDIyUosWLVL//v0VExOjzZs3O5dFR0drxIgROnDggEJCQjR69GgNGTLEuTw8PFzHjx9P1+b48eP1wgsv5Khf3CIPAEDRk9vv70LznKDChBAEAEDRU6yfEwQAAJBXCEEAAMBKhCAAAGAlQhAAALASIQgAAFiJEAQAAKxECAIAAFYiBAEAACsRggAAgJUIQQAAwEqEIAAAYCVCEAAAsBIhCAAAWIkQBAAArEQIAgAAViIEAQAAKxGCAACAlQhBAADASoQgAABgJUIQAACwEiEIAABYiRAEAACsRAgCAABWIgQBAAArEYIAAICVCEEAAMBKhCAAAGAlQhAAALASIQgAAFiJEAQAAKxECAIAAFYiBAEAACsRggAAgJUIQQAAwEqEIAAAYCVCEAAAsBIhCAAAWIkQBAAArEQIAgAAViIEAQAAKxGCAACAlQhBAADASoQgAABgJUIQAACwEiEIAABYiRAEAACsRAgCAABWIgQBAAArEYIAAICVCEEAAMBKhCAAAGAlQhAAALASIQgAAFiJEAQAAKxECAIAAFYiBAEAACvlOgR9/vnneuyxx/T000/rxx9/dFn222+/qV27dnnWOQAAgJslVyHogw8+ULdu3RQXF6etW7eqQYMGWrp0qXP51atXFR0dneP2vvnmG3Xp0kUhISFyOBz69NNPs10nOjpaDRs2lLe3t6pVq6Z58+alq7Ny5UrVrVtXXl5eqlu3rlatWpXjPgEAADvkKgRNmzZNb7zxhtauXatvv/1W77//voYMGaJ33333hjZ++fJl3XHHHZo1a1aO6h87dkz33XefWrVqpd27d+vZZ5/VsGHDtHLlSmedrVu3qnfv3urbt6/27t2rvn376qGHHtL3339/Q30EAADFk8MYY3JauXTp0tq3b5+qVq3qLNu8ebO6du2qKVOmqEePHgoJCVFKSkruO+JwaNWqVerevXumdUaPHq01a9bo0KFDzrIhQ4Zo79692rp1qySpd+/eSkxM1Lp165x1OnbsqICAAC1btixHfUlMTJS/v78SEhLk5+eX67EAAID8l9vv71wdCfLz89Ovv/7qUtamTRt99tln+te//qWZM2fmrre5tHXrVkVERLiUdejQQTt37lRycnKWdbZs2ZJpu0lJSUpMTHR5AQCA4i1XIeiuu+5yOcKSpnXr1vrss880ffr0vOpXhuLi4hQUFORSFhQUpGvXruns2bNZ1omLi8u03UmTJsnf39/5Cg0NzfvOAwCAQiVXIWjEiBHy9vbOcFmbNm20du1a9evXL086lhmHw+HyPu1s3vXlGdX5c9n1xowZo4SEBOfr5MmTedhjAABQGLnnpnLr1q3VunXrTJe3adNGbdq0+at9ylRwcHC6Izrx8fFyd3dX2bJls6zz56ND1/Py8pKXl1fedxgAABRauToSVKJECbm5uWX5cnfPVa7KlWbNmmnDhg0uZevXr1ejRo3k4eGRZZ3mzZvftH4BAICiJ1eJJavn7WzZskUzZ85ULm4206VLl3T06FHn+2PHjmnPnj0KDAxUWFiYxowZo1OnTum9996T9MedYLNmzdLIkSM1aNAgbd26Ve+++67LXV9PPvmk7r77bk2ePFndunXT6tWr9dVXX+m7777LzVABAEBxZ/6iQ4cOme7duxs3NzfTr18/c/z48Ryvu2nTJiMp3SsyMtIYY0xkZKRp3bq1yzqbN282DRo0MJ6eniY8PNzMnTs3XbsrVqwwtWrVMh4eHqZ27dpm5cqVuRpTQkKCkWQSEhJytR4AACg4uf3+ztVzgq4XGxur8ePHa/HixerQoYMmTZqkevXq5Vk4K0g8JwgAgKLnpj4nSJISEhI0evRo1ahRQwcOHNDGjRv12WefFZsABAAA7JCra4KmTJmiyZMnKzg4WMuWLVO3bt1uVr8AAABuqlydDitRooR8fHx07733ys3NLdN6n3zySZ50rqBwOgwAgKInt9/fuToS1K9fvywfOggAAFBU5CoELVq06CZ1AwAAIH/l+sJoAACA4oAQBAAArEQIAgAAViIEAQAAKxGCAACAlQhBAADASoQgAABgJUIQAACwEiEIAABYiRAEAACsRAgCAABWIgQBAAArEYIAAICVCEEAAMBKhCAAAGAlQhAAALASIQgAAFiJEAQAAKxECAIAAFYiBAEAACsRggAAgJUIQQAAwEqEIAAAYCVCEAAAsBIhCAAAWIkQBAAArEQIAgAAViIEAQAAKxGCAACAlQhBAADASoQgAABgJUIQAACwEiEIAABYiRAEAACsRAgCAABWIgQBAAArEYIAAICVCEEAAMBKhCAAAGAlQhAAALASIQgAAFiJEAQAAKxECAIAAFYiBAEAACsRggAAgJUIQQAAwEqEIAAAYCVCEAAAsBIhCAAAWIkQBAAArEQIAgAAVirwEDRnzhxVrVpV3t7eatiwob799tss68+ePVt16tSRj4+PatWqpffeey9dnenTp6tWrVry8fFRaGioRowYod9///1mDQEAABRB7gW58Q8//FDDhw/XnDlz1KJFC7311lvq1KmTDh48qLCwsHT1586dqzFjxmj+/Plq3Lixtm/frkGDBikgIEBdunSRJC1dulTPPPOMFixYoObNm+vIkSPq37+/JOmNN97Iz+EBAIBCzGGMMQW18SZNmujOO+/U3LlznWV16tRR9+7dNWnSpHT1mzdvrhYtWmjq1KnOsuHDh2vnzp367rvvJEmPP/64Dh06pI0bNzrrPPXUU9q+fXu2R5nSJCYmyt/fXwkJCfLz87vR4QEAgHyU2+/vAjsddvXqVe3atUsREREu5REREdqyZUuG6yQlJcnb29ulzMfHR9u3b1dycrIkqWXLltq1a5e2b98uSfr5558VFRWlzp07Z9qXpKQkJSYmurwAAEDxVmAh6OzZs0pJSVFQUJBLeVBQkOLi4jJcp0OHDnrnnXe0a9cuGWO0c+dOLViwQMnJyTp79qwk6eGHH9bLL7+sli1bysPDQ9WrV1fbtm31zDPPZNqXSZMmyd/f3/kKDQ3Nu4ECAIBCqcAvjHY4HC7vjTHpytKMGzdOnTp1UtOmTeXh4aFu3bo5r/dxc3OTJG3evFkTJkzQnDlz9MMPP+iTTz7R2rVr9fLLL2fahzFjxighIcH5OnnyZN4MDgAAFFoFFoLKlSsnNze3dEd94uPj0x0dSuPj46MFCxboypUriomJ0YkTJxQeHi5fX1+VK1dO0h9BqW/fvnrsscd02223qUePHpo4caImTZqk1NTUDNv18vKSn5+fywsAABRvBRaCPD091bBhQ23YsMGlfMOGDWrevHmW63p4eKhy5cpyc3PT8uXLdf/996tEiT+GcuXKFee/07i5uckYowK8BhwAABQyBXqL/MiRI9W3b181atRIzZo109tvv60TJ05oyJAhkv44TXXq1Cnns4COHDmi7du3q0mTJvrtt9/0+uuva//+/Vq8eLGzzS5duuj1119XgwYN1KRJEx09elTjxo1T165dnafMAAAACjQE9e7dW+fOndNLL72k06dPq169eoqKilKVKlUkSadPn9aJEyec9VNSUvTaa6/p8OHD8vDwUNu2bbVlyxaFh4c764wdO1YOh0Njx47VqVOnVL58eXXp0kUTJkzI7+EBAIBCrECfE1RY8ZwgAACKniLznCAAAICCRAgCAABWIgQBAAArEYIAAICVCEEAAMBKhCAAAGAlQhAAALASIQgAAFiJEAQAAKxECAIAAFYiBAEAACsRggAAgJUIQQAAwEqEIAAAYCVCEAAAsBIhCAAAWIkQBAAArEQIAgAAViIEAQAAKxGCAACAlQhBAADASoQgAABgJUIQAACwEiEIAABYiRAEAACsRAgCAABWIgQBAAArEYIAAICVCEEAAMBKhCAAAGAlQhAAALASIQgAAFiJEAQAAKxECAIAAFYiBAEAACsRggAAgJUIQQAAwEqEIAAAYCVCEAAAsBIhCAAAWIkQBAAArEQIAgAAViIEAQAAKxGCAACAlQhBAADASoQgAABgJUIQAACwEiEIAABYiRAEAACsRAgCAABWIgQBAAArEYIAAICVCEEAAMBKhCAAAGAlQhAAALASIQgAAFipwEPQnDlzVLVqVXl7e6thw4b69ttvs6w/e/Zs1alTRz4+PqpVq5bee++9dHUuXLigoUOHqmLFivL29ladOnUUFRV1s4YAAACKIPeC3PiHH36o4cOHa86cOWrRooXeeustderUSQcPHlRYWFi6+nPnztWYMWM0f/58NW7cWNu3b9egQYMUEBCgLl26SJKuXr2q9u3bq0KFCvr4449VuXJlnTx5Ur6+vvk9PAAAUIg5jDGmoDbepEkT3XnnnZo7d66zrE6dOurevbsmTZqUrn7z5s3VokULTZ061Vk2fPhw7dy5U999950kad68eZo6dap+/PFHeXh43FC/EhMT5e/vr4SEBPn5+d1QGwAAIH/l9vu7wE6HXb16Vbt27VJERIRLeUREhLZs2ZLhOklJSfL29nYp8/Hx0fbt25WcnCxJWrNmjZo1a6ahQ4cqKChI9erV08SJE5WSkpJpX5KSkpSYmOjyAgAAxVuBhaCzZ88qJSVFQUFBLuVBQUGKi4vLcJ0OHTronXfe0a5du2SM0c6dO7VgwQIlJyfr7NmzkqSff/5ZH3/8sVJSUhQVFaWxY8fqtdde04QJEzLty6RJk+Tv7+98hYaG5t1AAQBAoVTgF0Y7HA6X98aYdGVpxo0bp06dOqlp06by8PBQt27d1L9/f0mSm5ubJCk1NVUVKlTQ22+/rYYNG+rhhx/Wc88953LK7c/GjBmjhIQE5+vkyZN5MzgAAFBoFVgIKleunNzc3NId9YmPj093dCiNj4+PFixYoCtXrigmJkYnTpxQeHi4fH19Va5cOUlSxYoVVbNmTWcokv64ziguLk5Xr17NsF0vLy/5+fm5vAAAQPFWYCHI09NTDRs21IYNG1zKN2zYoObNm2e5roeHhypXriw3NzctX75c999/v0qU+GMoLVq00NGjR5Wamuqsf+TIEVWsWFGenp55PxAAAFAkFejpsJEjR+qdd97RggULdOjQIY0YMUInTpzQkCFDJP1xmqpfv37O+keOHNGSJUv03//+V9u3b9fDDz+s/fv3a+LEic46//znP3Xu3Dk9+eSTOnLkiD7//HNNnDhRQ4cOzffxAQCAwqtAnxPUu3dvnTt3Ti+99JJOnz6tevXqKSoqSlWqVJEknT59WidOnHDWT0lJ0WuvvabDhw/Lw8NDbdu21ZYtWxQeHu6sExoaqvXr12vEiBG6/fbbValSJT355JMaPXp0fg8PAAAUYgX6nKDCiucEAQBQ9BSZ5wQBAAAUJEIQAACwEiEIAABYiRAEAACsRAgCAABWIgQBAAArEYIAAICVCEEAAMBKhCAAAGAlQhAAALASIQgAAFiJEAQAAKxECAIAAFYiBAEAACsRggAAgJUIQQAAwEqEIAAAYCVCEAAAsBIhCAAAWIkQBAAArEQIAgAAViIEAQAAKxGCAACAlQhBAADASoQgAABgJUIQAACwEiEIAABYiRAEAACsRAgCAABWIgQBAAArEYIAAICVCEEAAMBKhCAAAGAlQhAAALASIQgAAFiJEAQAAKxECAIAAFYiBAEAACsRggAAgJUIQQAAwEqEIAAAYCVCEAAAsBIhCAAAWMm9oDtQGBljJEmJiYkF3BMAAJBTad/bad/j2SEEZeDixYuSpNDQ0ALuCQAAyK2LFy/K398/23oOk9O4ZJHU1FTFxsbK19dXDoejoLvjlJiYqNDQUJ08eVJ+fn4F3Z2boriPsbiPTyreYyzOY0tT3MdY3McnFf8xZjU+Y4wuXryokJAQlSiR/RU/HAnKQIkSJVS5cuWC7kam/Pz8iuWOfb3iPsbiPj6peI+xOI8tTXEfY3Efn1T8x5jZ+HJyBCgNF0YDAAArEYIAAICVCEFFiJeXl8aPHy8vL6+C7spNU9zHWNzHJxXvMRbnsaUp7mMs7uOTiv8Y83J8XBgNAACsxJEgAABgJUIQAACwEiEIAABYiRBUDDgcDn366acF3Q38Bcxh0cb8FX3MYdF3I3NICCqE+vfvr+7duxd0N27IpEmT1LhxY/n6+qpChQrq3r27Dh8+7FLHGKMXXnhBISEh8vHxUZs2bXTgwAHn8vPnz+uJJ55QrVq1VLJkSYWFhWnYsGFKSEhwaWfChAlq3ry5SpYsqTJlyuTH8HKMOcx+DmNiYjRw4EBVrVpVPj4+ql69usaPH6+rV6/m21gzw/zl7P9g165dFRYWJm9vb1WsWFF9+/ZVbGxsvowzO8xhzuYwTVJSkurXry+Hw6E9e/bczOHlWH7MISEIeSo6OlpDhw7Vtm3btGHDBl27dk0RERG6fPmys86UKVP0+uuva9asWdqxY4eCg4PVvn17599si42NVWxsrKZNm6Z9+/Zp0aJF+uKLLzRw4ECXbV29elW9evXSP//5z3wdY3GXX3P4448/KjU1VW+99ZYOHDigN954Q/PmzdOzzz6b72MuTvLz/2Dbtm310Ucf6fDhw1q5cqV++ukn9ezZM1/HWxzl5xymefrppxUSEpIv4ytUDAqdyMhI061bN2OMMVWqVDFvvPGGy/I77rjDjB8/3vleklm1alW+9S834uPjjSQTHR1tjDEmNTXVBAcHm1dffdVZ5/fffzf+/v5m3rx5mbbz0UcfGU9PT5OcnJxu2cKFC42/v3+e9/2vYA7Ty2oO00yZMsVUrVo17zp/g5i/9HIyf6tXrzYOh8NcvXo17wZwg5jD9DKbw6ioKFO7dm1z4MABI8ns3r37powjt/JjDjkShJsq7dBrYGCgJOnYsWOKi4tTRESEs46Xl5dat26tLVu2ZNmOn5+f3N35c3f5LT/nMCEhwbkd5I38mr/z589r6dKlat68uTw8PPJwBLiZc/jrr79q0KBBev/991WyZMmbNILCixCEm8YYo5EjR6ply5aqV6+eJCkuLk6SFBQU5FI3KCjIuezPzp07p5dfflmDBw++uR1GOvk5hz/99JNmzpypIUOG5FHvkR/zN3r0aJUqVUply5bViRMntHr16jwehd1u5hwaY9S/f38NGTJEjRo1ukkjKNwIQbhpHn/8cf3nP//RsmXL0i1zOBwu740x6cokKTExUZ07d1bdunU1fvz4m9ZXZCy/5jA2NlYdO3ZUr1699Nhjj+VN55Ev8/evf/1Lu3fv1vr16+Xm5qZ+/frJ8IcI8szNnMOZM2cqMTFRY8aMyfuOFxGEoEKuRIkS6X6gJCcnF1Bvcu6JJ57QmjVrtGnTJlWuXNlZHhwcLEnpfluJj49P91vNxYsX1bFjR5UuXVqrVq0qsofYmcOs5zA2NlZt27ZVs2bN9Pbbb9+Ekfw1zF/W81euXDnVrFlT7du31/LlyxUVFaVt27bdhBHdOOYw4zn8+uuvtW3bNnl5ecnd3V01atSQJDVq1EiRkZE3a1g35GbNISGokCtfvrxOnz7tfJ+YmKhjx44VYI+yZozR448/rk8++URff/21qlat6rK8atWqCg4O1oYNG5xlV69eVXR0tJo3b+4sS0xMVEREhDw9PbVmzRp5e3vn2xjyGnOY+RyeOnVKbdq00Z133qmFCxeqRInC9yOJ+cv5/8G0L6mkpKQ8Gk3eYA4znsM333xTe/fu1Z49e7Rnzx5FRUVJkj788ENNmDDhJo4w927WHHKVaSHXrl07LVq0SF26dFFAQIDGjRsnNze3gu5WpoYOHaoPPvhAq1evlq+vr/M3FX9/f/n4+MjhcGj48OGaOHGibrnlFt1yyy2aOHGiSpYsqb/97W+S/vjNJSIiQleuXNGSJUuUmJioxMRESX/8R0gb/4kTJ3T+/HmdOHFCKSkpzmdb1KhRQ6VLl87/wWeCOcx4DmNjY9WmTRuFhYVp2rRpOnPmjLMPab/pFgbMX8bzt337dm3fvl0tW7ZUQECAfv75Zz3//POqXr26mjVrVmDjzwhzmPEchoWFuWw37edm9erVXY48FQY3bQ5zdS8Z8kXfvn3Ngw8+aIwxJiEhwTz00EPGz8/PhIaGmkWLFhXqWzslZfhauHChs05qaqoZP368CQ4ONl5eXubuu+82+/btcy7ftGlTpu0cO3bMWS8yMjLDOps2bcq/AWeCOcx+DhcuXJhpnYLG/GU/f//5z39M27ZtTWBgoPHy8jLh4eFmyJAh5pdffsnnEWeMOczZz9HrHTt2rFDdIp8fc+j4fyuiEOnYsaNq1KihWbNmFXRXcIOYw6KN+Sv6mMOiLz/msPCdgLfYb7/9ps8//1ybN2/WvffeW9DdwQ1gDos25q/oYw6LvvycQ64JKkQGDBigHTt26KmnnlK3bt0Kuju4Acxh0cb8FX3MYdGXn3PI6TAAAGAlTocBAAArEYIAAICVCEEAAMBKhCAAAGAlQhCAYmPz5s1yOBy6cOFCQXcFQBHA3WEAiqw2bdqofv36mj59uqQ//n7S+fPnFRQUlOFf0waA6/GcIADFhqenZ6H6u2MACjdOhwEokvr376/o6GjNmDFDDodDDodDixYtcjkdtmjRIpUpU0Zr165VrVq1VLJkSfXs2VOXL1/W4sWLFR4eroCAAD3xxBNKSUlxtn316lU9/fTTqlSpkkqVKqUmTZpo8+bNBTNQADcNR4IAFEkzZszQkSNHVK9ePb300kuSpAMHDqSrd+XKFb355ptavny5Ll68qAceeEAPPPCAypQpo6ioKP3888968MEH1bJlS/Xu3VuS9Pe//10xMTFavny5QkJCtGrVKnXs2FH79u3TLbfckq/jBHDzEIIAFEn+/v7y9PRUyZIlnafAfvzxx3T1kpOTNXfuXFWvXl2S1LNnT73//vv69ddfVbp0adWtW1dt27bVpk2b1Lt3b/30009atmyZfvnlF4WEhEiSRo0apS+++EILFy7UxIkT82+QAG4qQhCAYq1kyZLOACRJQUFBCg8PV+nSpV3K4uPjJUk//PCDjDGqWbOmSztJSUkqW7Zs/nQaQL4gBAEo1jw8PFzeOxyODMtSU1MlSampqXJzc9OuXbvk5ubmUu/64ASg6CMEASiyPD09XS5ozgsNGjRQSkqK4uPj1apVqzxtG0Dhwt1hAIqs8PBwff/994qJidHZs2edR3P+ipo1a+qRRx5Rv3799Mknn+jYsWPasWOHJk+erKioqDzoNYDCghAEoMgaNWqU3NzcVLduXZUvX14nTpzIk3YXLlyofv366amnnlKtWrXUtWtXff/99woNDc2T9gEUDjwxGgAAWIkjQQAAwEqEIAAAYCVCEAAAsBIhCAAAWIkQBAAArEQIAgAAViIEAQAAKxGCAACAlQhBAADASoQgAABgJUIQAACwEiEIAABY6f8DCzn6K6nV4wQAAAAASUVORK5CYII=",
+      "text/plain": [
+       "<Figure size 640x480 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "transport_model.mesh.N2.isel(nface=217, time=slice(0, 5000)).plot()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 39,
+   "id": "426fa202",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[<matplotlib.lines.Line2D at 0x1c25cbd6e50>]"
+      ]
+     },
+     "execution_count": 39,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAkEAAAHFCAYAAAD1zS3+AAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjguNCwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8fJSN1AAAACXBIWXMAAA9hAAAPYQGoP6dpAAA4zUlEQVR4nO3deVhV5f7//9cWZFAEB5TBCRzAqY6KpphjJmplWmlofRzKTM/RzMxPaWqkpqZ5yrK0tD5qmkPnoNlRNDkJHksrMyjnY6ZBgJlaoJmgcP/+6Mv+tWMQDNjAej6ua19X+173uvf95t62X6y19sJmjDECAACwmCrOngAAAIAzEIIAAIAlEYIAAIAlEYIAAIAlEYIAAIAlEYIAAIAlEYIAAIAlEYIAAIAlEYIAAIAlEYJQLm3cuFGtW7eWp6enbDabEhMTnT2lcu/06dOy2Wz5PjZs2FCkMS5duqRJkyYpMDBQHh4eatu2bYH7fvnll7r99tvl5eWlmjVr6t5779W3336bp9+ZM2c0YcIENWnSRJ6enmrcuLFGjx6tpKSkP1XvjShqfaNGjcr359iiRYs/9fpLlixRs2bN5ObmJpvNpp9//vlPjWcVn3/+ufr27asaNWrIy8tLvXr10ieffJKnX3HXbcmSJWrRooXc3d0VHBysWbNm6erVq0Wa09WrVzVr1iwFBQXJ3d1dLVq00JIlS/5UnSh7rs6eAPBHP/74o4YPH65+/fpp6dKlcnd3V0hIiLOnVWE89thjeuCBBxzamjdvXqR97733Xu3fv18vvPCCQkJCtG7dOg0bNkw5OTkOYx47dkw9e/ZU27Zt9d577+nKlSt69tln1a1bNyUmJqpu3bqSpMzMTHXv3l0//fSTZs2apVatWun48eOKiorShx9+qKNHj6pGjRolV3wJ1SdJnp6e2rVrV562G5WYmKiJEyfqkUce0ciRI+Xq6lqmtVdU+/fvV/fu3XXLLbdozZo1MsZo4cKF6t27t+Li4hQeHu7Qv6jrNnfuXM2cOVNTp05VRESE9u/frxkzZiglJUXLly+/7rz+9re/ac2aNZozZ446duyoDz/8UI8//rguXryoZ5555s8VjbJjgHLm448/NpLMxo0bnT2VCuXUqVNGknnxxRdvaP9t27YZSWbdunUO7X369DGBgYHm2rVr9rYhQ4YYX19fk56ebm87ffq0qVq1qnnqqafsbbGxsUaSeeuttxzGXLdunZFkNm3adENz/aORI0eaHj16FNqnOPWNHDnSVK9evUTmlmvt2rVGkvnss89KdNzKrm/fvsbPz8/88ssv9raMjAzj6+trunTp4tC3qOt27tw54+HhYR599FGH9rlz5xqbzWYOHz5c6P6HDh0yNpvNzJs3z6F9zJgxxtPT05w/f/66c0D5wOkwlCujRo1S165dJUmRkZGy2Wzq2bOnJOmLL77Q0KFDFRQUJE9PTwUFBWnYsGH67rvv8oyTkpKiRx99VA0bNpSbm5sCAwM1ePBg/fDDD/Y+GRkZmjJlioKDg+Xm5qb69etr0qRJ+uWXX4o833Pnzqlhw4bq0qWLw2H0I0eOqHr16ho+fPgN/iTK3ubNm+Xl5aUhQ4Y4tD/00ENKTU3VZ599Jkm6du2atm7dqvvuu0/e3t72fo0bN1avXr20efNme1vVqlUlST4+Pg5j1qxZU5Lk4eHh0P7FF1/o7rvvVu3ateXh4aF27drpvffeK9P6SkPPnj31P//zP5KkTp06yWazadSoUZKk2NhYDRw4UA0aNJCHh4eaNWumsWPH6ty5c3nGOXbsmIYNGyY/Pz+5u7urUaNGGjFihDIzM+19zpw5o7Fjx6pBgwZyc3Ozn+a5du1akec7Z84cubq6Kjk5Oc+2hx9+WHXq1NGVK1eK+VO4MZ988ol69uypatWq2dtq1Kih7t27a+/evUpLSyv2mDt27NCVK1f00EMPObQ/9NBDMsbo/fffL3T/999/X8aYfPf/9ddftWPHjmLPCc5BCEK5MnPmTL3++uuSpHnz5mnfvn1aunSppN+ueQkNDdXixYv14YcfasGCBUpLS1PHjh0dPjBSUlLUsWNHbd68WZMnT9b27du1ePFi+fj46KeffpIkXb58WT169NDq1as1ceJEbd++XU8//bRWrVqlu+++W8aYIs3X19dXGzZs0P79+/X000/bxx4yZIgaNWqkN954o9D9jTG6du1akR5F9cILL8jNzU3VqlVT165d9cEHHxRpv0OHDqlly5ZydXU8S37zzTfbt0vSyZMn9euvv9rb/9j3m2++sX9A3nrrrQoLC9Nzzz2n/fv369KlS/ryyy/1zDPPqH379rr99tvt+8bFxenWW2/Vzz//rDfeeENbtmxR27ZtFRkZqVWrVhW5/j9bX65ff/1V/v7+cnFxUYMGDTRhwgRduHDhhl576dKlmjFjhiRp5cqV2rdvn2bOnCnpt59neHi4li1bpp07d+rZZ5/VZ599pq5duzoE66+++kodO3bUp59+qtmzZ2v79u2aP3++MjMzlZWVJem3AHTLLbfoww8/1LPPPqvt27dr9OjRmj9/vsaMGVPk+Y4dO1aurq568803HdovXLigDRs2aPTo0XkC7O+V5Ps6KytL7u7uedpz2w4ePOjQXpR1y13rm266yaE9ICBAvr6+ed4Lf3To0CHVrVtX/v7+Du0FvZdQjjn1OBSQj7i4OCPJ/OMf/yi037Vr18ylS5dM9erVzSuvvGJvf/jhh03VqlXNkSNHCtx3/vz5pkqVKmb//v0O7f/85z+NJBMTE1OsOS9YsMBIMps3bzYjR440np6e5uuvv77ufrm1FuVx6tSpQsdKTU01Y8aMMe+9957Zs2ePeffdd03nzp2NJLNixYrrzqV58+amb9+++Y4ryX7o/5NPPjGSzPr16/P0nTdvnpFkUlNT7W0ZGRlmwIABDrX07NkzzymDFi1amHbt2pmrV686tN91110mICDAZGdn29uuXr3q8BgxYoTp3r17nvacnJxi12eMMS+99JJ56aWXzM6dO83OnTvN9OnTTbVq1UyLFi3MxYsXr/ejzNfKlSuNpDzvud/LyckxV69eNd99952RZLZs2WLfdtttt5maNWuas2fPFrj/2LFjjZeXl/nuu+8c2hctWmQkXfc0z++NHDnS1KtXz2RmZtrbFixYYKpUqXLd92JurUV5XE/btm1NSEhInvVv0qRJntObRV23MWPGGHd393xfLyQkxERERBQ6pz59+pjQ0NB8t7m5ueU5zYbyiwujUWFcunRJc+bMUXR0tE6fPq3s7Gz7tqNHj9r/e/v27erVq5datmxZ4Fhbt25VmzZt1LZtW4ffRvv27Subzab4+Hj179+/yHP73//9X/3nP//RsGHDdOXKFb311lt5fsvMT1hYmPbv31+k1wgMDCx0e0BAQJ4LOocMGaJOnTpp6tSpGjVqVJ6jIH9ks9mKvK0ofa9evarIyEgdOnRIK1asUGhoqE6dOqXnn39effr00a5du+Tj46NvvvlGx44d06JFiyTJYU3uuOMObd26VcePH1fLli11+vRpBQcH5/u6uaffcsXFxdlPpxanvieeeMJhW58+fdSuXTsNHjxYK1asyLP9zzh79qyeffZZbdu2TampqcrJybFvO3r0qO6++25dvnxZu3fv1ujRo+0Xnedn69at6tWrlwIDAx1+hv3799eUKVO0e/dutWrVqkjzevzxx7V69Wr94x//0IMPPqicnBwtW7ZMd955p4KCggrdd8CAAUV+X1/PY489ptGjR2vChAmaPn26cnJyNGvWLPtp8CpV/v8TGsVZt+K814vbpyj7o3wgBKHCeOCBB/TRRx9p5syZ6tixo7y9vWWz2XTHHXfo119/tff78ccf1aBBg0LH+uGHH/TNN9/k+dDMld/1GIXJvcZj27Zt8vf3L/K1QF5eXmrbtm2R+l4vwOSnatWqioyM1NSpU3XixIlCg2GdOnV0/vz5PO25pxJq165t7yepwL42m81+zc/bb7+t7du3a//+/erQoYMkqVu3buratauaNm2qxYsXKyoqyn6t1pQpUzRlypR855e7JoGBgXk+YGfNmqXU1NQ8p29CQ0OLXV9B7rnnHlWvXl2ffvppof2KIycnRxEREUpNTdXMmTN10003qXr16srJyVHnzp3t7+uffvpJ2dnZRXpf/+tf/yqR93W7du3UrVs3vf7663rwwQe1detWnT59Os/POD+1a9fOcx3YjXr44Yf1448/6vnnn9eyZcskSeHh4ZoyZYoWLFig+vXrF7p/fuuWe03T5cuXHa41kn57P4SFhRU6Zp06dfK9bccvv/yirKys676XUH4QglAhpKena+vWrYqKitLUqVPt7ZmZmXnO99etW1fff/99oeP5+vrK09NT//d//1fg9uJIS0vT+PHj1bZtWx0+fFhTpkzRq6++et39du/erV69ehXpNU6dOnXd38DzY/7f9U2//405PzfddJPWr1+va9euOQSu3Gsu2rRpI0lq2rSpPD0981yLkdu3WbNm9utFEhMT5eLiovbt2zv0a9KkierUqWO/diL35z1t2jTde++9+c4vN9C4ubnZA1WuOnXq6OLFi3nab6S+whhjrvtzLI5Dhw7pq6++0qpVqzRy5Eh7+zfffOPQr3bt2nJxcSnS+/rmm2/W3Llz891+vaOJfzRx4kQNGTJEX375pV577TWFhISoT58+191v9erVeS4aLogpwvV3Tz/9tCZNmqQTJ06oRo0aaty4scaOHavq1atfN7Dkvsbv1y33KO3BgwfVqVMne/uZM2d07ty5674XbrrpJm3YsEFnzpxxuC6oOO8llA+EIFQINptNxpg8F0i+9dZbDqfFpN8O/a9Zs0bHjx93OBLwe3fddZfmzZunOnXqFHhqpaiys7M1bNgw2Ww2bd++Xe+++66mTJminj17FviBnqskT4fl5+rVq9q4caN8fX3VrFmzQvvec889WrFihaKjoxUZGWlvX716tQIDA+0fFq6urhowYIA2bdqkhQsX2u91k5SUpLi4OIdTDoGBgcrOztb+/fsdPmz++9//6vz58/YjG6GhoWrevLm++uorzZs3r9h1FkVR6yvIP//5T12+fFmdO3cusTnlnjb54/v6j0dbPD091aNHD/3jH//Q3LlzCwzpd911l2JiYtS0aVPVqlXrT8/vnnvuUaNGjfTkk09q9+7devnll4t0qqckT4flcnd3t4eLpKQkbdy4UWPGjLnuvZvyW7d+/frJw8NDq1atclj3VatWyWazadCgQYWOOXDgQM2YMUOrV6+2fyEid39PT0/169fvBiqEUzj1iiQgHwVdGN29e3dTu3Zts2LFChMbG2tmzJhhAgICTM2aNc3IkSPt/b7//nsTEBBg6tWrZxYvXmw++ugjEx0dbcaMGWOOHj1qjDHm0qVLpl27dqZBgwbm73//u4mNjTUffvihWbFihRkyZIj59NNPizzf6dOnmypVqph///vf9rYBAwaYmjVrmm+//fbP/TCK4YknnjATJkww69evN3Fxceadd94xHTt2NJLMypUrHfrOmjXLuLi4mPj4eIf2Pn36mFq1apnly5ebXbt2mTFjxhhJZu3atQ79jh49ary8vEz37t1NTEyM2bRpk2nTpo0JDAx0uHA3KSnJ1KxZ09SvX98sW7bM7Nq1y7z11lumSZMmpnr16ubYsWP2vrt27TLu7u4mIiLCrFu3zuzevdts3rzZzJs3zwwePLjQ2otyn6Ci1nf69GnTpUsX8+qrr5qYmBizfft2M3XqVOPh4WFat25tLl265DBmjx49inSBb34XRmdlZZmmTZuaxo0bm3Xr1pkdO3aY8ePHm5CQECPJREVF2fsmJiYaLy8v06RJE/v8169fb4YNG2YyMjKMMb9d5N24cWPTokULs3TpUvPRRx+Zbdu2mddff93ceeedJjk5+brz/KPci/6rV69ufv7552Lv/2cdPHjQPPfcc2br1q0mNjbWLFq0yPj6+poOHTo4XOxc3HV7/vnnjc1mM88884yJj483L774onF3dzdjxoxx6Ld69Wrj4uJiVq9e7dD+yCOPGHd3d/Piiy+a+Ph488wzzxibzWbmzp1bej8MlDhCEMqdgkLQ999/b+677z5Tq1YtU6NGDdOvXz9z6NAh07hxY4cQZIwxycnJ5uGHHzb+/v6matWqJjAw0Nx///3mhx9+sPe5dOmSmTFjhgkNDTVubm7Gx8fH3HTTTeaJJ54wZ86cKdJcd+7caapUqeLwYWWMMefPnzeNGjUyHTt2dPh2TWl6++23zS233GJq165tXF1dTa1atUzfvn3Nhx9+mKdvVFSUkWTi4uIc2i9evGgmTpxo/P39jZubm7n55pvz/RaYMcZ88cUXpnfv3qZatWrG29vbDBo0yHzzzTd5+p04ccIMHz7cBAUFGXd3d9OoUSMTGRmZ7zeVvvrqK3P//febevXqmapVqxp/f39z2223mTfeeKPQ2osagopS34ULF8w999xjgoKCjKenp3FzczPNmzc3Tz31VL4hICwszPj7+1/3tQv6dtiRI0dMnz59TI0aNUytWrXMkCFDTFJSUp4QlNt3yJAhpk6dOsbNzc00atTIjBo1yly5csXe58cffzQTJ040wcHBpmrVqqZ27domLCzMTJ8+PU8QKIrTp08bSWbcuHHF3rckHD9+3P4LkJubm2nWrJmZMWNGnlqKu27GGPPKK6+YkJAQ+88yKirKZGVlOfTJXbc//iKRlZVloqKiTKNGjYybm5sJCQkxr776aonWjtJnM6aIN0QBADi4ePGiateurcWLF2v8+PHOnk6pWLJkiSZOnKhDhw6pdevWzp4OUKK4JggAbtB//vMf1a9fv1g3IqwoEhISdOrUKc2ePVsDBw4kAKFS4kgQUICcnByHe7bk50a+tg44U3Z2dqHfyLLZbHJxcVFQUJDOnDmjbt26ac2aNXnujgxUBoQgoACjRo3S6tWrC+3DPx9UND179tTu3bsL3N64cWOdPn267CYEOBEhCCjA6dOnr3tzucLuSwOUR8ePH9fFixcL3O7u7l6ku50DlQEhCAAAWBJ/RR4AAFgSV3XmIycnR6mpqapRowZ/CA8AgArCGKOLFy8qMDCwSH/ihhCUj9TUVDVs2NDZ0wAAADcgOTn5un9wWCIE5Sv3byElJyfL29vbybMBAABFkZGRoYYNG9o/x6+HEJSP3FNg3t7ehCAAACqYol7KwoXRAADAkghBAADAkghBAADAkghBAADAkghBAADAkghBAADAkghBAADAkghBAADAkghBAADAkghBAADAkghBAADAkghBAADAkghBAADAkghBAADAkghBAADAkghBAADAkghBAADAkghBAADAkghBAADAkghBAADAkghBAADAkghBAADAkghBAADAkghBAADAkghBAADAkghBAADAkghBAADAkghBAADAkghBAADAkghBAADAkghBAADAkghBAADAkghBAADAkghBAADAkghBAADAkghBAADAkghBAADAkghBAADAkghBAADAkghBAADAkghBAADAkghBAADAkghBAADAkpwegpYuXarg4GB5eHgoLCxMe/bsKbBvfHy8bDZbnsexY8fsfVasWKFu3bqpVq1aqlWrlm6//XZ9/vnnZVEKAACoQJwagjZu3KhJkyZp+vTpSkhIULdu3dS/f38lJSUVut/x48eVlpZmfzRv3ty+LT4+XsOGDVNcXJz27dunRo0aKSIiQikpKaVdDgAAqEBsxhjjrBfv1KmT2rdvr2XLltnbWrZsqUGDBmn+/Pl5+sfHx6tXr1766aefVLNmzSK9RnZ2tmrVqqXXXntNI0aMKNI+GRkZ8vHxUXp6ury9vYu0DwAAcK7ifn477UhQVlaWDhw4oIiICIf2iIgI7d27t9B927Vrp4CAAPXu3VtxcXGF9r18+bKuXr2q2rVr/+k5AwCAysPVWS987tw5ZWdny8/Pz6Hdz89PZ86cyXefgIAALV++XGFhYcrMzNSaNWvUu3dvxcfHq3v37vnuM3XqVNWvX1+33357gXPJzMxUZmam/XlGRsYNVAQAACoSp4WgXDabzeG5MSZPW67Q0FCFhoban4eHhys5OVmLFi3KNwQtXLhQ69evV3x8vDw8PAqcw/z58zVr1qwbrAAAAFRETjsd5uvrKxcXlzxHfc6ePZvn6FBhOnfurBMnTuRpX7RokebNm6edO3fq5ptvLnSMadOmKT093f5ITk4u8usDAICKyWkhyM3NTWFhYYqNjXVoj42NVZcuXYo8TkJCggICAhzaXnzxRc2ZM0c7duxQhw4drjuGu7u7vL29HR4AAKByc+rpsMmTJ2v48OHq0KGDwsPDtXz5ciUlJWncuHGSfjtCk5KSonfeeUeStHjxYgUFBal169bKysrS2rVrFR0drejoaPuYCxcu1MyZM7Vu3ToFBQXZjzR5eXnJy8ur7IsEAADlklNDUGRkpM6fP6/Zs2crLS1Nbdq0UUxMjBo3bixJSktLc7hnUFZWlqZMmaKUlBR5enqqdevW2rZtm+644w57n6VLlyorK0uDBw92eK2oqCg999xzZVIXAAAo/5x6n6DyivsEAQBQ8VSY+wQBAAA4EyEIAABYEiEIAABYEiEIAABYEiEIAABYEiEIAABYEiEIAABYEiEIAABYEiEIAABYEiEIAABYEiEIAABYEiEIAABYEiEIAABYEiEIAABYEiEIAABYEiEIAABYEiEIAABYEiEIAABYEiEIAABYEiEIAABYEiEIAABYEiEIAABYEiEIAABYEiEIAABYEiEIAABYEiEIAABYEiEIAABYEiEIAABYEiEIAABYEiEIAABYEiEIAABYEiEIAABYEiEIAABYEiEIAABYEiEIAABYEiEIAABYEiEIAABYEiEIAABYEiEIAABYEiEIAABYEiEIAABYEiEIAABYEiEIAABYEiEIAABYEiEIAABYEiEIAABYEiEIAABYEiEIAABYEiEIAABYEiEIAABYEiEIAABYEiEIAABYEiEIAABYEiEIAABYEiEIAABYEiEIAABYktND0NKlSxUcHCwPDw+FhYVpz549BfaNj4+XzWbL8zh27Ji9z+HDh3XfffcpKChINptNixcvLoMqAABARePUELRx40ZNmjRJ06dPV0JCgrp166b+/fsrKSmp0P2OHz+utLQ0+6N58+b2bZcvX1aTJk30wgsvyN/fv7RLAAAAFZRTQ9BLL72k0aNH65FHHlHLli21ePFiNWzYUMuWLSt0v3r16snf39/+cHFxsW/r2LGjXnzxRQ0dOlTu7u6lXQIAAKignBaCsrKydODAAUVERDi0R0REaO/evYXu265dOwUEBKh3796Ki4srzWkCAIBKytVZL3zu3DllZ2fLz8/Pod3Pz09nzpzJd5+AgAAtX75cYWFhyszM1Jo1a9S7d2/Fx8ere/fuNzyXzMxMZWZm2p9nZGTc8FgAAKBicFoIymWz2RyeG2PytOUKDQ1VaGio/Xl4eLiSk5O1aNGiPxWC5s+fr1mzZt3w/gAAoOJx2ukwX19fubi45Dnqc/bs2TxHhwrTuXNnnThx4k/NZdq0aUpPT7c/kpOT/9R4AACg/HNaCHJzc1NYWJhiY2Md2mNjY9WlS5cij5OQkKCAgIA/NRd3d3d5e3s7PAAAQOXm1NNhkydP1vDhw9WhQweFh4dr+fLlSkpK0rhx4yT9doQmJSVF77zzjiRp8eLFCgoKUuvWrZWVlaW1a9cqOjpa0dHR9jGzsrJ05MgR+3+npKQoMTFRXl5eatasWdkXCQAAyiWnhqDIyEidP39es2fPVlpamtq0aaOYmBg1btxYkpSWluZwz6CsrCxNmTJFKSkp8vT0VOvWrbVt2zbdcccd9j6pqalq166d/fmiRYu0aNEi9ejRQ/Hx8WVWGwAAKN9sxhjj7EmUNxkZGfLx8VF6ejqnxgAAqCCK+/nt9D+bAQAA4AyEIAAAYEmEIAAAYEmEIAAAYEmEIAAAYEmEIAAAYEmEIAAAYEmEIAAAYEmEIAAAYEmEIAAAYEmEIAAAYEmEIAAAYEmEIAAAYEmEIAAAYEmEIAAAYEmEIAAAYEmEIAAAYEmEIAAAYEmEIAAAYEmEIAAAYEmEIAAAYEmEIAAAYEmEIAAAYEmEIAAAYEmEIAAAYEmEIAAAYEmEIAAAYEmEIAAAYEmEIAAAYEmEIAAAYEmEIAAAYEmEIAAAYEmEIAAAYEmEIAAAYEmEIAAAYEmEIAAAYEmEIAAAYEmEIAAAYEmEIAAAYEmEIAAAYEmEIAAAYEmEIAAAYEmEIAAAYEmEIAAAYEmEIAAAYEmEIAAAYEmEIAAAYEmEIAAAYEmEIAAAYEmEIAAAYEnFDkFvvfWWRo4cqZUrV0qSNm7cqJYtW6pJkyaKiooq8QkCAACUBtfidF68eLFmzJihvn37avr06UpNTdXLL7+sJ554Qjk5Ofr73/+u+vXr69FHHy2t+QIAAJSIYoWgN998U8uXL9cDDzyghIQE3XLLLXrjjTc0evRoSVKDBg30+uuvE4IAAEC5V6zTYd999526du0qSWrXrp1cXFzUuXNn+/Zu3brp5MmTJTtDAACAUlCsEFStWjX98ssv9ud169aVl5eXQ59r166VzMwAAABKUbFCUIsWLfT111/bnycnJ6tx48b258eOHVNQUFCJTQ4AAKC0FOuaoAULFqh69eoFbk9KStLYsWP/9KQAAABKW7GOBN16661q27Ztgdv/9re/acKECcWawNKlSxUcHCwPDw+FhYVpz549BfaNj4+XzWbL8zh27JhDv+joaLVq1Uru7u5q1aqVNm/eXKw5AQCAyq9YR4Jy/frrr4qNjdV///tf2Ww2NW/eXH369JGnp2exxtm4caMmTZqkpUuX6tZbb9Wbb76p/v3768iRI2rUqFGB+x0/flze3t7253Xr1rX/9759+xQZGak5c+bonnvu0ebNm3X//ffr448/VqdOnYpfLAAAqJRsxhhTnB0++OADPfLIIzp37pxDu6+vr95++20NGDCgyGN16tRJ7du317Jly+xtLVu21KBBgzR//vw8/ePj49WrVy/99NNPqlmzZr5jRkZGKiMjQ9u3b7e39evXT7Vq1dL69euLNK+MjAz5+PgoPT3dIWwBAIDyq7if38U6HbZ3714NHjxY3bt31yeffKILFy7owoUL+vjjj9WtWzcNHjxY+/btK9JYWVlZOnDggCIiIhzaIyIitHfv3kL3bdeunQICAtS7d2/FxcU5bNu3b1+eMfv27VvomJmZmcrIyHB4AACAyq1YIej555/XQw89pH/+858KDw9XzZo1VbNmTXXp0kXR0dEaNWqU5syZU6Sxzp07p+zsbPn5+Tm0+/n56cyZM/nuExAQoOXLlys6OlqbNm1SaGioevfurf/85z/2PmfOnCnWmJI0f/58+fj42B8NGzYsUg0AAKDiKtY1Qfv27dOCBQsK3D5+/Hj16NGjWBOw2WwOz40xedpyhYaGKjQ01P48PDxcycnJWrRokbp3735DY0rStGnTNHnyZPvzjIwMghAAAJVcsY4EXblypdBzbD4+PsrMzCzSWL6+vnJxcclzhObs2bN5juQUpnPnzjpx4oT9ub+/f7HHdHd3l7e3t8MDAABUbsUKQSEhIdq1a1eB2z/66CM1a9asSGO5ubkpLCxMsbGxDu2xsbHq0qVLkeeUkJCggIAA+/Pw8PA8Y+7cubNYYwIAgMqvWKfDRo0apSlTpsjPz0933HGHw7Zt27bpqaee0vTp04s83uTJkzV8+HB16NBB4eHhWr58uZKSkjRu3DhJv52mSklJ0TvvvCPpt79iHxQUpNatWysrK0tr165VdHS0oqOj7WM+/vjj6t69uxYsWKCBAwdqy5Yt+ve//62PP/64OKUCAIBKrlgh6PHHH9fevXt11113KTQ0VC1btpQkHTlyRCdOnNCgQYP0+OOPF3m8yMhInT9/XrNnz1ZaWpratGmjmJgY+5/iSEtLU1JSkr1/VlaWpkyZopSUFHl6eqp169batm2bQyDr0qWLNmzYoBkzZmjmzJlq2rSpNm7cyD2CAACAg2LfJ0j67SaH69ats1+LExISoqFDh2ro0KElPkFn4D5BAABUPMX9/L6hEFTZEYIAAKh4ivv5XazTYVWqVCn0q+bSb19Pv3btWnGGBQAAKHPFCkGF/SHSvXv3asmSJeLAEgAAqAiKFYIGDhyYp+3YsWOaNm2a/vWvf+nBBx8s8h2jAQAAnKlY9wn6vdTUVI0ZM0Y333yzrl27psTERK1evbrQv/4OAABQXhQ7BKWnp+vpp59Ws2bNdPjwYX300Uf617/+pTZt2pTG/AAAAEpFsU6HLVy4UAsWLJC/v7/Wr1+f7+kxAACAiqBYX5GvUqWKPD09dfvtt8vFxaXAfps2bSqRyTkLX5EHAKDiKdWvyI8YMeK6X5EHAACoCIoVglatWlVK0wAAAChbN/ztMAAAgIqMEAQAACyJEAQAACyJEAQAACyJEAQAACyJEAQAACyJEAQAACyJEAQAACyJEAQAACyJEAQAACyJEAQAACyJEAQAACyJEAQAACyJEAQAACyJEAQAACyJEAQAACyJEAQAACyJEAQAACyJEAQAACyJEAQAACyJEAQAACyJEAQAACyJEAQAACyJEAQAACyJEAQAACyJEAQAACyJEAQAACyJEAQAACyJEAQAACyJEAQAACyJEAQAACyJEAQAACyJEAQAACyJEAQAACyJEAQAACyJEAQAACyJEAQAACyJEAQAACyJEAQAACyJEAQAACyJEAQAACyJEAQAACyJEAQAACyJEAQAACyJEAQAACyJEAQAACzJ6SFo6dKlCg4OloeHh8LCwrRnz54i7ffJJ5/I1dVVbdu2dWi/evWqZs+eraZNm8rDw0N/+ctftGPHjlKYOQAAqMicGoI2btyoSZMmafr06UpISFC3bt3Uv39/JSUlFbpfenq6RowYod69e+fZNmPGDL355ptasmSJjhw5onHjxumee+5RQkJCaZUBAAAqIJsxxjjrxTt16qT27dtr2bJl9raWLVtq0KBBmj9/foH7DR06VM2bN5eLi4vef/99JSYm2rcFBgZq+vTpGj9+vL1t0KBB8vLy0tq1a4s0r4yMDPn4+Cg9PV3e3t7FLwwAAJS54n5+O+1IUFZWlg4cOKCIiAiH9oiICO3du7fA/VauXKmTJ08qKioq3+2ZmZny8PBwaPP09NTHH39c4JiZmZnKyMhweAAAgMrNaSHo3Llzys7Olp+fn0O7n5+fzpw5k+8+J06c0NSpU/Xuu+/K1dU13z59+/bVSy+9pBMnTignJ0exsbHasmWL0tLSCpzL/Pnz5ePjY380bNjwxgsDAAAVgtMvjLbZbA7PjTF52iQpOztbDzzwgGbNmqWQkJACx3vllVfUvHlztWjRQm5ubpowYYIeeughubi4FLjPtGnTlJ6ebn8kJyffeEEAAKBCyP9wShnw9fWVi4tLnqM+Z8+ezXN0SJIuXryoL774QgkJCZowYYIkKScnR8YYubq6aufOnbrttttUt25dvf/++7py5YrOnz+vwMBATZ06VcHBwQXOxd3dXe7u7iVbIAAAKNecdiTIzc1NYWFhio2NdWiPjY1Vly5d8vT39vbWwYMHlZiYaH+MGzdOoaGhSkxMVKdOnRz6e3h4qH79+rp27Zqio6M1cODAUq0HAABULE47EiRJkydP1vDhw9WhQweFh4dr+fLlSkpK0rhx4yT9dpoqJSVF77zzjqpUqaI2bdo47F+vXj15eHg4tH/22WdKSUlR27ZtlZKSoueee045OTl66qmnyrQ2AABQvjk1BEVGRur8+fOaPXu20tLS1KZNG8XExKhx48aSpLS0tOveM+iPrly5ohkzZujbb7+Vl5eX7rjjDq1Zs0Y1a9YshQoAAEBF5dT7BJVX3CcIAICKp8LcJwgAAMCZCEEAAMCSCEEAAMCSCEEAAMCSCEEAAMCSCEEAAMCSCEEAAMCSCEEAAMCSCEEAAMCSCEEAAMCSCEEAAMCSCEEAAMCSCEEAAMCSCEEAAMCSCEEAAMCSCEEAAMCSCEEAAMCSCEEAAMCSCEEAAMCSCEEAAMCSCEEAAMCSCEEAAMCSCEEAAMCSCEEAAMCSCEEAAMCSCEEAAMCSCEEAAMCSCEEAAMCSCEEAAMCSCEEAAMCSCEEAAMCSCEEAAMCSCEEAAMCSCEEAAMCSCEEAAMCSCEEAAMCSCEEAAMCSCEEAAMCSCEEAAMCSCEEAAMCSCEEAAMCSCEEAAMCSCEEAAMCSCEEAAMCSCEEAAMCSCEEAAMCSCEEAAMCSCEEAAMCSCEEAAMCSCEEAAMCSCEEAAMCSCEEAAMCSCEEAAMCSCEEAAMCSCEEAAMCSCEEAAMCSnB6Cli5dquDgYHl4eCgsLEx79uwp0n6ffPKJXF1d1bZt2zzbFi9erNDQUHl6eqphw4Z64okndOXKlRKeOQAAqMicGoI2btyoSZMmafr06UpISFC3bt3Uv39/JSUlFbpfenq6RowYod69e+fZ9u6772rq1KmKiorS0aNH9fbbb2vjxo2aNm1aaZUBAAAqIJsxxjjrxTt16qT27dtr2bJl9raWLVtq0KBBmj9/foH7DR06VM2bN5eLi4vef/99JSYm2rdNmDBBR48e1UcffWRve/LJJ/X5558X+ShTRkaGfHx8lJ6eLm9v7+IXBgAAylxxP7+ddiQoKytLBw4cUEREhEN7RESE9u7dW+B+K1eu1MmTJxUVFZXv9q5du+rAgQP6/PPPJUnffvutYmJidOeddxY4ZmZmpjIyMhweAACgcnN11gufO3dO2dnZ8vPzc2j38/PTmTNn8t3nxIkTmjp1qvbs2SNX1/ynPnToUP3444/q2rWrjDG6du2a/vrXv2rq1KkFzmX+/PmaNWvWjRcDAAAqHKdfGG2z2RyeG2PytElSdna2HnjgAc2aNUshISEFjhcfH6+5c+dq6dKl+vLLL7Vp0yZt3bpVc+bMKXCfadOmKT093f5ITk6+8YIAAECF4LQjQb6+vnJxcclz1Ofs2bN5jg5J0sWLF/XFF18oISFBEyZMkCTl5OTIGCNXV1ft3LlTt912m2bOnKnhw4frkUcekSTddNNN+uWXX/Too49q+vTpqlIlb+5zd3eXu7t7KVQJAADKK6cdCXJzc1NYWJhiY2Md2mNjY9WlS5c8/b29vXXw4EElJibaH+PGjVNoaKgSExPVqVMnSdLly5fzBB0XFxcZY+TEa8ABAEA547QjQZI0efJkDR8+XB06dFB4eLiWL1+upKQkjRs3TtJvp6lSUlL0zjvvqEqVKmrTpo3D/vXq1ZOHh4dD+4ABA/TSSy+pXbt26tSpk7755hvNnDlTd999t1xcXMq0PgAAUH45NQRFRkbq/Pnzmj17ttLS0tSmTRvFxMSocePGkqS0tLTr3jPoj2bMmCGbzaYZM2YoJSVFdevW1YABAzR37tzSKAEAAFRQTr1PUHnFfYIAAKh4Ksx9ggAAAJyJEAQAACyJEAQAACyJEAQAACyJEAQAACyJEAQAACyJEAQAACyJEAQAACyJEAQAACyJEAQAACyJEAQAACyJEAQAACyJEAQAACyJEAQAACyJEAQAACyJEAQAACyJEAQAACyJEAQAACyJEAQAACyJEAQAACyJEAQAACyJEAQAACyJEAQAACyJEAQAACyJEAQAACyJEAQAACyJEAQAACyJEAQAACyJEAQAACyJEAQAACyJEAQAACyJEAQAACyJEAQAACyJEAQAACyJEAQAACyJEAQAACyJEAQAACyJEAQAACyJEAQAACyJEAQAACyJEAQAACyJEAQAACyJEAQAACzJ1dkTKI+MMZKkjIwMJ88EAAAUVe7ndu7n+PUQgvJx8eJFSVLDhg2dPBMAAFBcFy9elI+Pz3X72UxR45KF5OTkKDU1VTVq1JDNZnP2dOwyMjLUsGFDJScny9vb29nTKRWVvcbKXp9UuWuszLXlquw1Vvb6pMpfY2H1GWN08eJFBQYGqkqV61/xw5GgfFSpUkUNGjRw9jQK5O3tXSnf2L9X2Wus7PVJlbvGylxbrspeY2WvT6r8NRZUX1GOAOXiwmgAAGBJhCAAAGBJhKAKxN3dXVFRUXJ3d3f2VEpNZa+xstcnVe4aK3NtuSp7jZW9Pqny11iS9XFhNAAAsCSOBAEAAEsiBAEAAEsiBAEAAEsiBFUCNptN77//vrOngT+BNazYWL+KjzWs+G5kDQlB5dCoUaM0aNAgZ0/jhsyfP18dO3ZUjRo1VK9ePQ0aNEjHjx936GOM0XPPPafAwEB5enqqZ8+eOnz4sH37hQsX9Nhjjyk0NFTVqlVTo0aNNHHiRKWnpzuMM3fuXHXp0kXVqlVTzZo1y6K8ImMNr7+Gp0+f1ujRoxUcHCxPT081bdpUUVFRysrKKrNaC8L6Fe3f4N13361GjRrJw8NDAQEBGj58uFJTU8ukzuthDYu2hrkyMzPVtm1b2Ww2JSYmlmZ5RVYWa0gIQonavXu3xo8fr08//VSxsbG6du2aIiIi9Msvv9j7LFy4UC+99JJee+017d+/X/7+/urTp4/9b7alpqYqNTVVixYt0sGDB7Vq1Srt2LFDo0ePdnitrKwsDRkyRH/961/LtMbKrqzW8NixY8rJydGbb76pw4cP6+WXX9Ybb7yhZ555psxrrkzK8t9gr1699N577+n48eOKjo7WyZMnNXjw4DKttzIqyzXM9dRTTykwMLBM6itXDMqdkSNHmoEDBxpjjGncuLF5+eWXHbb/5S9/MVFRUfbnkszmzZvLbH7FcfbsWSPJ7N692xhjTE5OjvH39zcvvPCCvc+VK1eMj4+PeeONNwoc57333jNubm7m6tWrebatXLnS+Pj4lPjc/wzWMK/C1jDXwoULTXBwcMlN/gaxfnkVZf22bNlibDabycrKKrkCbhBrmFdBaxgTE2NatGhhDh8+bCSZhISEUqmjuMpiDTkShFKVe+i1du3akqRTp07pzJkzioiIsPdxd3dXjx49tHfv3kLH8fb2lqsrf+6urJXlGqanp9tfByWjrNbvwoULevfdd9WlSxdVrVq1BCtAaa7hDz/8oDFjxmjNmjWqVq1aKVVQfhGCUGqMMZo8ebK6du2qNm3aSJLOnDkjSfLz83Po6+fnZ9/2R+fPn9ecOXM0duzY0p0w8ijLNTx58qSWLFmicePGldDsURbr9/TTT6t69eqqU6eOkpKStGXLlhKuwtpKcw2NMRo1apTGjRunDh06lFIF5RshCKVmwoQJ+vrrr7V+/fo822w2m8NzY0yeNknKyMjQnXfeqVatWikqKqrU5or8ldUapqamql+/fhoyZIgeeeSRkpk8ymT9/vd//1cJCQnauXOnXFxcNGLECBn+EEGJKc01XLJkiTIyMjRt2rSSn3gFQQgq56pUqZLnfyhXr1510myK7rHHHtMHH3yguLg4NWjQwN7u7+8vSXl+Wzl79mye32ouXryofv36ycvLS5s3b66wh9hZw8LXMDU1Vb169VJ4eLiWL19eCpX8Oaxf4evn6+urkJAQ9enTRxs2bFBMTIw+/fTTUqjoxrGG+a/hrl279Omnn8rd3V2urq5q1qyZJKlDhw4aOXJkaZV1Q0prDQlB5VzdunWVlpZmf56RkaFTp045cUaFM8ZowoQJ2rRpk3bt2qXg4GCH7cHBwfL391dsbKy9LSsrS7t371aXLl3sbRkZGYqIiJCbm5s++OADeXh4lFkNJY01LHgNU1JS1LNnT7Vv314rV65UlSrl739JrF/R/w3mfkhlZmaWUDUlgzXMfw1fffVVffXVV0pMTFRiYqJiYmIkSRs3btTcuXNLscLiK6015CrTcu62227TqlWrNGDAANWqVUszZ86Ui4uLs6dVoPHjx2vdunXasmWLatSoYf9NxcfHR56enrLZbJo0aZLmzZun5s2bq3nz5po3b56qVaumBx54QNJvv7lERETo8uXLWrt2rTIyMpSRkSHpt38IufUnJSXpwoULSkpKUnZ2tv3eFs2aNZOXl1fZF18A1jD/NUxNTVXPnj3VqFEjLVq0SD/++KN9Drm/6ZYHrF/+6/f555/r888/V9euXVWrVi19++23evbZZ9W0aVOFh4c7rf78sIb5r2GjRo0cXjf3/5tNmzZ1OPJUHpTaGhbru2QoE8OHDzf33XefMcaY9PR0c//99xtvb2/TsGFDs2rVqnL91U5J+T5Wrlxp75OTk2OioqKMv7+/cXd3N927dzcHDx60b4+LiytwnFOnTtn7jRw5Mt8+cXFxZVdwAVjD66/hypUrC+zjbKzf9dfv66+/Nr169TK1a9c27u7uJigoyIwbN858//33ZVxx/ljDov1/9PdOnTpVrr4iXxZraPt/O6Ic6devn5o1a6bXXnvN2VPBDWINKzbWr+JjDSu+sljD8ncC3sJ++uknbdu2TfHx8br99tudPR3cANawYmP9Kj7WsOIryzXkmqBy5OGHH9b+/fv15JNPauDAgc6eDm4Aa1ixsX4VH2tY8ZXlGnI6DAAAWBKnwwAAgCURggAAgCURggAAgCURggAAgCURggBUGvHx8bLZbPr555+dPRUAFQDfDgNQYfXs2VNt27bV4sWLJf3295MuXLggPz+/fP+aNgD8HvcJAlBpuLm5lau/OwagfON0GIAKadSoUdq9e7deeeUV2Ww22Ww2rVq1yuF02KpVq1SzZk1t3bpVoaGhqlatmgYPHqxffvlFq1evVlBQkGrVqqXHHntM2dnZ9rGzsrL01FNPqX79+qpevbo6deqk+Ph45xQKoNRwJAhAhfTKK6/ov//9r9q0aaPZs2dLkg4fPpyn3+XLl/Xqq69qw4YNunjxou69917de++9qlmzpmJiYvTtt9/qvvvuU9euXRUZGSlJeuihh3T69Glt2LBBgYGB2rx5s/r166eDBw+qefPmZVongNJDCAJQIfn4+MjNzU3VqlWznwI7duxYnn5Xr17VsmXL1LRpU0nS4MGDtWbNGv3www/y8vJSq1at1KtXL8XFxSkyMlInT57U+vXr9f333yswMFCSNGXKFO3YsUMrV67UvHnzyq5IAKWKEASgUqtWrZo9AEmSn5+fgoKC5OXl5dB29uxZSdKXX34pY4xCQkIcxsnMzFSdOnXKZtIAygQhCEClVrVqVYfnNpst37acnBxJUk5OjlxcXHTgwAG5uLg49Pt9cAJQ8RGCAFRYbm5uDhc0l4R27dopOztbZ8+eVbdu3Up0bADlC98OA1BhBQUF6bPPPtPp06d17tw5+9GcPyMkJEQPPvigRowYoU2bNunUqVPav3+/FixYoJiYmBKYNYDyghAEoMKaMmWKXFxc1KpVK9WtW1dJSUklMu7KlSs1YsQIPfnkkwoNDdXdd9+tzz77TA0bNiyR8QGUD9wxGgAAWBJHggAAgCURggAAgCURggAAgCURggAAgCURggAAgCURggAAgCURggAAgCURggAAgCURggAAgCURggAAgCURggAAgCURggAAgCX9f6chxVSIwITjAAAAAElFTkSuQmCC",
+      "text/plain": [
+       "<Figure size 640x480 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "transport_model.mesh.NO3.isel(nface=151, time=slice(0, 5000)).plot()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 40,
+   "id": "92609341",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[<matplotlib.lines.Line2D at 0x1c25cc70a10>]"
+      ]
+     },
+     "execution_count": 40,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAlMAAAHFCAYAAADWlnwrAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjguNCwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8fJSN1AAAACXBIWXMAAA9hAAAPYQGoP6dpAAA9E0lEQVR4nO3deVyVZf7/8fcROAdUQMUCcWFxQc1KRTMccWkSl0otM6b6krY4+pvKQcdyy6wsl8Ypcx/Lr5pNao2ajmlKpYyTaGhqbtmGYSIZLYBZrNfvj36c35xAPHgDR/D1fDzOo851f+77vq5zHTxv7vs+NzZjjBEAAAAuSR1PdwAAAKAmI0wBAABYQJgCAACwgDAFAABgAWEKAADAAsIUAACABYQpAAAACwhTAAAAFhCmAAAALCBMoVZbu3atrrnmGvn5+clms+ngwYOe7tJl7+TJk7LZbGU+1qxZ49Y2zp07p8TERIWGhsrX11cdO3a84LofffSRbr75ZtWvX18NGjTQHXfcoS+//LJUXWZmph555BFFRkbKz89PYWFhevDBB5Wenm5pvJfC3fGNGDGizNexbdu2lvY/f/58tWrVSna7XTabTT/++KOl7V0pPvzwQ/Xr10/+/v6qX7+++vTpow8++KBUXUXnbf78+Wrbtq0cDociIiL09NNPq6CgwK0+FRQU6Omnn1Z4eLgcDofatm2r+fPnWxonqp+3pzsAVJVvv/1WCQkJ6t+/vxYtWiSHw6E2bdp4uls1xqOPPqp77rnHpa1169ZurXvHHXcoNTVVs2bNUps2bfT666/r7rvvVnFxscs2P/nkE/Xu3VsdO3bUG2+8oV9++UVPPvmkYmNjdfDgQV111VWSpLy8PPXs2VM//PCDnn76abVv314nTpzQtGnTtG3bNh0/flz+/v6VN/hKGp8k+fn56f333y/VdqkOHjyoMWPG6KGHHtLw4cPl7e1drWOvqVJTU9WzZ0/dcMMNWrVqlYwxev755/X73/9eO3bsUExMjEu9u/P23HPPaerUqZo4caLi4uKUmpqqJ554QqdPn9bSpUsv2q8//elPWrVqlaZPn66uXbtq27Zt+vOf/6zc3FxNnjzZ2qBRfQxQS/3nP/8xkszatWs93ZUaJS0tzUgyf/3rXy9p/bfffttIMq+//rpLe9++fU1oaKgpLCx0tg0bNsw0btzYZGdnO9tOnjxpfHx8zOOPP+5sS0pKMpLMK6+84rLN119/3Ugy69evv6S+/tbw4cNNr169yq2pyPiGDx9u6tWrVyl9K/Haa68ZSWbv3r2Vut3arl+/fiY4ONj89NNPzracnBzTuHFj0717d5dad+ctKyvL+Pr6mj/+8Y8u7c8995yx2Wzm6NGj5a5/5MgRY7PZzIwZM1zaR44cafz8/Mx333130T7g8sBpPtRKI0aMUI8ePSRJ8fHxstls6t27tyRp3759+sMf/qDw8HD5+fkpPDxcd999t7766qtS2zl9+rT++Mc/qnnz5rLb7QoNDdWdd96pb775xlmTk5Oj8ePHKyIiQna7XU2bNlViYqJ++uknt/ublZWl5s2bq3v37i6nB44dO6Z69eopISHhEl+J6rdhwwbVr19fw4YNc2m///77lZGRob1790qSCgsLtXnzZg0dOlQBAQHOurCwMPXp00cbNmxwtvn4+EiSAgMDXbbZoEEDSZKvr69L+759+zRo0CA1atRIvr6+6tSpk954441qHV9V6N27t/7nf/5HktStWzfZbDaNGDFCkpSUlKTBgwerWbNm8vX1VatWrTRq1ChlZWWV2s4nn3yiu+++W8HBwXI4HGrRooXuu+8+5eXlOWsyMzM1atQoNWvWTHa73Xn6qrCw0O3+Tp8+Xd7e3jp16lSpZQ888ICCgoL0yy+/VPBVuDQffPCBevfurbp16zrb/P391bNnT+3evVtnzpyp8Dbfeecd/fLLL7r//vtd2u+//34ZY/TWW2+Vu/5bb70lY0yZ6//888965513KtwneAZhCrXS1KlTtXDhQknSjBkzlJKSokWLFkn69ZqgqKgozZ07V9u2bdPs2bN15swZde3a1eWD5/Tp0+ratas2bNigcePGaevWrZo7d64CAwP1ww8/SJLOnz+vXr16aeXKlRozZoy2bt2qCRMmaMWKFRo0aJCMMW71t3HjxlqzZo1SU1M1YcIE57aHDRumFi1aaMmSJeWub4xRYWGhWw93zZo1S3a7XXXr1lWPHj20adMmt9Y7cuSI2rVrJ29v16sIrrvuOudySfriiy/0888/O9t/W/v55587P2h/97vfKTo6Wk899ZRSU1N17tw5ffTRR5o8ebI6d+6sm2++2bnujh079Lvf/U4//vijlixZoo0bN6pjx46Kj4/XihUr3B6/1fGV+PnnnxUSEiIvLy81a9ZMjzzyiL7//vtL2veiRYv0xBNPSJKWL1+ulJQUTZ06VdKvr2dMTIwWL16s7du368knn9TevXvVo0cPl4B+6NAhde3aVXv27NEzzzyjrVu3aubMmcrLy1N+fr6kX4PUDTfcoG3btunJJ5/U1q1b9eCDD2rmzJkaOXKk2/0dNWqUvL299fe//92l/fvvv9eaNWv04IMPlgrC/60y39f5+flyOByl2kvaDh8+7NLuzryVzPW1117r0t6kSRM1bty41Hvht44cOaKrrrpKISEhLu0Xei/hMubR42JAFdqxY4eRZN58881y6woLC825c+dMvXr1zEsvveRsf+CBB4yPj485duzYBdedOXOmqVOnjklNTXVp/+c//2kkmS1btlSoz7NnzzaSzIYNG8zw4cONn5+f+fjjjy+6XslY3XmkpaWVu62MjAwzcuRI88Ybb5hdu3aZf/zjH+bGG280kszLL7980b60bt3a9OvXr8ztSnKe0vjggw+MJLN69epStTNmzDCSTEZGhrMtJyfH3HbbbS5j6d27d6lTIW3btjWdOnUyBQUFLu233nqradKkiSkqKnK2FRQUuDzuu+8+07Nnz1LtxcXFFR6fMca88MIL5oUXXjDbt28327dvN1OmTDF169Y1bdu2Nbm5uRd7Kcu0fPlyI6nUe+6/FRcXm4KCAvPVV18ZSWbjxo3OZTfddJNp0KCBOXv27AXXHzVqlKlfv7756quvXNrnzJljJF309NV/Gz58uLn66qtNXl6es2327NmmTp06F30vlozVncfFdOzY0bRp06bU/EdGRpY6bevuvI0cOdI4HI4y99emTRsTFxdXbp/69u1roqKiylxmt9tLnT7E5YsL0HHFOXfunKZPn65169bp5MmTKioqci47fvy48/+3bt2qPn36qF27dhfc1ubNm9WhQwd17NjR5bfjfv36yWazaefOnRowYIDbfXvsscf073//W3fffbd++eUXvfLKK6V+6y1LdHS0UlNT3dpHaGhoucubNGlS6sLZYcOGqVu3bpo4caJGjBhR6qjMb9lsNreXuVNbUFCg+Ph4HTlyRC+//LKioqKUlpamZ599Vn379tX777+vwMBAff755/rkk080Z84cSXKZk4EDB2rz5s06ceKE2rVrp5MnTyoiIqLM/ZacViyxY8cO52niioxv7NixLsv69u2rTp066c4779TLL79carkVZ8+e1ZNPPqm3335bGRkZKi4udi47fvy4Bg0apPPnzys5OVkPPvig8+L+smzevFl9+vRRaGioy2s4YMAAjR8/XsnJyWrfvr1b/frzn/+slStX6s0339S9996r4uJiLV68WLfccovCw8PLXfe2225z+319MY8++qgefPBBPfLII5oyZYqKi4v19NNPO0/v16nz/0/UVGTeKvJer2iNO+vj8kCYwhXnnnvu0XvvvaepU6eqa9euCggIkM1m08CBA/Xzzz8767799ls1a9as3G198803+vzzz0t9+JYo63qV8pRcA/P2228rJCTE7Wul6tevr44dO7pVe7EgVBYfHx/Fx8dr4sSJ+uyzz8oNmEFBQfruu+9KtZecImnUqJGzTtIFa202m/OaqGXLlmnr1q1KTU1Vly5dJEmxsbHq0aOHWrZsqblz52ratGnOa9nGjx+v8ePHl9m/kjkJDQ0t9UH99NNPKyMjo9RpqaioqAqP70Juv/121atXT3v27Cm3riKKi4sVFxenjIwMTZ06Vddee63q1aun4uJi3Xjjjc739Q8//KCioiK33tf/+te/KuV93alTJ8XGxmrhwoW69957tXnzZp08ebLUa1yWRo0albpO7lI98MAD+vbbb/Xss89q8eLFkqSYmBiNHz9es2fPVtOmTctdv6x5K7nm6/z58y7XYkm/vh+io6PL3WZQUFCZt2v56aeflJ+ff9H3Ei4fhClcUbKzs7V582ZNmzZNEydOdLbn5eWVuh7iqquu0tdff13u9ho3biw/Pz/97//+7wWXV8SZM2f08MMPq2PHjjp69KjGjx+vefPmXXS95ORk9enTx619pKWlXfSIQFnM/7v+679/gy/Ltddeq9WrV6uwsNAluJVck9KhQwdJUsuWLeXn51fqWpWS2latWjmvpzl48KC8vLzUuXNnl7rIyEgFBQU5ry0peb0nTZqkO+64o8z+lQQju93uDGYlgoKClJubW6r9UsZXHmPMRV/Hijhy5IgOHTqkFStWaPjw4c72zz//3KWuUaNG8vLycut9fd111+m5554rc/nFjm7+1pgxYzRs2DB99NFHWrBggdq0aaO+fftedL2VK1eWujj7Qowb1ydOmDBBiYmJ+uyzz+Tv76+wsDCNGjVK9erVu2jwKdnHf89byVHjw4cPq1u3bs72zMxMZWVlXfS9cO2112rNmjXKzMx0uW6qIu8lXB4IU7ii2Gw2GWNKXYj6yiuvuJzuk349pbFq1SqdOHHC5cjEf7v11ls1Y8YMBQUFXfCUkbuKiop09913y2azaevWrfrHP/6h8ePHq3fv3hcMBiUq8zRfWQoKCrR27Vo1btxYrVq1Krf29ttv18svv6x169YpPj7e2b5y5UqFhoY6P3S8vb112223af369Xr++eed90pKT0/Xjh07XE6lhIaGqqioSKmpqS4fWp9++qm+++4755GWqKgotW7dWocOHdKMGTMqPE53uDu+C/nnP/+p8+fP68Ybb6y0PpWcDvrt+/q3R3/8/PzUq1cvvfnmm3ruuecuGPZvvfVWbdmyRS1btlTDhg0t9+/2229XixYt9Je//EXJycl68cUX3TqFVZmn+Uo4HA5nSElPT9fatWs1cuTIi977q6x569+/v3x9fbVixQqXeV+xYoVsNpuGDBlS7jYHDx6sJ554QitXrnR+8aRkfT8/P/Xv3/8SRgiP8OgVW0AVutAF6D179jSNGjUyL7/8sklKSjJPPPGEadKkiWnQoIEZPny4s+7rr782TZo0MVdffbWZO3euee+998y6devMyJEjzfHjx40xxpw7d8506tTJNGvWzPztb38zSUlJZtu2bebll182w4YNM3v27HG7v1OmTDF16tQx7777rrPttttuMw0aNDBffvmltRejAsaOHWseeeQRs3r1arNjxw7z6quvmq5duxpJZvny5S61Tz/9tPHy8jI7d+50ae/bt69p2LChWbp0qXn//ffNyJEjjSTz2muvudQdP37c1K9f3/Ts2dNs2bLFrF+/3nTo0MGEhoa6XCCdnp5uGjRoYJo2bWoWL15s3n//ffPKK6+YyMhIU69ePfPJJ584a99//33jcDhMXFycef31101ycrLZsGGDmTFjhrnzzjvLHbs795lyd3wnT5403bt3N/PmzTNbtmwxW7duNRMnTjS+vr7mmmuuMefOnXPZZq9evdy6kLqsC9Dz8/NNy5YtTVhYmHn99dfNO++8Yx5++GHTpk0bI8lMmzbNWXvw4EFTv359ExkZ6ez/6tWrzd13321ycnKMMb9eTB8WFmbatm1rFi1aZN577z3z9ttvm4ULF5pbbrnFnDp16qL9/K2SL1fUq1fP/PjjjxVe36rDhw+bp556ymzevNkkJSWZOXPmmMaNG5suXbq4XFRe0Xl79tlnjc1mM5MnTzY7d+40f/3rX43D4TAjR450qVu5cqXx8vIyK1eudGl/6KGHjMPhMH/961/Nzp07zeTJk43NZjPPPfdc1b0YqHSEKdRaFwpTX3/9tRk6dKhp2LCh8ff3N/379zdHjhwxYWFhLmHKGGNOnTplHnjgARMSEmJ8fHxMaGioueuuu8w333zjrDl37px54oknTFRUlLHb7SYwMNBce+21ZuzYsSYzM9Otvm7fvt3UqVPH5UPPGGO+++4706JFC9O1a1eXb0NVpWXLlpkbbrjBNGrUyHh7e5uGDRuafv36mW3btpWqnTZtmpFkduzY4dKem5trxowZY0JCQozdbjfXXXddmd/aM8aYffv2md///vembt26JiAgwAwZMsR8/vnnpeo+++wzk5CQYMLDw43D4TAtWrQw8fHxZX6z7NChQ+auu+4yV199tfHx8TEhISHmpptuMkuWLCl37O6GKXfG9/3335vbb7/dhIeHGz8/P2O3203r1q3N448/XmaYiI6ONiEhIRfd94W+zXfs2DHTt29f4+/vbxo2bGiGDRtm0tPTS4Wpktphw4aZoKAgY7fbTYsWLcyIESPML7/84qz59ttvzZgxY0xERITx8fExjRo1MtHR0WbKlCmlAoU7Tp48aSSZ0aNHV3jdynDixAnnL1J2u920atXKPPHEE6XGUtF5M8aYl156ybRp08b5Wk6bNs3k5+e71JTM229/IcnPzzfTpk0zLVq0MHa73bRp08bMmzevUseOqmczxs0b4QAAqkRubq4aNWqkuXPn6uGHH/Z0d6rE/PnzNWbMGB05ckTXXHONp7sDVCqumQIAD/v3v/+tpk2bVuiGmDXFgQMHlJaWpmeeeUaDBw8mSKFW4sgUUMWKi4td7vlTlku5XQHgSUVFReV+g85ms8nLy0vh4eHKzMxUbGysVq1aVepu30BtQJgCqtiIESO0cuXKcmv4MURN07t3byUnJ19weVhYmE6ePFl9HQI8iDAFVLGTJ09e9CaH5d3XCLgcnThxQrm5uRdc7nA43Lp7P1AbEKYAAAAsqLxb8AIAAFyBuOq1ChUXFysjI0P+/v78wUoAAGoIY4xyc3MVGhrq1p9+IkxVoYyMDDVv3tzT3QAAAJfg1KlTF/3D4BJhqkqV/K2xU6dOKSAgwMO9AQAA7sjJyVHz5s2dn+MXQ5iqQiWn9gICAghTAADUMO5eosMF6AAAABYQpgAAACwgTAEAAFhAmAIAALCAMAUAAGABYQoAAMACwhQAAIAFhCkAAAALCFMAAAAWEKYAAAAsIEwBAABYQJgCAACwgDAFAABgAWEKAADAAsIUAACABYQpAAAACwhTAAAAFhCmAAAALCBMAQAAWECYAgAAsIAwBQAAYAFhCgAAwALCFAAAgAWEKQAAAAsIUwAAABYQpgAAACwgTAEAAFhAmAIAALCAMAUAAGABYQoAAMACwhQAAIAFhCkAAAALCFMAAAAWEKYAAAAsIEwBAABYQJgCAACwgDAFAABgAWEKAADAAsIUAACABYQpAAAACwhTAAAAFhCmAAAALCBMAQAAWODxMLVo0SJFRETI19dX0dHR2rVrV7n1ycnJio6Olq+vryIjI7VkyRKX5UePHtXQoUMVHh4um82muXPnWt7vqFGjyt0WAAC4cnk0TK1du1aJiYmaMmWKDhw4oNjYWA0YMEDp6ell1qelpWngwIGKjY3VgQMHNHnyZI0ZM0br1q1z1pw/f16RkZGaNWuWQkJCLO/3rbfe0t69exUaGlo5gwYAALWL8aAbbrjBjB492qWtbdu2ZuLEiWXWP/7446Zt27YubaNGjTI33nhjmfVhYWHmxRdfvOT9fv3116Zp06bmyJEjF9xWebKzs40kk52dXaH1AACA51T089tjR6by8/O1f/9+xcXFubTHxcVp9+7dZa6TkpJSqr5fv37at2+fCgoKKnW/xcXFSkhI0GOPPaZrrrnGrW0DAIArj7endpyVlaWioiIFBwe7tAcHByszM7PMdTIzM8usLywsVFZWlpo0aVJp+509e7a8vb01ZswYd4ekvLw85eXlOZ/n5OS4vS4AAKiZPH4Bus1mc3lujCnVdrH6stqt7Hf//v166aWXtGLFigptd+bMmQoMDHQ+mjdvXqE+AQCAmsdjYapx48by8vIqdRTq7NmzpY4alQgJCSmz3tvbW0FBQZW23127duns2bNq0aKFvL295e3tra+++kp/+ctfFB4efsFtT5o0SdnZ2c7HqVOn3OoTAACouTwWpux2u6Kjo5WUlOTSnpSUpO7du5e5TkxMTKn67du3q0uXLvLx8am0/SYkJOjjjz/WwYMHnY/Q0FA99thj2rZt2wW37XA4FBAQ4PIAAAC1m8eumZKkcePGKSEhQV26dFFMTIyWLl2q9PR0jR49WtKvR3pOnz6tV199VZI0evRoLViwQOPGjdPIkSOVkpKiZcuWafXq1c5t5ufn69ixY87/P336tA4ePKj69eurVatWbu03KCio1JEuHx8fhYSEKCoqqspfFwAAUHN4NEzFx8fru+++0zPPPKMzZ86oQ4cO2rJli8LCwiRJZ86ccbn3U0REhLZs2aKxY8dq4cKFCg0N1bx58zR06FBnTUZGhjp16uR8PmfOHM2ZM0e9evXSzp073dovAACAu2ym5ApuVLqcnBwFBgYqOzubU34AANQQFf389vi3+QAAAGoywhQAAIAFhCkAAAALCFMAAAAWEKYAAAAsIEwBAABYQJgCAACwgDAFAABgAWEKAADAAsIUAACABYQpAAAACwhTAAAAFhCmAAAALCBMAQAAWECYAgAAsIAwBQAAYAFhCgAAwALCFAAAgAWEKQAAAAsIUwAAABYQpgAAACwgTAEAAFhAmAIAALCAMAUAAGABYQoAAMACwhQAAIAFhCkAAAALCFMAAAAWEKYAAAAsIEwBAABYQJgCAACwgDAFAABgAWEKAADAAsIUAACABYQpAAAACwhTAAAAFhCmAAAALCBMAQAAWECYAgAAsIAwBQAAYAFhCgAAwALCFAAAgAWEKQAAAAsIUwAAABYQpgAAACwgTAEAAFhAmAIAALCAMAUAAGABYQoAAMACwhQAAIAFhCkAAAALCFMAAAAWEKYAAAAsIEwBAABYQJgCAACwgDAFAABggcfD1KJFixQRESFfX19FR0dr165d5dYnJycrOjpavr6+ioyM1JIlS1yWHz16VEOHDlV4eLhsNpvmzp1b4f0WFBRowoQJuvbaa1WvXj2FhobqvvvuU0ZGhuXxAgCA2sWjYWrt2rVKTEzUlClTdODAAcXGxmrAgAFKT08vsz4tLU0DBw5UbGysDhw4oMmTJ2vMmDFat26ds+b8+fOKjIzUrFmzFBISckn7PX/+vD766CNNnTpVH330kdavX69PP/1UgwYNqvwXAQAA1Gg2Y4zx1M67deumzp07a/Hixc62du3aaciQIZo5c2ap+gkTJmjTpk06fvy4s2306NE6dOiQUlJSStWHh4crMTFRiYmJlvYrSampqbrhhhv01VdfqUWLFm6NLycnR4GBgcrOzlZAQIBb6wAAAM+q6Oe3x45M5efna//+/YqLi3Npj4uL0+7du8tcJyUlpVR9v379tG/fPhUUFFTZfiUpOztbNptNDRo0cGs/AADgyuDtqR1nZWWpqKhIwcHBLu3BwcHKzMwsc53MzMwy6wsLC5WVlaUmTZpUyX5/+eUXTZw4Uffcc0+5CTUvL095eXnO5zk5ORftDwAAqNk8fgG6zWZzeW6MKdV2sfqy2itrvwUFBfrDH/6g4uJiLVq0qNxtzpw5U4GBgc5H8+bNK9QnAABQ83gsTDVu3FheXl6ljgadPXu21FGjEiEhIWXWe3t7KygoqNL3W1BQoLvuuktpaWlKSkq66HnTSZMmKTs72/k4deqUW30CAAA1l8fClN1uV3R0tJKSklzak5KS1L179zLXiYmJKVW/fft2denSRT4+PpW635Ig9dlnn+ndd991K6w5HA4FBAS4PAAAQO3msWumJGncuHFKSEhQly5dFBMTo6VLlyo9PV2jR4+W9OuRntOnT+vVV1+V9Os39xYsWKBx48Zp5MiRSklJ0bJly7R69WrnNvPz83Xs2DHn/58+fVoHDx5U/fr11apVK7f2W1hYqDvvvFMfffSRNm/erKKiIueRrEaNGslut1fbawQAAC5zxsMWLlxowsLCjN1uN507dzbJycnOZcOHDze9evVyqd+5c6fp1KmTsdvtJjw83CxevNhleVpampFU6vHb7ZS33wttQ5LZsWOH22PLzs42kkx2drbb6wAAAM+q6Oe3R+8zVdtxnykAAGqeGnOfKQAAgNqAMAUAAGABYQoAAMACwhQAAIAFhCkAAAALCFMAAAAWEKYAAAAsIEwBAABYQJgCAACwgDAFAABgAWEKAADAAsIUAACABYQpAAAACwhTAAAAFhCmAAAALCBMAQAAWECYAgAAsIAwBQAAYAFhCgAAwALCFAAAgAWEKQAAAAsIUwAAABYQpgAAACwgTAEAAFhAmAIAALCAMAUAAGABYQoAAMACwhQAAIAFhCkAAAALCFMAAAAWEKYAAAAsIEwBAABYQJgCAACwgDAFAABgAWEKAADAAsIUAACABYQpAAAACwhTAAAAFhCmAAAALCBMAQAAWECYAgAAsIAwBQAAYAFhCgAAwALCFAAAgAWEKQAAAAsIUwAAABYQpgAAACwgTAEAAFhAmAIAALCAMAUAAGBBpYSpm266SV999VVlbAoAAKBG8a5I8aZNm8ps//e//63NmzerefPmkqRBgwZZ7xkAAEANYDPGGHeL69SpI5vNpvJWsdlsKioqqpTO1XQ5OTkKDAxUdna2AgICPN0dAADghop+flfoNF+/fv00YMAAZWZmqri42Pnw8vLSkSNHVFxcTJACAABXlAqFqa1bt+r3v/+9unbtqs2bN1dVnwAAAGqMCl+APnbsWG3atEkTJkzQqFGjdP78+aroFwAAQI1wSd/mu/7667Vv3z7ZbDZ17Nix3GuoAAAAarNLvjWCn5+flixZojlz5ujRRx9V48aNL2k7ixYtUkREhHx9fRUdHa1du3aVW5+cnKzo6Gj5+voqMjJSS5YscVl+9OhRDR06VOHh4bLZbJo7d+4l7dcYo6eeekqhoaHy8/NT7969dfTo0UsaIwAAqL0s32dq0KBBevHFF3X11VdXeN21a9cqMTFRU6ZM0YEDBxQbG6sBAwYoPT29zPq0tDQNHDhQsbGxOnDggCZPnqwxY8Zo3bp1zprz588rMjJSs2bNUkhIyCXv9/nnn9cLL7ygBQsWKDU1VSEhIerbt69yc3MrPE4AAFB7VejWCPPmzXOrbsyYMW7VdevWTZ07d9bixYudbe3atdOQIUM0c+bMUvUTJkzQpk2bdPz4cWfb6NGjdejQIaWkpJSqDw8PV2JiohITEyu0X2OMQkNDlZiYqAkTJkiS8vLyFBwcrNmzZ2vUqFFujY9bIwAAUPNU9PO7QjftfPHFF12enzp1Sk2aNJG39//fjM1mcytM5efna//+/Zo4caJLe1xcnHbv3l3mOikpKYqLi3Np69evn5YtW6aCggL5+PhUyn7T0tKUmZnpsi+Hw6FevXpp9+7dFwxTeXl5ysvLcz7Pycm5aH8AAEDNVqEwlZaW5vLc399fycnJioyMrPCOs7KyVFRUpODgYJf24OBgZWZmlrlOZmZmmfWFhYXKyspSkyZNKmW/Jf8tq6a8P5szc+ZMPf300xftAwAAqD08/oeObTaby3NjTKm2i9WX1V4Z+61o3yZNmqTs7Gzn49SpUxXqEwAAqHkqdGSqMjVu3FheXl6ljkKdPXu21BGhEiEhIWXWe3t7KygoqNL2W3LhemZmpsvRrvL6Jv16KtDhcLjVDwAAUDt47MiU3W5XdHS0kpKSXNqTkpLUvXv3MteJiYkpVb99+3Z16dLFreul3N1vRESEQkJCXGry8/OVnJx8wb4BAIArU4WOTP32gmqbzaZz586Vanf3m2vjxo1TQkKCunTpopiYGC1dulTp6ekaPXq0pF9Pm50+fVqvvvqqpF+/ubdgwQKNGzdOI0eOVEpKipYtW6bVq1c7t5mfn69jx445///06dM6ePCg6tevr1atWrm1X5vNpsTERM2YMUOtW7dW69atNWPGDNWtW1f33HNPRV4yAABQ25kKsNlspk6dOs7HhZ5XxMKFC01YWJix2+2mc+fOJjk52bls+PDhplevXi71O3fuNJ06dTJ2u92Eh4ebxYsXuyxPS0szkko9frud8vZrjDHFxcVm2rRpJiQkxDgcDtOzZ09z+PDhCo0tOzvbSDLZ2dkVWg8AAHhORT+/K3SfqZ07d7p1oXevXr0uLdnVMtxnCgCAmqdK7zPVu3fvS+0XAABArVShMFWnTp2LHpmy2WwqLCy01CkAAICaokJhasOGDRdctnv3bs2fP18VOGsIAABQ41UoTA0ePLhU2yeffKJJkybpX//6l+69915Nnz690joHAABwubvk+0xlZGRo5MiRuu6661RYWKiDBw9q5cqVatGiRWX2DwAA4LJW4TCVnZ2tCRMmqFWrVjp69Kjee+89/etf/1KHDh2qon8AAACXtQqd5nv++ec1e/ZshYSEaPXq1WWe9gMAALiSVOg+U3Xq1JGfn59uvvlmeXl5XbBu/fr1ldK5mo77TAEAUPNU6X2m7rvvPrdu2gkAAHClqFCYWrFiRRV1AwAAoGa65G/zAQAAgDAFAABgCWEKAADAAsIUAACABYQpAAAACwhTAAAAFhCmAAAALCBMAQAAWECYAgAAsIAwBQAAYAFhCgAAwALCFAAAgAWEKQAAAAsIUwAAABYQpgAAACwgTAEAAFhAmAIAALCAMAUAAGABYQoAAMACwhQAAIAFhCkAAAALCFMAAAAWEKYAAAAsIEwBAABYQJgCAACwgDAFAABgAWEKAADAAsIUAACABYQpAAAACwhTAAAAFhCmAAAALCBMAQAAWECYAgAAsIAwBQAAYAFhCgAAwALCFAAAgAWEKQAAAAsIUwAAABYQpgAAACwgTAEAAFhAmAIAALCAMAUAAGABYQoAAMACwhQAAIAFhCkAAAALCFMAAAAWeDxMLVq0SBEREfL19VV0dLR27dpVbn1ycrKio6Pl6+uryMhILVmypFTNunXr1L59ezkcDrVv314bNmxwWZ6bm6vExESFhYXJz89P3bt3V2pqqkvNuXPn9Mgjj6hZs2by8/NTu3bttHjxYusDBgAAtYpHw9TatWuVmJioKVOm6MCBA4qNjdWAAQOUnp5eZn1aWpoGDhyo2NhYHThwQJMnT9aYMWO0bt06Z01KSori4+OVkJCgQ4cOKSEhQXfddZf27t3rrHnooYeUlJSkVatW6fDhw4qLi9PNN9+s06dPO2vGjh2rd955R6+99pqOHz+usWPH6tFHH9XGjRur7gUBAAA1js0YYzy1827duqlz584uR3zatWunIUOGaObMmaXqJ0yYoE2bNun48ePOttGjR+vQoUNKSUmRJMXHxysnJ0dbt2511vTv318NGzbU6tWr9fPPP8vf318bN27ULbfc4qzp2LGjbr31Vj377LOSpA4dOig+Pl5Tp0511kRHR2vgwIGaPn26W+PLyclRYGCgsrOzFRAQ4OarAgAAPKmin98eOzKVn5+v/fv3Ky4uzqU9Li5Ou3fvLnOdlJSUUvX9+vXTvn37VFBQUG5NyTYLCwtVVFQkX19flxo/Pz/95z//cT7v0aOHNm3apNOnT8sYox07dujTTz9Vv379LjimvLw85eTkuDwAAEDt5rEwlZWVpaKiIgUHB7u0BwcHKzMzs8x1MjMzy6wvLCxUVlZWuTUl2/T391dMTIymT5+ujIwMFRUV6bXXXtPevXt15swZ5zrz5s1T+/bt1axZM9ntdvXv31+LFi1Sjx49LjimmTNnKjAw0Plo3ry5+y8IAACokTx+AbrNZnN5bowp1Xax+t+2X2ybq1atkjFGTZs2lcPh0Lx583TPPffIy8vLWTNv3jzt2bNHmzZt0v79+/W3v/1Nf/rTn/Tuu+9esG+TJk1Sdna283Hq1KlyRg4AAGoDb0/tuHHjxvLy8ip1FOrs2bOljiyVCAkJKbPe29tbQUFB5db89zZbtmyp5ORk/fTTT8rJyVGTJk0UHx+viIgISdLPP/+syZMna8OGDc7rqq677jodPHhQc+bM0c0331xm/xwOhxwORwVeBQAAUNN57MiU3W5XdHS0kpKSXNqTkpLUvXv3MteJiYkpVb99+3Z16dJFPj4+5daUtc169eqpSZMm+uGHH7Rt2zYNHjxYklRQUKCCggLVqeP68nh5eam4uLhiAwUAALWax45MSdK4ceOUkJCgLl26KCYmRkuXLlV6erpGjx4t6dfTZqdPn9arr74q6ddv7i1YsEDjxo3TyJEjlZKSomXLlmn16tXObf75z39Wz549NXv2bA0ePFgbN27Uu+++63Jx+bZt22SMUVRUlD7//HM99thjioqK0v333y9JCggIUK9evfTYY4/Jz89PYWFhSk5O1quvvqoXXnihGl8hAABw2TMetnDhQhMWFmbsdrvp3LmzSU5Odi4bPny46dWrl0v9zp07TadOnYzdbjfh4eFm8eLFpbb55ptvmqioKOPj42Patm1r1q1b57J87dq1JjIy0tjtdhMSEmIefvhh8+OPP7rUnDlzxowYMcKEhoYaX19fExUVZf72t7+Z4uJit8eWnZ1tJJns7Gy31wEAAJ5V0c9vj95nqrbjPlMAANQ8NeY+UwAAALUBYQoAAMACwhQAAIAFhCkAAAALCFMAAAAWEKYAAAAsIEwBAABYQJgCAACwgDAFAABgAWEKAADAAsIUAACABYQpAAAACwhTAAAAFhCmAAAALCBMAQAAWECYAgAAsIAwBQAAYAFhCgAAwALCFAAAgAWEKQAAAAsIUwAAABYQpgAAACwgTAEAAFhAmAIAALCAMAUAAGABYQoAAMACwhQAAIAFhCkAAAALCFMAAAAWEKYAAAAsIEwBAABYQJgCAACwgDAFAABgAWEKAADAAsIUAACABYQpAAAACwhTAAAAFhCmAAAALCBMAQAAWECYAgAAsIAwBQAAYAFhCgAAwALCFAAAgAWEKQAAAAsIUwAAABYQpgAAACwgTAEAAFhAmAIAALCAMAUAAGABYQoAAMACwhQAAIAFhCkAAAALCFMAAAAWEKYAAAAsIEwBAABYQJgCAACwwONhatGiRYqIiJCvr6+io6O1a9eucuuTk5MVHR0tX19fRUZGasmSJaVq1q1bp/bt28vhcKh9+/basGGDy/Lc3FwlJiYqLCxMfn5+6t69u1JTU0tt5/jx4xo0aJACAwPl7++vG2+8Uenp6dYGDAAAahWPhqm1a9cqMTFRU6ZM0YEDBxQbG6sBAwZcMLCkpaVp4MCBio2N1YEDBzR58mSNGTNG69atc9akpKQoPj5eCQkJOnTokBISEnTXXXdp7969zpqHHnpISUlJWrVqlQ4fPqy4uDjdfPPNOn36tLPmiy++UI8ePdS2bVvt3LlThw4d0tSpU+Xr61t1LwgAAKhxbMYY46mdd+vWTZ07d9bixYudbe3atdOQIUM0c+bMUvUTJkzQpk2bdPz4cWfb6NGjdejQIaWkpEiS4uPjlZOTo61btzpr+vfvr4YNG2r16tX6+eef5e/vr40bN+qWW25x1nTs2FG33nqrnn32WUnSH/7wB/n4+GjVqlWXPL6cnBwFBgYqOztbAQEBl7wdAABQfSr6+e2xI1P5+fnav3+/4uLiXNrj4uK0e/fuMtdJSUkpVd+vXz/t27dPBQUF5daUbLOwsFBFRUWljjD5+fnpP//5jySpuLhYb7/9ttq0aaN+/frp6quvVrdu3fTWW2+VO6a8vDzl5OS4PAAAQO3msTCVlZWloqIiBQcHu7QHBwcrMzOzzHUyMzPLrC8sLFRWVla5NSXb9Pf3V0xMjKZPn66MjAwVFRXptdde0969e3XmzBlJ0tmzZ3Xu3DnNmjVL/fv31/bt23X77bfrjjvuUHJy8gXHNHPmTAUGBjofzZs3r9iLAgAAahyPX4Bus9lcnhtjSrVdrP637Rfb5qpVq2SMUdOmTeVwODRv3jzdc8898vLykvTrkSlJGjx4sMaOHauOHTtq4sSJuvXWW8u84L3EpEmTlJ2d7XycOnWqvKEDAIBawGNhqnHjxvLy8ip1FOrs2bOljiyVCAkJKbPe29tbQUFB5db89zZbtmyp5ORknTt3TqdOndKHH36ogoICRUREOPvm7e2t9u3bu2ynXbt25X6bz+FwKCAgwOUBAABqN4+FKbvdrujoaCUlJbm0JyUlqXv37mWuExMTU6p++/bt6tKli3x8fMqtKWub9erVU5MmTfTDDz9o27ZtGjx4sLNvXbt21YkTJ1zqP/30U4WFhVVsoAAAoHYzHrRmzRrj4+Njli1bZo4dO2YSExNNvXr1zMmTJ40xxkycONEkJCQ467/88ktTt25dM3bsWHPs2DGzbNky4+PjY/75z386az744APj5eVlZs2aZY4fP25mzZplvL29zZ49e5w177zzjtm6dav58ssvzfbt2831119vbrjhBpOfn++sWb9+vfHx8TFLly41n332mZk/f77x8vIyu3btcnt82dnZRpLJzs628jIBAIBqVNHPb4+GKWOMWbhwoQkLCzN2u9107tzZJCcnO5cNHz7c9OrVy6V+586dplOnTsZut5vw8HCzePHiUtt88803TVRUlPHx8TFt27Y169atc1m+du1aExkZaex2uwkJCTEPP/yw+fHHH0ttZ9myZaZVq1bG19fXXH/99eatt96q0NgIUwAA1DwV/fz26H2majvuMwUAQM1TY+4zBQAAUBsQpgAAACwgTAEAAFhAmAIAALCAMAUAAGABYQoAAMACwhQAAIAFhCkAAAALCFMAAAAWEKYAAAAsIEwBAABYQJgCAACwgDAFAABgAWEKAADAAsIUAACABYQpAAAACwhTAAAAFhCmAAAALCBMAQAAWECYAgAAsIAwBQAAYAFhCgAAwALCFAAAgAWEKQAAAAsIUwAAABYQpgAAACwgTAEAAFhAmAIAALCAMAUAAGABYQoAAMACwhQAAIAFhCkAAAALCFMAAAAWEKYAAAAsIEwBAABYQJgCAACwgDAFAABgAWEKAADAAsIUAACABYQpAAAACwhTAAAAFhCmAAAALCBMAQAAWODt6Q7UZsYYSVJOTo6HewIAANxV8rld8jl+MYSpKpSbmytJat68uYd7AgAAKio3N1eBgYEXrbMZd2MXKqy4uFgZGRny9/eXzWbzdHeccnJy1Lx5c506dUoBAQGe7k6VqM1jrM1jK1Hbx1jbxyfV/jHW9vFJtX+M5Y3PGKPc3FyFhoaqTp2LXxHFkakqVKdOHTVr1szT3biggICAWvkD8t9q8xhr89hK1PYx1vbxSbV/jLV9fFLtH+OFxufOEakSXIAOAABgAWEKAADAAsLUFcjhcGjatGlyOBye7kqVqc1jrM1jK1Hbx1jbxyfV/jHW9vFJtX+MlTk+LkAHAACwgCNTAAAAFhCmAAAALCBMAQAAWECYgpPNZtNbb73l6W7gEjF/NR9zWPMxhzXfpcwhYaoWGzFihIYMGeLpblySmTNnqmvXrvL399fVV1+tIUOG6MSJEy41xhg99dRTCg0NlZ+fn3r37q2jR486l3///fd69NFHFRUVpbp166pFixYaM2aMsrOzXbbz3HPPqXv37qpbt64aNGhQHcNzS02eP6n65vDkyZN68MEHFRERIT8/P7Vs2VLTpk1Tfn5+tY31QmryHFbnz+CgQYPUokUL+fr6qkmTJkpISFBGRka1jPNimEP35rBEXl6eOnbsKJvNpoMHD1bl8NxWHXNImMJlKTk5WQ8//LD27NmjpKQkFRYWKi4uTj/99JOz5vnnn9cLL7ygBQsWKDU1VSEhIerbt6/zbyJmZGQoIyNDc+bM0eHDh7VixQq98847evDBB132lZ+fr2HDhun//J//U61jrO2qaw4/+eQTFRcX6+9//7uOHj2qF198UUuWLNHkyZOrfcy1SXX+DPbp00dvvPGGTpw4oXXr1umLL77QnXfeWa3jrY2qcw5LPP744woNDa2W8V1WDGqt4cOHm8GDBxtjjAkLCzMvvviiy/Lrr7/eTJs2zflcktmwYUO19a8izp49aySZ5ORkY4wxxcXFJiQkxMyaNctZ88svv5jAwECzZMmSC27njTfeMHa73RQUFJRatnz5chMYGFjpfb9UtWn+jKmeOSzx/PPPm4iIiMrr/CWqTXNYnfO3ceNGY7PZTH5+fuUN4BIxh6VdaA63bNli2rZta44ePWokmQMHDlTJOCqqOuaQI1OoEUoOKTdq1EiSlJaWpszMTMXFxTlrHA6HevXqpd27d5e7nYCAAHl782cpq1t1zmF2drZzP6gc1TV/33//vf7xj3+oe/fu8vHxqcQRoCrn8JtvvtHIkSO1atUq1a1bt4pGcPkiTOGyZ4zRuHHj1KNHD3Xo0EGSlJmZKUkKDg52qQ0ODnYu+63vvvtO06dP16hRo6q2wyilOufwiy++0Pz58zV69OhK6j2qY/4mTJigevXqKSgoSOnp6dq4cWMlj+LKVpVzaIzRiBEjNHr0aHXp0qWKRnB5I0zhsvfII4/o448/1urVq0sts9lsLs+NMaXaJCknJ0e33HKL2rdvr2nTplVZX1G26prDjIwM9e/fX8OGDdNDDz1UOZ1HtczfY489pgMHDmj79u3y8vLSfffdJ8Mf6Kg0VTmH8+fPV05OjiZNmlT5Ha8hCFNXiDp16pT6h6mgoMBDvXHfo48+qk2bNmnHjh1q1qyZsz0kJESSSv32dPbs2VK/ZeXm5qp///6qX7++NmzYUCNPHdTU+ZOqbw4zMjLUp08fxcTEaOnSpVUwEmtq6hxW1/w1btxYbdq0Ud++fbVmzRpt2bJFe/bsqYIRXTrmsOw5fP/997Vnzx45HA55e3urVatWkqQuXbpo+PDhVTWsS1JVc0iYukJcddVVOnPmjPN5Tk6O0tLSPNij8hlj9Mgjj2j9+vV6//33FRER4bI8IiJCISEhSkpKcrbl5+crOTlZ3bt3d7bl5OQoLi5OdrtdmzZtkq+vb7WNoTLVtPmTqncOT58+rd69e6tz585avny56tS5/P5pq2lz6MmfwZIPu7y8vEoaTeVgDsuew3nz5unQoUM6ePCgDh48qC1btkiS1q5dq+eee64KR1hxVTWHXIV7hbjpppu0YsUK3XbbbWrYsKGmTp0qLy8vT3frgh5++GG9/vrr2rhxo/z9/Z2/OQUGBsrPz082m02JiYmaMWOGWrdurdatW2vGjBmqW7eu7rnnHkm//iYVFxen8+fP67XXXlNOTo5ycnIk/foDVTL+9PR0ff/990pPT1dRUZHz3iitWrVS/fr1q3/wZahp8ydV3xxmZGSod+/eatGihebMmaNvv/3W2YeS37wvBzVtDqtr/j788EN9+OGH6tGjhxo2bKgvv/xSTz75pFq2bKmYmBiPjb8szGHZc9iiRQuX/Zb8u9myZUuXI2GXgyqbwwp99w81SkJCghk6dKgxxpjs7Gxz1113mYCAANO8eXOzYsWKy/orvZLKfCxfvtxZU1xcbKZNm2ZCQkKMw+EwPXv2NIcPH3Yu37FjxwW3k5aW5qwbPnx4mTU7duyovgGXoSbPnzHVN4fLly+/YI2n1eQ5rK75+/jjj02fPn1Mo0aNjMPhMOHh4Wb06NHm66+/ruYRl405dO/f0f+WlpZ2Wd0aoTrm0Pb/VkQt1L9/f7Vq1UoLFizwdFdwCZi/mo85rPmYw5qvOubw8ruwAJb98MMPevvtt7Vz507dfPPNnu4OKoj5q/mYw5qPOaz5qnMOuWaqFnrggQeUmpqqv/zlLxo8eLCnu4MKYv5qPuaw5mMOa77qnENO8wEAAFjAaT4AAAALCFMAAAAWEKYAAAAsIEwBAABYQJgCgN/YuXOnbDabfvzxR093BUANwLf5AFzxevfurY4dO2ru3LmSfv37ZN9//72Cg4Nls9k82zkAlz3uMwUAv2G32y+rv+sH4PLGaT4AV7QRI0YoOTlZL730kmw2m2w2m1asWOFymm/FihVq0KCBNm/erKioKNWtW1d33nmnfvrpJ61cuVLh4eFq2LChHn30URUVFTm3nZ+fr8cff1xNmzZVvXr11K1bN+3cudMzAwVQZTgyBeCK9tJLL+nTTz9Vhw4d9Mwzz0iSjh49Wqru/PnzmjdvntasWaPc3FzdcccduuOOO9SgQQNt2bJFX375pYYOHaoePXooPj5eknT//ffr5MmTWrNmjUJDQ7Vhwwb1799fhw8fVuvWrat1nACqDmEKwBUtMDBQdrtddevWdZ7a++STT0rVFRQUaPHixWrZsqUk6c4779SqVav0zTffqH79+mrfvr369OmjHTt2KD4+Xl988YVWr16tr7/+WqGhoZKk8ePH65133tHy5cs1Y8aM6hskgCpFmAIAN9StW9cZpCQpODhY4eHhql+/vkvb2bNnJUkfffSRjDFq06aNy3by8vIUFBRUPZ0GUC0IUwDgBh8fH5fnNputzLbi4mJJUnFxsby8vLR//355eXm51P13AANQ8xGmAFzx7Ha7y4XjlaFTp04qKirS2bNnFRsbW6nbBnB54dt8AK544eHh2rt3r06ePKmsrCzn0SUr2rRpo3vvvVf33Xef1q9fr7S0NKWmpmr27NnasmVLJfQawOWCMAXgijd+/Hh5eXmpffv2uuqqq5Senl4p212+fLnuu+8+/eUvf1FUVJQGDRqkvXv3qnnz5pWyfQCXB+6ADgAAYAFHpgAAACwgTAEAAFhAmAIAALCAMAUAAGABYQoAAMACwhQAAIAFhCkAAAALCFMAAAAWEKYAAAAsIEwBAABYQJgCAACwgDAFAABgwf8FIHUPZPwPy0gAAAAASUVORK5CYII=",
+      "text/plain": [
+       "<Figure size 640x480 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "transport_model.mesh.NH4.isel(nface=151, time=slice(0, 5000)).plot()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 41,
+   "id": "5db5b8be",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[<matplotlib.lines.Line2D at 0x1c25c780310>]"
+      ]
+     },
+     "execution_count": 41,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAkEAAAHFCAYAAAD1zS3+AAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjguNCwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8fJSN1AAAACXBIWXMAAA9hAAAPYQGoP6dpAAA49ElEQVR4nO3deVzVVeL/8fcVBEEBwQW8iEqumZVOmUtuWC7lWmmOlqBm2WQ5Vo7llFsLpNM0mmbOOKaOa4uafs2NUnGc1HBMx6VsNFxxqVTADRXO749+3OnGIiD7eT0fj/t4eM/nnM/nnHsu3jfn87kfHMYYIwAAAMuUK+4OAAAAFAdCEAAAsBIhCAAAWIkQBAAArEQIAgAAViIEAQAAKxGCAACAlQhBAADASoQgAABgJUIQbsqHH36o2267TT4+PnI4HNq1a1dxd6nEO3z4sBwOR5aPJUuW5GofFy5c0MiRI+V0OlWhQgU1bdo027Y7d+7U/fffr0qVKqly5cp6+OGH9f333+e4//3798vb21sOh0M7duzI8xhvVm7HN2jQoCxfx0aNGt3U8adNm6Z69erJy8tLDodD58+fv6n92WDDhg0aMmSIGjVqpIoVKyo0NFS9evXSv//971y1//zzz9WpUyc5nU55e3urevXq6tixo1avXp1t/VatWsnX11dVq1bVoEGDdObMGbc6EyZMyPZnLS8/bwXlzJkzGjRokKpWrSpfX1+1atVKX3zxRaZ6r7zyipo1a6agoCBVqFBBt9xyi5566ikdOXKkSPtrA8/i7gBKrx9++EEDBw5U165dNWPGDHl7e6tBgwbF3a1S47nnntOAAQPcyurXr5+rtg8//LDi4+P11ltvqUGDBlq0aJH69++v9PR0t31+++236tChg5o2baqPPvpIV65c0bhx49S2bVvt2rVL1apVy7TvtLQ0DRkyRFWrVlViYuLNDTKfcjs+SfLx8dGGDRsyleXXrl27NGLECA0dOlRRUVHy9PSUn59fvvdni/fff18//fSTfv/736tx48b64Ycf9Oc//1ktW7bUunXr1LFjxxzb//TTT7rttts0dOhQhYSE6OzZs5o5c6a6deum+fPn6/HHH3fVjYuL0wMPPKBu3bppxYoVOnPmjF566SXdd9992rFjh7y9vSVJQ4cOVdeuXTMd68knn9ShQ4ey3FZYUlNTdd999+n8+fOaOnWqqlevrvfee09du3bV559/rvbt27vqnj9/Xv3799ett94qPz8/7d+/X2+88YZWrlypffv2qUqVKkXW7zLPAPm0ZcsWI8l8+OGHxd2VUiUhIcFIMn/605/y1f6zzz4zksyiRYvcyjt16mScTqe5fv26q6xv376matWqJikpyVV2+PBhU758eTN69Ogs9/+nP/3JhIaGmqlTpxpJJj4+Pl/9zEpUVJRp3759jnXyMr6oqChTsWLFAuufMcYsWLDASDLbt28v0P2WdadPn85UlpKSYoKDg819992Xr31evXrVhIaGmrZt27qVN2/e3DRu3Nhcu3bNVfavf/3LSDIzZszIcZ8JCQnG4XCYxx9/PF99ykr79u1NVFRUjnXee+89I8l8+eWXrrJr166Zxo0bm3vuueeGx1i9erWRZGbPnn2z3cUvcDoM+TJo0CC1adNGktSvXz85HA516NBBkrRjxw799re/VZ06deTj46M6deqof//+WS7lnjhxQk899ZTCwsLk5eUlp9OpPn366PTp0646ycnJGjVqlMLDw+Xl5aXQ0FCNHDlSFy9ezHV/f/zxR4WFhal169a6du2aq3z//v2qWLGiBg4cmM9XougtX75clSpVUt++fd3KBw8erMTERG3fvl2SdP36da1atUqPPPKI/P39XfVq166tiIgILV++PNO+//vf/2rcuHGaMWOGW5tf27Fjh3r27Olarm/WrJk++uijIh1fYejQoYNrxaFFixZyOBwaNGiQJCk2Nla9evVSzZo1VaFCBdWrV0/Dhg3Tjz/+mGk/3377rfr376/g4GB5e3urVq1aioyMVGpqqqvOqVOnNGzYMNWsWVNeXl4KDw/XxIkTdf369Vz39/XXX5enp6eOHTuWaduQIUNUpUoVXblyJY+vQv5Ur149U1mlSpXUuHHjLPuXG+XLl1flypXl6fm/kxYnTpxQfHy8Bg4c6FbeunVrNWjQIMv39S998MEHMsZo6NChmbZ9/vnnuu++++Tv7y9fX1/de++9WZ6uyo/ly5erYcOGatWqlavM09NTjz/+uL766iudOHEix/YZq7a/HDNuHiEI+TJ27Fi99957kqTo6Ght3bpVM2bMkPTzNS8NGzbUlClTtG7dOk2aNEknT55U8+bN3T4wTpw4oebNm2v58uV64YUXtGbNGk2ZMkUBAQE6d+6cJOnSpUtq37695s2bpxEjRmjNmjV66aWXNHfuXPXs2VPGmFz1t2rVqlqyZIni4+P10ksvufbdt29f1apVSzNnzsyxvTFG169fz9Ujt9566y15eXnJ19dXbdq00cqVK3PVbu/evbr11lsz/Wd4xx13uLZL0qFDh3T58mVX+a/rHjx40O0DMuODoXv37urZs2e2x9+4caPuvfdenT9/XjNnztSKFSvUtGlT9evXT3Pnzs3VGApifBkuX76skJAQeXh4qGbNmnr22Wd19uzZfB17xowZevXVVyVJc+bM0datWzV27FhJP7+erVq10vvvv6/169dr3Lhx2r59u9q0aeMWrHfv3q3mzZtr27Zteu2117RmzRrFxMQoNTVVV69elfRzALrnnnu0bt06jRs3TmvWrNETTzyhmJgYPfnkk7nu77Bhw+Tp6am//vWvbuVnz57VkiVL9MQTT6hChQrZti+M9/UvJSUlaefOnbrtttty3SY9PV3Xr19XYmKixo8fr++++04vvviia3vG/Gf3vv71++PX+547d67q1avndvpJkhYsWKDOnTvL399f8+bN00cffaSgoCB16dKlQILQ3r17s+2zJO3bty/TtuvXr+vy5cv6+uuvNXLkSDVo0EAPP/zwTfcFv1Cs61Ao1TZu3GgkmY8//jjHetevXzcXLlwwFStWNFOnTnWVDxkyxJQvX97s378/27YxMTGmXLlymU7JfPLJJ0aSWb16dZ76PGnSJCPJLF++3ERFRRkfHx/zn//854btMsaam0dCQkKO+0pMTDRPPvmk+eijj8w///lPs3DhQtOyZUsjycyaNeuGfalfv77p0qVLlvuVZKKjo40x/zs9sHjx4kx1o6OjjSSTmJjoKps2bZoJDAw0p06dMsYYM2fOnCxPhzVq1Mg0a9bM7VSEMcZ0797d1KhRw6SlpbnKrl275vaIjIw07dq1y1Senp6e5/EZY8w777xj3nnnHbN+/Xqzfv1688orrxhfX1/TqFEjk5KSkuPrmJ3sxv1L6enp5tq1a+bIkSNGklmxYoVrW8eOHU3lypXNmTNnsm0/bNgwU6lSJXPkyBG38rfffttIMvv27ct1f6Oiokz16tVNamqqq2zSpEmmXLlyN3wvZow1N4/8eOyxx4ynp6fZsWNHrtt06dLFdUx/f3+zbNkyt+0LFy40kszWrVsztX3qqaeMl5dXtvtes2aNkWRiYmLcyi9evGiCgoJMjx493MrT0tLMnXfe6Xa6KmPuf/lo166diYyMzFT+S+XLlzfDhg3L1Kcvv/wyy9O/J0+edHv9W7RoYU6cOJHt2JA/rKuhwF24cEGvv/66li5dqsOHDystLc217ZtvvnH9e82aNYqIiNCtt96a7b5WrVqlJk2aqGnTpm6/jXbp0kUOh0ObNm3SAw88kOu+/eEPf9DmzZvVv39/XblyRX//+991++2337DdXXfdpfj4+Fwdw+l05ri9Ro0a+tvf/uZW1rdvX7Vo0UIvv/yyBg0adMMlb4fDkettual75MgRjRkzRlOmTFFwcHC29Q8ePKhvv/1Wb7/9tiS5zcmDDz6oVatW6cCBA7r11lt1+PBhhYeHZ7mf8uXLuz3fuHGj63RqbvssSc8//7zbtk6dOqlZs2bq06ePZs2alWn7zThz5ozGjRunzz77TImJiUpPT3dt++abb9SzZ09dunRJcXFxeuKJJ7K86DzDqlWrFBERIafT6fYaPvDAAxo1apTi4uLUuHHjXPXr97//vebNm6ePP/5Yjz32mNLT0/X++++rW7duqlOnTo5te/Tokev3dV6NHTtWCxcu1LRp03TXXXflut20adN0/vx5nTx5UgsWLFC/fv00b9489e/f361edu+RnN47s2fPlqenp+sUZ4Yvv/xSZ8+eVVRUVKZVr65du2ry5Mm6ePGiKlasqLi4OEVERGTa9+bNm/WPf/zDrSwhIcFtDvLyc1u1alXFx8crNTVV33zzjSZPnqyIiAht2rRJNWrUyHY/yBtCEArcgAED9MUXX2js2LFq3ry5/P395XA49OCDD+ry5cuuej/88INq1qyZ475Onz6tgwcPZvrQzJDV9Rg5ybjG47PPPlNISEiurwWqVKmSmjZtmqu6+TlnX758efXr108vv/yy/vvf/+YYDKtUqaKffvopU3nGKaCgoCBXPUnZ1nU4HKpcubIkafjw4WrSpIkeeeQR19fBL126JOnnUJuUlKSAgADXtVqjRo3SqFGjsuxfxpw4nc5MH7ATJ05UYmJiptM3DRs2zPP4svPQQw+pYsWK2rZtW4718iI9PV2dO3dWYmKixo4dq9tvv10VK1ZUenq6WrZs6Xpfnzt3Tmlpabl6X//f//1fgbyvmzVrprZt2+q9997TY489plWrVunw4cOZXuOsBAUFKSAgINfHyq2JEyfqjTfe0Jtvvqlnn302T21/+Q3Jnj176oEHHtDw4cPVr18/lStX7obv6+zeHz/++KNWrlypbt26KSQkxG1bxvu6T58+2fbr7NmzqlixYpa/EA0bNkxOp1Pjx493K//lL0R5fV97enrq7rvvliTde++96tq1q8LDw/XWW29p6tSp2fYTeUMIQoFKSkrSqlWrNH78eL388suu8tTU1EzXaVSrVk3Hjx/PcX9Vq1aVj4+PPvjgg2y358XJkyc1fPhwNW3aVPv27dOoUaP07rvv3rBddr/9ZeXXv/3llvn/1zeVK5fzpXq33367Fi9erOvXr7sFrj179kiSmjRpIkmqW7eufHx8XOW/tGfPHtWrV891vcjevXt15MgRBQYGZqobERGhgIAAnT9/3vV6jxkzJttrEzICjZeXl+s/8QxVqlRRSkpKpvL8jC8nxpgbvo55sXfvXu3evVtz585VVFSUq/zgwYNu9YKCguTh4ZGr9/Udd9yhN998M8vtN1pN/LURI0aob9++2rlzp6ZPn64GDRqoU6dON2w3b948DR48OFfHMLm8/m7ixImaMGGCJkyYoD/+8Y+5apOTe+65R2vXrtUPP/yg4OBg1/zv2bNHDz74oFvdPXv2ZPv+mD9/vq5evZrlBdEZ7+tp06apZcuWWbbPWCH18/PL9P718/NTlSpVbvi+zu5nUbrx+7pmzZpyOp367rvvcqyHvCEEoUA5HA4ZY1z36cjw97//3e20mPTz0v/8+fN14MABt5WAX+revbuio6NVpUqVbE+t5FZaWpr69+8vh8OhNWvWaOHChRo1apQ6dOhww4sNC/J0WFauXbumDz/8UFWrVlW9evVyrPvQQw9p1qxZWrp0qfr16+cqnzdvnpxOp1q0aCHp598ke/TooWXLlmny5Mmue90cPXpUGzdudDtVtGTJkkzfIlq7dq0mTZqkmTNnui5sbdiwoerXr6/du3crOjo6z+PMjdyOLzuffPKJLl26lO2HWX5knKr49fv616stPj4+at++vT7++GO9+eab2Yb07t27a/Xq1apbt26WwTOvHnroIdWqVUsvvvii4uLi9Je//CXHUy8ZCvp02Ouvv64JEybo1VdfzbQqkh/GGMXFxaly5cquFaDQ0FDdc889WrBggUaNGiUPDw9J0rZt23TgwAGNHDkyy33Nnj1bTqczy9Pn9957rypXrqz9+/fneeUqtx566CE988wz2r59u+s9fP36dS1YsEAtWrS44f8bBw8e1PHjx3P80gLyoVivSEKplt2F0e3atTNBQUFm1qxZJjY21rz66qumRo0apnLlym730jh+/LipUaOGqV69upkyZYr54osvzNKlS82TTz5pvvnmG2OMMRcuXDDNmjUzNWvWNH/+859NbGysWbdunZk1a5bp27ev2bZtW677+8orr5hy5cqZzz//3FXWo0cPU7lyZfP999/f3IuRB88//7x59tlnzeLFi83GjRvNP/7xD9O8eXMjycyZM8et7sSJE42Hh4fZtGmTW3mnTp1MYGCg+dvf/mY2bNhgnnzySSPJLFiwwK3eN998YypVqmTatWtnVq9ebZYtW2aaNGlinE5njhfuGpP9BcIbNmww3t7epnPnzmbRokUmLi7OLF++3ERHR5s+ffrkuM/c3Ccot+M7fPiwad26tXn33XfN6tWrzZo1a8zLL79sKlSoYG677TZz4cIFt322b98+Vxf4ZjXuq1evmrp165ratWubRYsWmbVr15rhw4ebBg0aGElm/Pjxrrq7du0ylSpVMrfccour/4sXLzb9+/c3ycnJxpifL/KuXbu2adSokZkxY4b54osvzGeffWbee+89061bN3Ps2LEb9vPXMi76r1ixojl//nye29+sjIu6u3btarZu3Zrp8UtDhgwxHh4e5vDhw66ynj17mrFjx5qlS5eaTZs2mUWLFpnOnTsbSea9995za79x40bj6elpHnroIRMbG2sWLlxowsLCTJMmTcyVK1cy9W3btm1GkvnjH/+Ybf/nz59vypUrZ/r162c+/vhjExcXZz755BMzduxY8/TTT+c49tzcJ+jKlSvmtttuM2FhYWbhwoUmNjbWPPTQQ8bT09Pt53v37t2mY8eOZsaMGWbt2rVm/fr15s9//rOpWbOmqVatmttrhptHCEK+ZReCjh8/bh555BETGBho/Pz8TNeuXc3evXtN7dq1M/1HcezYMTNkyBATEhJiypcvb5xOp3n00Ufdbrx24cIF8+qrr5qGDRsaLy8vExAQYG6//Xbz/PPPu77JdCPr16835cqVc/uwMsaYn376ydSqVcs0b97c7ds1hWn27NnmnnvuMUFBQcbT09MEBgaaLl26mHXr1mWqO378eCPJbNy40a08JSXFjBgxwoSEhBgvLy9zxx13ZPktMGOM2bFjh7nvvvuMr6+v8ff3N7179zYHDx68YT9z+pbU7t27zaOPPmqqV69uypcvb0JCQkzHjh3NzJkzc9xnbkNQbsZ39uxZ89BDD5k6deoYHx8f4+XlZerXr29Gjx6dZQi46667TEhIyA2Pnd249+/fbzp16mT8/PxMYGCg6du3rzl69GimEJRRt2/fvqZKlSrGy8vL1KpVywwaNMjtA/qHH34wI0aMMOHh4aZ8+fImKCjI3HXXXeaVV17JFOBy4/Dhw0bSDT+wC0tGyMzu8UtRUVGZvkk5adIk07x5cxMYGGg8PDxMlSpVTJcuXcyqVauyPN769etNy5YtTYUKFUxQUJCJjIzM8oaNxhjz5JNPGofDYQ4dOpTjGOLi4ky3bt1MUFCQKV++vAkNDTXdunW74TdgcxOCjDHm1KlTJjIy0gQFBZkKFSqYli1bmtjY2Ex1Hn/8cVO3bl3j6+trvLy8zC233GKefvppc/To0RseA3njMCaXJ3oBoJRKSUlRUFCQpkyZouHDhxd3dwrFtGnTNGLECO3duzdP9+UBbMY1QQDKvM2bNys0NDRPNyIsLb7++mslJCTotddeU69evQhAQB6wEoRSLz093e2eLVnhVvMobdLS0nL8RpbD4ZCHh4fq1KmjU6dOqW3btpo/f36mr38DyB4hCKXeoEGDNG/evBzr8DZHadOhQwfFxcVlu7127do6fPhw0XUIKIMIQSj1Dh8+fMOby+V0/w6gJDpw4IBSUlKy3e7t7Z2ru50DyB4hCAAAWIm/Ig8AAKzE1aJZSE9PV2Jiovz8/HJ111UAAFD8jDFKSUmR0+nM1Z/OIQRlITExUWFhYcXdDQAAkA/Hjh274R8ylghBWcr4G0vHjh2Tv79/MfcGAADkRnJyssLCwlyf4zdCCMpCxikwf39/QhAAAKVMbi9l4cJoAABgJUIQAACwEiEIAABYiRAEAACsRAgCAABWIgQBAAArEYIAAICVCEEAAMBKhCAAAGAlQhAAALASIQgAAFiJEAQAAKxECAIAAFYiBAEAACsRggAAgJUIQQAAwEqEIAAAYCVCEAAAsBIhCAAAWIkQBAAArEQIAgAAViIEAQAAKxGCAACAlQhBAADASoQgAABgJUIQAACwEiEIAABYiRAEAACsRAgCAABWIgQBAAArEYIAAICVCEEAAMBKhCAAAGAlQhAAALASIQgAAFiJEAQAAKxECAIAAFYiBAEAACsRggAAgJUIQQAAwEqEIAAAYCVCEAAAsBIhCAAAWKlYQ9DmzZvVo0cPOZ1OORwOffrpp27bjTGaMGGCnE6nfHx81KFDB+3bty/X+1+yZIkcDod69+5dsB0HAAClXrGGoIsXL+rOO+/U9OnTs9w+efJkvfPOO5o+fbri4+MVEhKiTp06KSUl5Yb7PnLkiEaNGqW2bdsWdLcBAEAZ4FmcB3/ggQf0wAMPZLnNGKMpU6bolVde0cMPPyxJmjdvnoKDg7Vo0SINGzYs2/2mpaXpscce08SJE/XPf/5T58+fL4zuAwCAUqzEXhOUkJCgU6dOqXPnzq4yb29vtW/fXl9++WWObV977TVVq1ZNTzzxRGF3EwAAlFLFuhKUk1OnTkmSgoOD3cqDg4N15MiRbNv961//0uzZs7Vr165cHys1NVWpqamu58nJyXnrLAAAKHVK7EpQBofD4fbcGJOpLENKSooef/xxzZo1S1WrVs31MWJiYhQQEOB6hIWF3VSfAQBAyVdiV4JCQkIk/bwiVKNGDVf5mTNnMq0OZTh06JAOHz6sHj16uMrS09MlSZ6enjpw4IDq1q2bqd2YMWP0wgsvuJ4nJycThAAAKONKbAgKDw9XSEiIYmNj1axZM0nS1atXFRcXp0mTJmXZplGjRtqzZ49b2auvvqqUlBRNnTo122Dj7e0tb2/vgh0AAAAo0Yo1BF24cEEHDx50PU9ISNCuXbsUFBSkWrVqaeTIkYqOjlb9+vVVv359RUdHy9fXVwMGDHC1iYyMVGhoqGJiYlShQgU1adLE7RiVK1eWpEzlAADAbsUagnbs2KGIiAjX84xTUlFRUZo7d65Gjx6ty5cv65lnntG5c+fUokULrV+/Xn5+fq42R48eVblyJf7SJgAAUMI4jDGmuDtR0iQnJysgIEBJSUny9/cv7u4AAIBcyOvnN0soAADASoQgAABgJUIQAACwEiEIAABYiRAEAACsRAgCAABWIgQBAAArEYIAAICVCEEAAMBKhCAAAGAlQhAAALASIQgAAFiJEAQAAKxECAIAAFYiBAEAACsRggAAgJUIQQAAwEqEIAAAYCVCEAAAsBIhCAAAWIkQBAAArEQIAgAAViIEAQAAKxGCAACAlQhBAADASoQgAABgJUIQAACwEiEIAABYiRAEAACsRAgCAABWIgQBAAArEYIAAICVCEEAAMBKhCAAAGAlQhAAALASIQgAAFiJEAQAAKxECAIAAFYiBAEAACsRggAAgJUIQQAAwEqEIAAAYCVCEAAAsBIhCAAAWIkQBAAArEQIAgAAViIEAQAAKxGCAACAlQhBAADASoQgAABgJUIQAACwEiEIAABYiRAEAACsRAgCAABWIgQBAAArEYIAAICVijUEbd68WT169JDT6ZTD4dCnn37qtt0YowkTJsjpdMrHx0cdOnTQvn37ctznrFmz1LZtWwUGBiowMFD333+/vvrqq0IcBQAAKI2KNQRdvHhRd955p6ZPn57l9smTJ+udd97R9OnTFR8fr5CQEHXq1EkpKSnZ7nPTpk3q37+/Nm7cqK1bt6pWrVrq3LmzTpw4UVjDAAAApZDDGGOKuxOS5HA4tHz5cvXu3VvSz6tATqdTI0eO1EsvvSRJSk1NVXBwsCZNmqRhw4blar9paWkKDAzU9OnTFRkZmas2ycnJCggIUFJSkvz9/fM1HgAAULTy+vldYq8JSkhI0KlTp9S5c2dXmbe3t9q3b68vv/wy1/u5dOmSrl27pqCgoMLoJgAAKKU8i7sD2Tl16pQkKTg42K08ODhYR44cyfV+Xn75ZYWGhur+++/Ptk5qaqpSU1Ndz5OTk/PYWwAAUNqU2JWgDA6Hw+25MSZTWXYmT56sxYsXa9myZapQoUK29WJiYhQQEOB6hIWF3VSfAQBAyVdiQ1BISIik/60IZThz5kym1aGsvP3224qOjtb69et1xx135Fh3zJgxSkpKcj2OHTuW/44DAIBSocSGoPDwcIWEhCg2NtZVdvXqVcXFxal169Y5tv3Tn/6k119/XWvXrtXdd999w2N5e3vL39/f7QEAAMq2Yr0m6MKFCzp48KDreUJCgnbt2qWgoCDVqlVLI0eOVHR0tOrXr6/69esrOjpavr6+GjBggKtNZGSkQkNDFRMTI+nnU2Bjx47VokWLVKdOHddKUqVKlVSpUqWiHSAAACixijUE7dixQxEREa7nL7zwgiQpKipKc+fO1ejRo3X58mU988wzOnfunFq0aKH169fLz8/P1ebo0aMqV+5/C1ozZszQ1atX1adPH7djjR8/XhMmTCjcAQEAgFKjxNwnqCThPkEAAJQ+ZeY+QQAAAIWJEAQAAKxECAIAAFYiBAEAACsRggAAgJUIQQAAwEqEIAAAYCVCEAAAsBIhCAAAWIkQBAAArEQIAgAAViIEAQAAKxGCAACAlQhBAADASoQgAABgJUIQAACwEiEIAABYiRAEAACsRAgCAABWIgQBAAArEYIAAICVCEEAAMBKhCAAAGAlQhAAALASIQgAAFiJEAQAAKxECAIAAFYiBAEAACsRggAAgJUIQQAAwEqEIAAAYCVCEAAAsBIhCAAAWIkQBAAArEQIAgAAViIEAQAAKxGCAACAlQhBAADASoQgAABgJUIQAACwEiEIAABYiRAEAACsRAgCAABWIgQBAAArEYIAAICVCEEAAMBKhCAAAGAlQhAAALASIQgAAFiJEAQAAKxECAIAAFYiBAEAACsRggAAgJUIQQAAwEqe+WmUlpam5cuX65tvvpHD4VCjRo3Uu3dveXrma3cAAABFLs+pZe/everVq5dOnTqlhg0bSpK+++47VatWTStXrtTtt99e4J0EAAAoaHk+HTZ06FDddtttOn78uHbu3KmdO3fq2LFjuuOOO/TUU08VRh8BAAAKXJ5D0O7duxUTE6PAwEBXWWBgoN58803t2rUrT/vavHmzevToIafTKYfDoU8//dRtuzFGEyZMkNPplI+Pjzp06KB9+/bdcL9Lly5V48aN5e3trcaNG2v58uV56hcAACj78hyCGjZsqNOnT2cqP3PmjOrVq5enfV28eFF33nmnpk+fnuX2yZMn65133tH06dMVHx+vkJAQderUSSkpKdnuc+vWrerXr58GDhyo3bt3a+DAgXr00Ue1ffv2PPUNAACUbQ5jjMlLg9WrV2v06NGaMGGCWrZsKUnatm2bXnvtNb311ltq06aNq66/v3/uO+JwaPny5erdu7ekn1eBnE6nRo4cqZdeekmSlJqaquDgYE2aNEnDhg3Lcj/9+vVTcnKy1qxZ4yrr2rWrAgMDtXjx4lz1JTk5WQEBAUpKSsrTGAAAQPHJ6+d3ni+M7t69uyTp0UcflcPhkPRzYJGkHj16uJ47HA6lpaXldfcuCQkJOnXqlDp37uwq8/b2Vvv27fXll19mG4K2bt2q559/3q2sS5cumjJlSrbHSk1NVWpqqut5cnJyvvsNAABKhzyHoI0bN2a7befOnfrNb35zUx3KcOrUKUlScHCwW3lwcLCOHDmSY7us2mTsLysxMTGaOHHiTfQWAACUNnkOQe3bt3d7npSUpIULF+rvf/+7du/efVOrP1nJWG3KkLHKVJBtxowZoxdeeMH1PDk5WWFhYfnoLQAAKC3yfcfoDRs26PHHH1eNGjU0bdo0Pfjgg9qxY0eBdSwkJESSMq3gnDlzJtNKz6/b5bWNt7e3/P393R4AAKBsy1MIOn78uN544w3dcsst6t+/vwIDA3Xt2jUtXbpUb7zxhpo1a1ZgHQsPD1dISIhiY2NdZVevXlVcXJxat26dbbtWrVq5tZGk9evX59gGAADYJ9enwx588EFt2bJF3bt317Rp09S1a1d5eHho5syZ+T74hQsXdPDgQdfzhIQE7dq1S0FBQapVq5ZGjhyp6Oho1a9fX/Xr11d0dLR8fX01YMAAV5vIyEiFhoYqJiZGkvT73/9e7dq106RJk9SrVy+tWLFCn3/+ubZs2ZLvfgIAgLIn1yFo/fr1GjFihH73u9+pfv36BXLwHTt2KCIiwvU847qcqKgozZ07V6NHj9bly5f1zDPP6Ny5c2rRooXWr18vPz8/V5ujR4+qXLn/LWi1bt1aS5Ys0auvvqqxY8eqbt26+vDDD9WiRYsC6TMAACgbcn2foK1bt+qDDz7QRx99pEaNGmngwIHq16+fnE6ndu/ercaNGxd2X4sM9wkCAKD0yevnd66vCWrVqpVmzZqlkydPatiwYVqyZIlCQ0OVnp6u2NjYHO/iDAAAUNLk+Y7Rv3TgwAHNnj1b8+fP1/nz59WpUyetXLmyIPtXLFgJAgCg9Cm0laCsNGzYUJMnT9bx48dz/ScpAAAASoKbWgkqq1gJAgCg9CnSlSAAAIDSihAEAACsRAgCAABWIgQBAAArEYIAAICVCEEAAMBKhCAAAGAlQhAAALASIQgAAFiJEAQAAKxECAIAAFYiBAEAACsRggAAgJUIQQAAwEqEIAAAYCVCEAAAsBIhCAAAWIkQBAAArEQIAgAAViIEAQAAKxGCAACAlQhBAADASoQgAABgJUIQAACwEiEIAABYiRAEAACsRAgCAABWIgQBAAArEYIAAICVCEEAAMBKhCAAAGAlQhAAALASIQgAAFiJEAQAAKxECAIAAFYiBAEAACsRggAAgJUIQQAAwEqEIAAAYCVCEAAAsBIhCAAAWIkQBAAArEQIAgAAViIEAQAAKxGCAACAlQhBAADASoQgAABgJUIQAACwEiEIAABYiRAEAACsRAgCAABWIgQBAAArlfgQlJKSopEjR6p27dry8fFR69atFR8fn2ObhQsX6s4775Svr69q1KihwYMH66effiqiHgMAgNKgxIegoUOHKjY2VvPnz9eePXvUuXNn3X///Tpx4kSW9bds2aLIyEg98cQT2rdvnz7++GPFx8dr6NChRdxzAABQkpXoEHT58mUtXbpUkydPVrt27VSvXj1NmDBB4eHhev/997Nss23bNtWpU0cjRoxQeHi42rRpo2HDhmnHjh1F3HsAAFCSlegQdP36daWlpalChQpu5T4+PtqyZUuWbVq3bq3jx49r9erVMsbo9OnT+uSTT9StW7dsj5Oamqrk5GS3BwAAKNtKdAjy8/NTq1at9PrrrysxMVFpaWlasGCBtm/frpMnT2bZpnXr1lq4cKH69esnLy8vhYSEqHLlypo2bVq2x4mJiVFAQIDrERYWVlhDAgAAJUSJDkGSNH/+fBljFBoaKm9vb7377rsaMGCAPDw8sqy/f/9+jRgxQuPGjdO///1vrV27VgkJCXr66aezPcaYMWOUlJTkehw7dqywhgMAAEoIhzHGFHcncuPixYtKTk5WjRo11K9fP124cEGfffZZpnoDBw7UlStX9PHHH7vKtmzZorZt2yoxMVE1atS44bGSk5MVEBCgpKQk+fv7F+g4AABA4cjr53eJXwnKULFiRdWoUUPnzp3TunXr1KtXryzrXbp0SeXKuQ8rY9WolOQ9AABQBEp8CFq3bp3rlFZsbKwiIiLUsGFDDR48WNLPp7IiIyNd9Xv06KFly5bp/fff1/fff69//etfGjFihO655x45nc7iGgYAAChhPIu7AzeSlJSkMWPG6Pjx4woKCtIjjzyiN998U+XLl5cknTx5UkePHnXVHzRokFJSUjR9+nS9+OKLqly5sjp27KhJkyYV1xAAAEAJVGquCSpKXBMEAEDpU2avCQIAAChIhCAAAGAlQhAAALASIQgAAFiJEAQAAKxECAIAAFYiBAEAACsRggAAgJUIQQAAwEqEIAAAYCVCEAAAsBIhCAAAWIkQBAAArEQIAgAAViIEAQAAKxGCAACAlQhBAADASoQgAABgJUIQAACwEiEIAABYiRAEAACsRAgCAABWIgQBAAArEYIAAICVCEEAAMBKhCAAAGAlQhAAALASIQgAAFiJEAQAAKxECAIAAFYiBAEAACsRggAAgJUIQQAAwEqEIAAAYCVCEAAAsBIhCAAAWIkQBAAArEQIAgAAViIEAQAAKxGCAACAlQhBAADASoQgAABgJUIQAACwEiEIAABYiRAEAACsRAgCAABWIgQBAAArEYIAAICVCEEAAMBKhCAAAGAlQhAAALASIQgAAFiJEAQAAKxECAIAAFYiBAEAACsRggAAgJVKfAhKSUnRyJEjVbt2bfn4+Kh169aKj4/PsU1qaqpeeeUV1a5dW97e3qpbt64++OCDIuoxAAAoDTyLuwM3MnToUO3du1fz58+X0+nUggULdP/992v//v0KDQ3Nss2jjz6q06dPa/bs2apXr57OnDmj69evF3HPAQBASeYwxpji7kR2Ll++LD8/P61YsULdunVzlTdt2lTdu3fXG2+8kanN2rVr9dvf/lbff/+9goKC8nXc5ORkBQQEKCkpSf7+/vnuPwAAKDp5/fwu0afDrl+/rrS0NFWoUMGt3MfHR1u2bMmyzcqVK3X33Xdr8uTJCg0NVYMGDTRq1Chdvnw52+OkpqYqOTnZ7QEAAMq2Eh2C/Pz81KpVK73++utKTExUWlqaFixYoO3bt+vkyZNZtvn++++1ZcsW7d27V8uXL9eUKVP0ySefaPjw4dkeJyYmRgEBAa5HWFhYYQ0JAACUECX6dJgkHTp0SEOGDNHmzZvl4eGh3/zmN2rQoIF27typ/fv3Z6rfuXNn/fOf/9SpU6cUEBAgSVq2bJn69OmjixcvysfHJ1Ob1NRUpaamup4nJycrLCyM02EAAJQiZep0mCTVrVtXcXFxunDhgo4dO6avvvpK165dU3h4eJb1a9SoodDQUFcAkqRbb71VxhgdP348yzbe3t7y9/d3ewAAgLKtxIegDBUrVlSNGjV07tw5rVu3Tr169cqy3r333qvExERduHDBVfbdd9+pXLlyqlmzZlF1FwAAlHAlPgStW7dOa9euVUJCgmJjYxUREaGGDRtq8ODBkqQxY8YoMjLSVX/AgAGqUqWKBg8erP3792vz5s36wx/+oCFDhmR5KgwAANipxIegpKQkDR8+XI0aNVJkZKTatGmj9evXq3z58pKkkydP6ujRo676lSpVUmxsrM6fP6+7775bjz32mHr06KF33323uIYAAABKoBJ/YXRx4D5BAACUPmXuwmgAAIDCQAgCAABWIgQBAAArEYIAAICVCEEAAMBKhCAAAGAlQhAAALASIQgAAFiJEAQAAKxECAIAAFYiBAEAACsRggAAgJUIQQAAwEqEIAAAYCVCEAAAsBIhCAAAWIkQBAAArEQIAgAAViIEAQAAKxGCAACAlQhBAADASoQgAABgJUIQAACwEiEIAABYiRAEAACsRAgCAABWIgQBAAArEYIAAICVCEEAAMBKhCAAAGAlQhAAALASIQgAAFiJEAQAAKxECAIAAFYiBAEAACsRggAAgJUIQQAAwEqEIAAAYCVCEAAAsBIhCAAAWIkQBAAArEQIAgAAViIEAQAAK3kWdwdKImOMJCk5ObmYewIAAHIr43M743P8RghBWUhJSZEkhYWFFXNPAABAXqWkpCggIOCG9Rwmt3HJIunp6UpMTJSfn58cDkdxd8clOTlZYWFhOnbsmPz9/Yu7O4WirI+xrI9PKttjLMtjy1DWx1jWxyeV/THmND5jjFJSUuR0OlWu3I2v+GElKAvlypVTzZo1i7sb2fL39y+Tb+xfKutjLOvjk8r2GMvy2DKU9TGW9fFJZX+M2Y0vNytAGbgwGgAAWIkQBAAArEQIKkW8vb01fvx4eXt7F3dXCk1ZH2NZH59UtsdYlseWoayPsayPTyr7YyzI8XFhNAAAsBIrQQAAwEqEIAAAYCVCEAAAsBIhqAxwOBz69NNPi7sbuAnMYenG/JV+zGHpl585JASVQIMGDVLv3r2Luxv5EhMTo+bNm8vPz0/Vq1dX7969deDAAbc6xhhNmDBBTqdTPj4+6tChg/bt2+fafvbsWT333HNq2LChfH19VatWLY0YMUJJSUlu+3nzzTfVunVr+fr6qnLlykUxvFxjDm88h4cPH9YTTzyh8PBw+fj4qG7duho/fryuXr1aZGPNDvOXu5/Bnj17qlatWqpQoYJq1KihgQMHKjExsUjGeSPMYe7mMENqaqqaNm0qh8OhXbt2Febwcq0o5pAQhAIVFxen4cOHa9u2bYqNjdX169fVuXNnXbx40VVn8uTJeueddzR9+nTFx8crJCREnTp1cv3NtsTERCUmJurtt9/Wnj17NHfuXK1du1ZPPPGE27GuXr2qvn376ne/+12RjrGsK6o5/Pbbb5Wenq6//vWv2rdvn/7yl79o5syZ+uMf/1jkYy5LivJnMCIiQh999JEOHDigpUuX6tChQ+rTp0+RjrcsKso5zDB69Gg5nc4iGV+JYlDiREVFmV69ehljjKldu7b5y1/+4rb9zjvvNOPHj3c9l2SWL19eZP3LizNnzhhJJi4uzhhjTHp6ugkJCTFvvfWWq86VK1dMQECAmTlzZrb7+eijj4yXl5e5du1apm1z5swxAQEBBd73m8EcZpbTHGaYPHmyCQ8PL7jO5xPzl1lu5m/FihXG4XCYq1evFtwA8ok5zCy7OVy9erVp1KiR2bdvn5Fkvv7660IZR14VxRyyEoRClbH0GhQUJElKSEjQqVOn1LlzZ1cdb29vtW/fXl9++WWO+/H395enJ3/urqgV5RwmJSW5joOCUVTzd/bsWS1cuFCtW7dW+fLlC3AEKMw5PH36tJ588knNnz9fvr6+hTSCkosQhEJjjNELL7ygNm3aqEmTJpKkU6dOSZKCg4Pd6gYHB7u2/dpPP/2k119/XcOGDSvcDiOTopzDQ4cOadq0aXr66acLqPcoivl76aWXVLFiRVWpUkVHjx7VihUrCngUdivMOTTGaNCgQXr66ad19913F9IISjZCEArNs88+q//85z9avHhxpm0Oh8PtuTEmU5kkJScnq1u3bmrcuLHGjx9faH1F1opqDhMTE9W1a1f17dtXQ4cOLZjOo0jm7w9/+IO+/vprrV+/Xh4eHoqMjJThDxEUmMKcw2nTpik5OVljxowp+I6XEoSgEq5cuXKZ/kO5du1aMfUm95577jmtXLlSGzduVM2aNV3lISEhkpTpt5UzZ85k+q0mJSVFXbt2VaVKlbR8+fJSu8TOHOY8h4mJiYqIiFCrVq30t7/9rRBGcnOYv5znr2rVqmrQoIE6deqkJUuWaPXq1dq2bVshjCj/mMOs53DDhg3atm2bvL295enpqXr16kmS7r77bkVFRRXWsPKlsOaQEFTCVatWTSdPnnQ9T05OVkJCQjH2KGfGGD377LNatmyZNmzYoPDwcLft4eHhCgkJUWxsrKvs6tWriouLU+vWrV1lycnJ6ty5s7y8vLRy5UpVqFChyMZQ0JjD7OfwxIkT6tChg37zm99ozpw5Kleu5P2XxPzl/mcw40MqNTW1gEZTMJjDrOfw3Xff1e7du7Vr1y7t2rVLq1evliR9+OGHevPNNwtxhHlXWHPIVaYlXMeOHTV37lz16NFDgYGBGjt2rDw8PIq7W9kaPny4Fi1apBUrVsjPz8/1m0pAQIB8fHzkcDg0cuRIRUdHq379+qpfv76io6Pl6+urAQMGSPr5N5fOnTvr0qVLWrBggZKTk5WcnCzp5x+EjPEfPXpUZ8+e1dGjR5WWlua6t0W9evVUqVKloh98NpjDrOcwMTFRHTp0UK1atfT222/rhx9+cPUh4zfdkoD5y3r+vvrqK3311Vdq06aNAgMD9f3332vcuHGqW7euWrVqVWzjzwpzmPUc1qpVy+24Gf9v1q1b123lqSQotDnM03fJUCQGDhxoHnnkEWOMMUlJSebRRx81/v7+JiwszMydO7dEf7VTUpaPOXPmuOqkp6eb8ePHm5CQEOPt7W3atWtn9uzZ49q+cePGbPeTkJDgqhcVFZVlnY0bNxbdgLPBHN54DufMmZNtneLG/N14/v7zn/+YiIgIExQUZLy9vU2dOnXM008/bY4fP17EI84ac5i7/0d/KSEhoUR9Rb4o5tDx/xuiBOnatavq1aun6dOnF3dXkE/MYenG/JV+zGHpVxRzWPJOwFvs3Llz+uyzz7Rp0ybdf//9xd0d5ANzWLoxf6Ufc1j6FeUcck1QCTJkyBDFx8frxRdfVK9evYq7O8gH5rB0Y/5KP+aw9CvKOeR0GAAAsBKnwwAAgJUIQQAAwEqEIAAAYCVCEAAAsBIhCECZsWnTJjkcDp0/f764uwKgFODbYQBKrQ4dOqhp06aaMmWKpJ//ftLZs2cVHByc5V/TBoBf4j5BAMoMLy+vEvV3xwCUbJwOA1AqDRo0SHFxcZo6daocDoccDofmzp3rdjps7ty5qly5slatWqWGDRvK19dXffr00cWLFzVv3jzVqVNHgYGBeu6555SWluba99WrVzV69GiFhoaqYsWKatGihTZt2lQ8AwVQaFgJAlAqTZ06Vd99952aNGmi1157TZK0b9++TPUuXbqkd999V0uWLFFKSooefvhhPfzww6pcubJWr16t77//Xo888ojatGmjfv36SZIGDx6sw4cPa8mSJXI6nVq+fLm6du2qPXv2qH79+kU6TgCFhxAEoFQKCAiQl5eXfH19XafAvv3220z1rl27pvfff19169aVJPXp00fz58/X6dOnValSJTVu3FgRERHauHGj+vXrp0OHDmnx4sU6fvy4nE6nJGnUqFFau3at5syZo+jo6KIbJIBCRQgCUKb5+vq6ApAkBQcHq06dOqpUqZJb2ZkzZyRJO3fulDFGDRo0cNtPamqqqlSpUjSdBlAkCEEAyrTy5cu7PXc4HFmWpaenS5LS09Pl4eGhf//73/Lw8HCr98vgBKD0IwQBKLW8vLzcLmguCM2aNVNaWprOnDmjtm3bFui+AZQsfDsMQKlVp04dbd++XYcPH9aPP/7oWs25GQ0aNNBjjz2myMhILVu2TAkJCYqPj9ekSZO0evXqAug1gJKCEASg1Bo1apQ8PDzUuHFjVatWTUePHi2Q/c6ZM0eRkZF68cUX1bBhQ/Xs2VPbt29XWFhYgewfQMnAHaMBAICVWAkCAABWIgQBAAArEYIAAICVCEEAAMBKhCAAAGAlQhAAALASIQgAAFiJEAQAAKxECAIAAFYiBAEAACsRggAAgJUIQQAAwEr/D0MgF1H/xm0uAAAAAElFTkSuQmCC",
+      "text/plain": [
+       "<Figure size 640x480 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "transport_model.mesh.Ap.isel(nface=207, time=slice(0, 5000)).plot()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 42,
+   "id": "d6648856",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[<matplotlib.lines.Line2D at 0x1c25c7e8310>]"
+      ]
+     },
+     "execution_count": 42,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAjgAAAHFCAYAAAD/kYOsAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjguNCwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8fJSN1AAAACXBIWXMAAA9hAAAPYQGoP6dpAABAjElEQVR4nO3de3zP9f//8ft7Rxs25jzG5pxRfEsi5VAOOVZIU9kM6ZvSSbFPDlEMSUnk8+mjGXNK0UGU80pR5BAKKTPZWCV7r9TY9vz90c/7690O3mPbe3t1u14u78vF+/V6Pl+vx3PPt73vex3eb5sxxggAAMBCPNxdAAAAQFEj4AAAAMsh4AAAAMsh4AAAAMsh4AAAAMsh4AAAAMsh4AAAAMsh4AAAAMsh4AAAAMsh4CBfK1asUHh4uPz8/GSz2bR37153l1TqJSUlyWaz5flYvny5S9v47bff9Pjjjys4OFjlypVTy5Yt8+27e/du3X777apQoYIqVaqku+++Wz/88EOB2//mm2/k6+srm82mXbt2FXqMV8vV8UVFReX5c2zatOlV7X/OnDlq2LChfHx8ZLPZdPbs2ava3j/B5s2bFR0draZNm6p8+fKqXbu2+vbtq6+++sql/hs3blSXLl0UHBwsX19fVa9eXZ07d9batWvzbd+2bVv5+/uratWqioqKUlpamlOb5557Lt//a4X5/1ZU0tLSFBUVpapVq8rf319t27bVpk2bcrV79tln1apVKwUFBalcuXKqX7++HnzwQR0/frxE6/0n8HJ3ASidfvrpJz3wwAPq3r275s2bJ19fXzVu3NjdZZUZjz76qAYNGuS0rFGjRi71vfvuu7Vz505NmzZNjRs31tKlSxUREaGcnBynbR46dEgdO3ZUy5Yt9dZbb+nPP//UhAkTdMstt2jv3r2qVq1arm1nZ2crOjpaVatWVUpKytUN8gq5Oj5J8vPz0+bNm3Mtu1J79+7VqFGjNGzYMEVGRsrLy0sVK1a84u39U7z++uv65Zdf9Nhjj6lZs2b66aef9NJLL+mmm27Sxx9/rM6dOxfY/5dfflF4eLiGDRummjVr6syZM5o/f7569uypxYsX6/7773e0TUxM1B133KGePXvqvffeU1pamsaMGaPbbrtNu3btkq+vryRp2LBh6t69e659DR8+XN9//32e64pLZmambrvtNp09e1azZ89W9erVNXfuXHXv3l0bN25Uhw4dHG3Pnj2riIgIXXPNNapYsaK++eYbvfDCC3r//fd18OBBValSpcTqtjwD5GHbtm1GklmxYoW7SylTjh07ZiSZF1988Yr6f/jhh0aSWbp0qdPyLl26mODgYJOVleVYNmDAAFO1alWTnp7uWJaUlGS8vb3NM888k+f2X3zxRVO7dm0ze/ZsI8ns3LnziurMS2RkpOnQoUOBbQozvsjISFO+fPkiq88YYxISEowk88UXXxTpdq3u9OnTuZZlZGSYGjVqmNtuu+2Ktnn+/HlTu3Ztc8sttzgtb926tWnWrJm5cOGCY9lnn31mJJl58+YVuM1jx44Zm81m7r///iuqKS8dOnQwkZGRBbaZO3eukWQ+//xzx7ILFy6YZs2amRtvvPGy+1i7dq2RZBYsWHC15eISnKJCLlFRUWrfvr0kaeDAgbLZbOrYsaMkadeuXbr33nsVGhoqPz8/hYaGKiIiIs/DqydPntSDDz6okJAQ+fj4KDg4WP3799fp06cdbex2u0aPHq2wsDD5+Piodu3aevzxx/X777+7XO/PP/+skJAQtWvXThcuXHAs/+abb1S+fHk98MADV/iTKHmrV69WhQoVNGDAAKflQ4YMUUpKir744gtJUlZWltasWaN+/fopICDA0a5evXrq1KmTVq9enWvb3333nSZMmKB58+Y59fm7Xbt2qU+fPo5D6K1atdJbb71VouMrDh07dnQcKWjTpo1sNpuioqIkSRs2bFDfvn1Vp04dlStXTg0bNtSIESP0888/59rOoUOHFBERoRo1asjX11d169bV4MGDlZmZ6Whz6tQpjRgxQnXq1JGPj4/CwsI0adIkZWVluVzv888/Ly8vL504cSLXuujoaFWpUkV//vlnIX8KV6Z69eq5llWoUEHNmjXLsz5XeHt7q1KlSvLy+r8TCSdPntTOnTv1wAMPOC1v166dGjdunOfr+lJvvvmmjDEaNmxYrnUbN27UbbfdpoCAAPn7++vmm2/O8xTSlVi9erWaNGmitm3bOpZ5eXnp/vvv15dffqmTJ08W2P/i0dZLx4yrR8BBLuPHj9fcuXMlSVOnTtX27ds1b948SX9dY9KkSRO98sor+vjjjzV9+nSlpqaqdevWTm8GJ0+eVOvWrbV69Wo9+eSTWrdunV555RUFBgbq119/lSSdO3dOHTp0UHx8vEaNGqV169ZpzJgxWrhwofr06SPj4hfdV61aVcuXL9fOnTs1ZswYx7YHDBigunXrav78+QX2N8YoKyvLpYerpk2bJh8fH/n7+6t9+/Z6//33Xep34MABXXPNNbl+0V177bWO9ZL0/fff648//nAs/3vbo0ePOr35Xfyl36tXL/Xp0yff/W/ZskU333yzzp49q/nz5+u9995Ty5YtNXDgQC1cuNClMRTF+C76448/VLNmTXl6eqpOnTp65JFHdObMmSva97x58zRu3DhJUlxcnLZv367x48dL+uvn2bZtW73++utav369JkyYoC+++ELt27d3Cs379u1T69attWPHDk2ePFnr1q1TbGysMjMzdf78eUl/hZsbb7xRH3/8sSZMmKB169Zp6NChio2N1fDhw12ud8SIEfLy8tK///1vp+VnzpzR8uXLNXToUJUrVy7f/sXxur5Uenq6du/erfDwcJf75OTkKCsrSykpKZo4caKOHDmip556yrH+4vzn97r+++vj79teuHChGjZs6HRKSJISEhLUtWtXBQQEKD4+Xm+99ZaCgoLUrVu3Igk5Bw4cyLdmSTp48GCudVlZWfrjjz+0Z88ePf7442rcuLHuvvvuq64Fl3Dr8SOUWlu2bDGSzMqVKwtsl5WVZX777TdTvnx5M3v2bMfy6Oho4+3tbb755pt8+8bGxhoPD49cp0nefvttI8msXbu2UDVPnz7dSDKrV682kZGRxs/Pz3z99deX7XdxrK48jh07VuC2UlJSzPDhw81bb71lPv30U7NkyRJz0003GUnmjTfeuGwtjRo1Mt26dctzu5LM1KlTjTH/d8h+2bJludpOnTrVSDIpKSmOZXPmzDGVK1c2p06dMsYYExcXl+cpqqZNm5pWrVo5nR4wxphevXqZWrVqmezsbMeyCxcuOD0GDx5sbr311lzLc3JyCj0+Y4yZNWuWmTVrllm/fr1Zv369efbZZ42/v79p2rSpycjIKPDnmJ/8xn2pnJwcc+HCBXP8+HEjybz33nuOdZ07dzaVKlUyaWlp+fYfMWKEqVChgjl+/LjT8pkzZxpJ5uDBgy7XGxkZaapXr24yMzMdy6ZPn248PDwu+1q8OFZXHlfivvvuM15eXmbXrl0u9+nWrZtjnwEBAWbVqlVO65csWWIkme3bt+fq++CDDxofH598t71u3TojycTGxjot//33301QUJDp3bu30/Ls7Gxz3XXXOZ1Cujj3lz5uvfVWM3jw4FzLL+Xt7W1GjBiRq6bPP/88z1OyqampTj//Nm3amJMnT+Y7NlwZjoehUH777Tc9//zzeuedd5SUlKTs7GzHum+//dbx73Xr1qlTp0665ppr8t3WmjVr1Lx5c7Vs2dLpr8hu3brJZrNp69atuuOOO1yu7emnn9Ynn3yiiIgI/fnnn/rvf/+rFi1aXLbf9ddfr507d7q0j+Dg4ALX16pVS//5z3+clg0YMEBt2rTR2LFjFRUVddnD0DabzeV1rrQ9fvy4YmJi9Morr6hGjRr5tj969KgOHTqkmTNnSpLTnPTo0UNr1qzR4cOHdc011ygpKUlhYWF5bsfb29vp+ZYtWxynOF2tWZKeeOIJp3VdunRRq1at1L9/f73xxhu51l+NtLQ0TZgwQR9++KFSUlKUk5PjWPftt9+qT58+OnfunBITEzV06NA8L+C+aM2aNerUqZOCg4OdfoZ33HGHRo8ercTERDVr1syluh577DHFx8dr5cqVuu+++5STk6PXX39dPXv2VGhoaIF9e/fu7fLrurDGjx+vJUuWaM6cObr++utd7jdnzhydPXtWqampSkhI0MCBAxUfH6+IiAindvm9Rgp67SxYsEBeXl6O044Xff755zpz5owiIyNzHa3q3r27ZsyYod9//13ly5dXYmKiOnXqlGvbn3zyiRYtWuS07NixY05zUJj/t1WrVtXOnTuVmZmpb7/9VjNmzFCnTp20detW1apVK9/toHAIOCiUQYMGadOmTRo/frxat26tgIAA2Ww29ejRQ3/88Yej3U8//aQ6deoUuK3Tp0/r6NGjud4QL8rr+oeCXLym4sMPP1TNmjVdvvamQoUKatmypUttr+Qcube3twYOHKixY8fqu+++KzD0ValSRb/88kuu5RdPywQFBTnaScq3rc1mU6VKlSRJI0eOVPPmzdWvXz/HLdHnzp2T9FdgTU9PV2BgoOPaqNGjR2v06NF51ndxToKDg3O9eU6aNEkpKSm5Tqk0adKk0OPLz1133aXy5ctrx44dBbYrjJycHHXt2lUpKSkaP368WrRoofLlyysnJ0c33XST43X966+/Kjs726XX9QcffFAkr+tWrVrplltu0dy5c3XfffdpzZo1SkpKyvUzzktQUJACAwNd3perJk2apBdeeEFTpkzRI488Uqi+l95J2KdPH91xxx0aOXKkBg4cKA8Pj8u+rvN7ffz88896//331bNnT9WsWdNp3cXXdf/+/fOt68yZMypfvnyef+yMGDFCwcHBmjhxotPyS//YKezr2svLSzfccIMk6eabb1b37t0VFhamadOmafbs2fnWicIh4MBl6enpWrNmjSZOnKixY8c6lmdmZua6LqJatWr68ccfC9xe1apV5efnpzfffDPf9YWRmpqqkSNHqmXLljp48KBGjx6tV1999bL98vurLS9//6vNVeb/X0/k4VHwZW8tWrTQsmXLlJWV5RSm9u/fL0lq3ry5JKlBgwby8/NzLL/U/v371bBhQ8f1GQcOHNDx48dVuXLlXG07deqkwMBAnT171vHzjomJyfdagIthxcfHx/EL+qIqVaooIyMj1/IrGV9BjDGX/TkWxoEDB7Rv3z4tXLhQkZGRjuVHjx51ahcUFCRPT0+XXtfXXnutpkyZkuf6yx0F/LtRo0ZpwIAB2r17t1577TU1btxYXbp0uWy/+Ph4DRkyxKV9GBevd5s0aZKee+45Pffcc/rXv/7lUp+C3Hjjjfroo4/0008/qUaNGo75379/v3r06OHUdv/+/fm+PhYvXqzz58/neXHxxdf1nDlzdNNNN+XZ/+KRzYoVK+Z6/VasWFFVqlS57Os6v/+L0uVf13Xq1FFwcLCOHDlSYDsUDgEHLrPZbDLGOD6H4qL//ve/TqeqpL8Oxy9evFiHDx92+gv+Ur169dLUqVNVpUqVfE93uCo7O1sRERGy2Wxat26dlixZotGjR6tjx46XvXCvKE9R5eXChQtasWKFqlatqoYNGxbY9q677tIbb7yhd955RwMHDnQsj4+PV3BwsNq0aSPpr78Ae/furVWrVmnGjBmOz3JJTk7Wli1bnE7fLF++PNfdNh999JGmT5+u+fPnOy4SbdKkiRo1aqR9+/Zp6tSphR6nK1wdX37efvttnTt3Lt83qitx8fTB31/Xfz9K4ufnpw4dOmjlypWaMmVKvgG8V69eWrt2rRo0aJBnqCysu+66S3Xr1tVTTz2lxMREvfzyywWeDrmoqE9RPf/883ruuec0bty4XEczroQxRomJiapUqZLjyE3t2rV14403KiEhQaNHj5anp6ckaceOHTp8+LAef/zxPLe1YMECBQcH53lK++abb1alSpX0zTffFPqIk6vuuusuPfzww/riiy8cr+GsrCwlJCSoTZs2l/29cfToUf34448F3gCAK+DWK4BQauV3kfGtt95qgoKCzBtvvGE2bNhgxo0bZ2rVqmUqVark9FkRP/74o6lVq5apXr26eeWVV8ymTZvMO++8Y4YPH26+/fZbY4wxv/32m2nVqpWpU6eOeemll8yGDRvMxx9/bN544w0zYMAAs2PHDpfrffbZZ42Hh4fZuHGjY1nv3r1NpUqVzA8//HB1P4xCeOKJJ8wjjzxili1bZrZs2WIWLVpkWrdubSSZuLg4p7aTJk0ynp6eZuvWrU7Lu3TpYipXrmz+85//mM2bN5vhw4cbSSYhIcGp3bfffmsqVKhgbr31VrN27VqzatUq07x5cxMcHFzgRbDG5H+x7ebNm42vr6/p2rWrWbp0qUlMTDSrV682U6dONf379y9wm658Do6r40tKSjLt2rUzr776qlm7dq1Zt26dGTt2rClXrpwJDw83v/32m9M2O3To4NLFsnmN+/z586ZBgwamXr16ZunSpeajjz4yI0eONI0bNzaSzMSJEx1t9+7daypUqGDq16/vqH/ZsmUmIiLC2O12Y8xfF0zXq1fPNG3a1MybN89s2rTJfPjhh2bu3LmmZ8+e5sSJE5et8+8uXkBfvnx5c/bs2UL3v1oXL5Du3r272b59e67HpaKjo42np6dJSkpyLOvTp48ZP368eeedd8zWrVvN0qVLTdeuXY0kM3fuXKf+W7ZsMV5eXuauu+4yGzZsMEuWLDEhISGmefPm5s8//8xV244dO4wk869//Svf+hcvXmw8PDzMwIEDzcqVK01iYqJ5++23zfjx481DDz1U4Nhd+RycP//804SHh5uQkBCzZMkSs2HDBnPXXXcZLy8vp//f+/btM507dzbz5s0zH330kVm/fr156aWXTJ06dUy1atWcfma4egQc5Cm/gPPjjz+afv36mcqVK5uKFSua7t27mwMHDph69erl+iVw4sQJEx0dbWrWrGm8vb1NcHCwueeee5w+NOy3334z48aNM02aNDE+Pj4mMDDQtGjRwjzxxBOOO34uZ/369cbDw8PpjcgYY3755RdTt25d07p1a6e7UIrTggULzI033miCgoKMl5eXqVy5sunWrZv5+OOPc7WdOHGikWS2bNnitDwjI8OMGjXK1KxZ0/j4+Jhrr702z7uljDFm165d5rbbbjP+/v4mICDA3Hnnnebo0aOXrbOgu4n27dtn7rnnHlO9enXj7e1tatasaTp37mzmz59f4DZdDTiujO/MmTPmrrvuMqGhocbPz8/4+PiYRo0amWeeeSbPN/jrr7/e1KxZ87L7zm/c33zzjenSpYupWLGiqVy5shkwYIBJTk7OFXAuth0wYICpUqWK8fHxMXXr1jVRUVFOb74//fSTGTVqlAkLCzPe3t4mKCjIXH/99ebZZ5/NFc5ckZSUZCRd9s24uFwMkPk9LhUZGZnrjsPp06eb1q1bm8qVKxtPT09TpUoV061bN7NmzZo897d+/Xpz0003mXLlypmgoCAzePDgPD9s0Bhjhg8fbmw2m/n+++8LHENiYqLp2bOnCQoKMt7e3qZ27dqmZ8+el71T1JWAY4wxp06dMoMHDzZBQUGmXLly5qabbjIbNmzI1eb+++83DRo0MP7+/sbHx8fUr1/fPPTQQyY5Ofmy+0Dh2Ixx8eQrAJRCGRkZCgoK0iuvvKKRI0e6u5xiMWfOHI0aNUoHDhwo1OfOAP9kXIMDoEz75JNPVLt27UJ9iF5ZsWfPHh07dkyTJ09W3759CTdAIXAEB6VaTk6O02eS5IWPN0dZk52dXeCdSzabTZ6engoNDdWpU6d0yy23aPHixblugQaQPwIOSrWoqCjFx8cX2IaXMMqajh07KjExMd/19erVU1JSUskVBFgQAQelWlJS0mU/GK2gz6cASqPDhw8rIyMj3/W+vr4ufQo3gPwRcAAAgOXwbeIAAMBy/nFXZ+bk5CglJUUVK1Z06dNAAQCA+xljlJGRoeDgYJe+ruUfF3BSUlIUEhLi7jIAAMAVOHHixGW/9Fb6Bwaci9/Zc+LECQUEBLi5GgAA4Aq73a6QkBDH+/jl/OMCzsXTUgEBAQQcAADKGFcvL+EiYwAAYDkEHAAAYDkEHAAAYDkEHAAAYDkEHAAAYDkEHAAAYDkEHAAAYDkEHAAAYDkEHAAAYDkEHAAAYDluDThZWVkaN26cwsLC5Ofnp/r162vy5MnKyclxqf9nn30mLy8vtWzZsngLBQAAZYpbv4tq+vTpmj9/vuLj4xUeHq5du3ZpyJAhCgwM1GOPPVZg3/T0dA0ePFi33XabTp8+XUIVAwCAssCtAWf79u3q27evevbsKUkKDQ3VsmXLtGvXrsv2HTFihAYNGiRPT0+9++67xVwpAAAoS9x6iqp9+/batGmTjhw5Iknat2+ftm3bph49ehTYLy4uTt9//70mTpx42X1kZmbKbrc7PQAAgLW59QjOmDFjlJ6erqZNm8rT01PZ2dmaMmWKIiIi8u3z3XffaezYsfr000/l5XX58mNjYzVp0qSiLBsAAJRybj2Cs2LFCiUkJGjp0qXavXu34uPjNXPmTMXHx+fZPjs7W4MGDdKkSZPUuHFjl/YRExOj9PR0x+PEiRNFOQQAAFAK2Ywxxl07DwkJ0dixYzVy5EjHshdeeEEJCQk6dOhQrvZnz55V5cqV5enp6ViWk5MjY4w8PT21fv16de7cucB92u12BQYGKj09XQEBAUU3GAAAUGwK+/7t1lNU586dk4eH80EkT0/PfG8TDwgI0P79+52WzZs3T5s3b9bbb7+tsLCwYqsVAACUHW4NOL1799aUKVNUt25dhYeHa8+ePZo1a5aio6MdbWJiYnTy5EktWrRIHh4eat68udM2qlevrnLlyuVaDgAA/rncGnDmzJmj8ePH6+GHH1ZaWpqCg4M1YsQITZgwwdEmNTVVycnJbqwSAACUNW69BscduAYHAICyp7Dv33wXFQAAsBwCDgAAsBwCDgAAsBwCDgAAsBwCDgAAsBwCDgAAsBwCDgAAsBwCDgAAsBwCDgAAsBwCDgAAsBwCDgAAsBwCDgAAsBwCDgAAsBwCDgAAsBwCDgAAsBwCDgAAsBwCDgAAsBwCDgAAsBwCDgAAsBwCDgAAsBwCDgAAsBwCDgAAsBwCDgAAsBwCDgAAsBwCDgAAsBwCDgAAsBwCDgAAsBwCDgAAsBwCDgAAsBwCDgAAsBwCDgAAsBy3BpysrCyNGzdOYWFh8vPzU/369TV58mTl5OTk22fbtm26+eabVaVKFfn5+alp06Z6+eWXS7BqAABQ2nm5c+fTp0/X/PnzFR8fr/DwcO3atUtDhgxRYGCgHnvssTz7lC9fXo888oiuvfZalS9fXtu2bdOIESNUvnx5PfjggyU8AgAAUBrZjDHGXTvv1auXatSooQULFjiW9evXT/7+/lq8eLHL27n77rtVvnx5l/rY7XYFBgYqPT1dAQEBV1Q3AAAoWYV9/3brKar27dtr06ZNOnLkiCRp37592rZtm3r06OHyNvbs2aPPP/9cHTp0yHN9Zmam7Ha70wMAAFibW09RjRkzRunp6WratKk8PT2VnZ2tKVOmKCIi4rJ969Spo59++klZWVl67rnnNGzYsDzbxcbGatKkSUVdOgAAKMXcegRnxYoVSkhI0NKlS7V7927Fx8dr5syZio+Pv2zfTz/9VLt27dL8+fP1yiuvaNmyZXm2i4mJUXp6uuNx4sSJoh4GAAAoZdx6DU5ISIjGjh2rkSNHOpa98MILSkhI0KFDh1zezgsvvKDFixfr8OHDl23LNTgAAJQ9ZeoanHPnzsnDw7kET0/PAm8Tz4sxRpmZmUVZGgAAKMPceg1O7969NWXKFNWtW1fh4eHas2ePZs2apejoaEebmJgYnTx5UosWLZIkzZ07V3Xr1lXTpk0l/fW5ODNnztSjjz7qljEAAIDSx60BZ86cORo/frwefvhhpaWlKTg4WCNGjNCECRMcbVJTU5WcnOx4npOTo5iYGB07dkxeXl5q0KCBpk2bphEjRrhjCAAAoBRy6zU47sA1OAAAlD1l6hocAACA4kDAAQAAlkPAAQAAlkPAAQAAlkPAAQAAlkPAAQAAlkPAAQAAlkPAAQAAlkPAAQAAlkPAAQAAlkPAAQAAlkPAAQAAlkPAAQAAlkPAAQAAlkPAAQAAlkPAAQAAlkPAAQAAlkPAAQAAlkPAAQAAlkPAAQAAlkPAAQAAlkPAAQAAlkPAAQAAlkPAAQAAlkPAAQAAlkPAAQAAlkPAAQAAlkPAAQAAlkPAAQAAlkPAAQAAlkPAAQAAluPWgJOVlaVx48YpLCxMfn5+ql+/viZPnqycnJx8+6xatUpdunRRtWrVFBAQoLZt2+rjjz8uwaoBAEBp59aAM336dM2fP1+vvfaavv32W82YMUMvvvii5syZk2+fTz75RF26dNHatWv11VdfqVOnTurdu7f27NlTgpUDAIDSzGaMMe7aea9evVSjRg0tWLDAsaxfv37y9/fX4sWLXd5OeHi4Bg4cqAkTJly2rd1uV2BgoNLT0xUQEHBFdQMAgJJV2Pdvtx7Bad++vTZt2qQjR45Ikvbt26dt27apR48eLm8jJydHGRkZCgoKynN9Zmam7Ha70wMAAFiblzt3PmbMGKWnp6tp06by9PRUdna2pkyZooiICJe38dJLL+n333/XPffck+f62NhYTZo0qahKBgAAZYBbj+CsWLFCCQkJWrp0qXbv3q34+HjNnDlT8fHxLvVftmyZnnvuOa1YsULVq1fPs01MTIzS09MdjxMnThTlEAAAQCnk1iM4Tz/9tMaOHat7771XktSiRQsdP35csbGxioyMLLDvihUrNHToUK1cuVK33357vu18fX3l6+tbpHUDAIDSza1HcM6dOycPD+cSPD09C7xNXPrryE1UVJSWLl2qnj17FmeJAACgDHLrEZzevXtrypQpqlu3rsLDw7Vnzx7NmjVL0dHRjjYxMTE6efKkFi1aJOmvcDN48GDNnj1bN910k06dOiVJ8vPzU2BgoFvGAQAAShe33iaekZGh8ePHa/Xq1UpLS1NwcLAiIiI0YcIE+fj4SJKioqKUlJSkrVu3SpI6duyoxMTEXNuKjIzUwoULL7tPbhMHAKDsKez7t1sDjjsQcAAAKHvK1OfgAAAAFAcCDgAAsBwCDgAAsBwCDgAAsBwCDgAAsBwCDgAAsBwCDgAAsBwCDgAAsBwCDgAAsBwCDgAAsBwCDgAAsBwCDgAAsBwCDgAAsBwCDgAAsBwCDgAAsBwCDgAAsBwCDgAAsBwCDgAAsBwCDgAAsBwCDgAAsBwCDgAAsBwCDgAAsBwCDgAAsBwCDgAAsBwCDgAAsBwCDgAAsBwCDgAAsBwCDgAAsBwCDgAAsBwCDgAAsBwCDgAAsBy3BpysrCyNGzdOYWFh8vPzU/369TV58mTl5OTk2yc1NVWDBg1SkyZN5OHhoccff7zkCgYAAGWClzt3Pn36dM2fP1/x8fEKDw/Xrl27NGTIEAUGBuqxxx7Ls09mZqaqVaumZ599Vi+//HIJVwwAAMoCtwac7du3q2/fvurZs6ckKTQ0VMuWLdOuXbvy7RMaGqrZs2dLkt58880SqRMAAJQtbj1F1b59e23atElHjhyRJO3bt0/btm1Tjx49imwfmZmZstvtTg8AAGBtbj2CM2bMGKWnp6tp06by9PRUdna2pkyZooiIiCLbR2xsrCZNmlRk2wMAAKWfW4/grFixQgkJCVq6dKl2796t+Ph4zZw5U/Hx8UW2j5iYGKWnpzseJ06cKLJtAwCA0smtR3CefvppjR07Vvfee68kqUWLFjp+/LhiY2MVGRlZJPvw9fWVr69vkWwLAACUDW49gnPu3Dl5eDiX4OnpWeBt4gAAAJfj1iM4vXv31pQpU1S3bl2Fh4drz549mjVrlqKjox1tYmJidPLkSS1atMixbO/evZKk3377TT/99JP27t0rHx8fNWvWrKSHAAAASiGbMca4a+cZGRkaP368Vq9erbS0NAUHBysiIkITJkyQj4+PJCkqKkpJSUnaunWro5/NZsu1rXr16ikpKemy+7Tb7QoMDFR6eroCAgKKaigAAKAYFfb9260Bxx0IOAAAlD2Fff/mu6gAAIDlEHAAAIDlEHAAAIDlEHAAAIDlEHAAAIDlEHAAAIDlEHAAAIDlEHAAAIDlEHAAAIDlEHAAAIDlEHAAAIDlEHAAAIDlEHAAAIDlEHAAAIDlEHAAAIDlEHAAAIDlEHAAAIDlEHAAAIDlEHAAAIDlEHAAAIDlEHAAAIDlEHAAAIDlEHAAAIDlFCrgbNq0qcD1OTk5euGFF66qIAAAgKtVqIBzxx136JFHHtG5c+dyrTtw4IBat26t119/vciKAwAAuBKFCjiffvqpNm3apGuvvVafffaZpP87anP99dfrmmuu0YEDB4qlUAAAAFd5FaZxmzZttGfPHo0dO1adOnXSgw8+qB07dujkyZN666231Ldv3+KqEwAAwGWFCjiSVK5cOb388stKS0vTvHnzVL58ee3cuVNNmzYtjvoAAAAKrdB3UX3//fe69dZbtXnzZs2fP18tWrRQhw4dtHr16uKoDwAAoNAKFXBee+01XXfddapevbr279+vBx98UNu2bdOTTz6pQYMG6f7779evv/5aXLUCAAC4xGaMMa42rlKlil599VXdd999udYdPHhQkZGRSk1N1cmTJ4u0yKJkt9sVGBio9PR0BQQEuLscAADggsK+fxfqCM6BAwfyDDeSFB4eri+++EIPPfSQy9vLysrSuHHjFBYWJj8/P9WvX1+TJ09WTk5Ogf0SExN1/fXXq1y5cqpfv77mz59fmGEAAACLK9RFxrVq1ZIkrVy5UsuWLdORI0dks9nUqFEjDRo0SP3799f48eNd3t706dM1f/58xcfHKzw8XLt27dKQIUMUGBioxx57LM8+x44dU48ePTR8+HAlJCTos88+08MPP6xq1aqpX79+hRkOAACwqEKdosrJyVFERIRWrlypxo0bq2nTpjLG6NChQzp69KgGDBigZcuWyWazubS9Xr16qUaNGlqwYIFjWb9+/eTv76/Fixfn2WfMmDF6//339e233zqWPfTQQ9q3b5+2b99+2X1yigoAgLKnWE9RvfLKK9q4caPef/99HTp0SO+++67ee+89HT58WKtXr9aGDRs0e/Zsl7fXvn17bdq0SUeOHJEk7du3T9u2bVOPHj3y7bN9+3Z17drVaVm3bt20a9cuXbhwIVf7zMxM2e12pwcAALC2QgWchQsX6sUXX1SvXr1yrevTp49mzJjhdDTmcsaMGaOIiAg1bdpU3t7eatWqlR5//HFFRETk2+fUqVOqUaOG07IaNWooKytLP//8c672sbGxCgwMdDxCQkJcrg8AAJRNhQo43333nW6//fZ8199+++06evSoy9tbsWKFEhIStHTpUu3evVvx8fGaOXOm4uPjC+z391NgF8+y5XVqLCYmRunp6Y7HiRMnXK4PAACUTYW6yNjPz09nz55V3bp181xvt9vl5+fn8vaefvppjR07Vvfee68kqUWLFjp+/LhiY2MVGRmZZ5+aNWvq1KlTTsvS0tLk5eWlKlWq5Grv6+srX19fl2sCAABlX6GO4LRt27bAbwufO3eu2rZt6/L2zp07Jw8P5xI8PT0LvE28bdu22rBhg9Oy9evX64YbbpC3t7fL+wYAANZVqCM4zz77rDp27KhffvlFo0ePdtxF9e233+qll17Se++9py1btri8vd69e2vKlCmqW7euwsPDtWfPHs2aNUvR0dGONjExMTp58qQWLVok6a87pl577TU9+eSTGj58uLZv364FCxZo2bJlhRkKAACwsELdJi5Jq1ev1oMPPqgzZ844lhljFBQUpH//+9+F+iyajIwMjR8/XqtXr1ZaWpqCg4MVERGhCRMmyMfHR5IUFRWlpKQkbd261dEvMTFRTzzxhA4ePKjg4GCNGTPG5Q8Y5DZxAADKnsK+fxc64Eh/nVpav3694/buxo0bq2vXrvL39y98xSWMgAMAQNlT2PfvQp2ikv76sL/ly5dr1apVSkpKks1mU1hYmOx2ux544AGXP+QPAACguBTqImNjjPr06aNhw4bp5MmTatGihcLDw3X8+HFFRUXprrvuKq46AQAAXFaoIzgLFy7UJ598ok2bNqlTp05O6zZv3qw777xTixYt0uDBg4u0SAAAgMIo1BGcZcuW6V//+leucCNJnTt31tixY7VkyZIiKw4AAOBKFCrgfP311+revXu+6++44w7t27fvqosCAAC4GoUKOGfOnMn1PVCXqlGjhn799derLgoAAOBqFCrgZGdny8sr/8t2PD09lZWVddVFAQAAXI1CXWRsjFFUVFS+3+2UmZlZJEUBAABcjUIFnPy+APNS3EEFAADcrVABJy4urrjqAAAAKDKFugYHAACgLCDgAAAAyyHgAAAAyyHgAAAAyyHgAAAAyyHgAAAAyyHgAAAAyyHgAAAAyyHgAAAAyyHgAAAAyyHgAAAAyyHgAAAAyyHgAAAAyyHgAAAAyyHgAAAAyyHgAAAAyyHgAAAAyyHgAAAAyyHgAAAAyyHgAAAAyyHgAAAAy3FrwAkNDZXNZsv1GDlyZL595s6dq2uuuUZ+fn5q0qSJFi1aVIIVAwCAssDLnTvfuXOnsrOzHc8PHDigLl26aMCAAXm2f/311xUTE6M33nhDrVu31pdffqnhw4ercuXK6t27d0mVDQAASjmbMca4u4iLHn/8ca1Zs0bfffedbDZbrvXt2rXTzTffrBdffNGpz65du7Rt2zaX9mG32xUYGKj09HQFBAQUWe0AAKD4FPb9261HcC51/vx5JSQk6Mknn8wz3EhSZmamypUr57TMz89PX375pS5cuCBvb+88+2RmZjqe2+32oi0cAACUOqXmIuN3331XZ8+eVVRUVL5tunXrpv/+97/66quvZIzRrl279Oabb+rChQv6+eef8+wTGxurwMBAxyMkJKSYRgAAAEqLUnOKqlu3bvLx8dEHH3yQb5s//vhDI0eO1OLFi2WMUY0aNXT//fdrxowZOn36tKpXr56rT15HcEJCQjhFBQBAGVLYU1Sl4gjO8ePHtXHjRg0bNqzAdn5+fnrzzTd17tw5JSUlKTk5WaGhoapYsaKqVq2aZx9fX18FBAQ4PQAAgLWVimtw4uLiVL16dfXs2dOl9t7e3qpTp44kafny5erVq5c8PEpFVgMAAKWA2wNOTk6O4uLiFBkZKS8v53JiYmJ08uRJx2fdHDlyRF9++aXatGmjX3/9VbNmzdKBAwcUHx/vjtIBAEAp5faAs3HjRiUnJys6OjrXutTUVCUnJzueZ2dn66WXXtLhw4fl7e2tTp066fPPP1doaGgJVgwAAEq7UnORcUnhc3AAACh7yuRFxgAAAEWJgAMAACyHgAMAACyHgAMAACyHgAMAACyHgAMAACyHgAMAACyHgAMAACyHgAMAACyHgAMAACyHgAMAACyHgAMAACyHgAMAACyHgAMAACyHgAMAACyHgAMAACyHgAMAACyHgAMAACyHgAMAACyHgAMAACyHgAMAACyHgAMAACyHgAMAACyHgAMAACyHgAMAACyHgAMAACyHgAMAACyHgAMAACyHgAMAACyHgAMAACyHgAMAACzHrQEnNDRUNpst12PkyJH59lmyZImuu+46+fv7q1atWhoyZIh++eWXEqwaAACUdm4NODt37lRqaqrjsWHDBknSgAED8my/bds2DR48WEOHDtXBgwe1cuVK7dy5U8OGDSvJsgEAQCnn5c6dV6tWzen5tGnT1KBBA3Xo0CHP9jt27FBoaKhGjRolSQoLC9OIESM0Y8aMYq8VAACUHaXmGpzz588rISFB0dHRstlsebZp166dfvzxR61du1bGGJ0+fVpvv/22evbsme92MzMzZbfbnR4AAMDaSk3Aeffdd3X27FlFRUXl26Zdu3ZasmSJBg4cKB8fH9WsWVOVKlXSnDlz8u0TGxurwMBAxyMkJKQYqgcAAKWJzRhj3F2EJHXr1k0+Pj764IMP8m3zzTff6Pbbb9cTTzyhbt26KTU1VU8//bRat26tBQsW5NknMzNTmZmZjud2u10hISFKT09XQEBAkY8DAAAUPbvdrsDAQJffv0tFwDl+/Ljq16+vVatWqW/fvvm2e+CBB/Tnn39q5cqVjmXbtm3TLbfcopSUFNWqVeuy+yrsDwgAALhfYd+/S8Upqri4OFWvXr3Aa2kk6dy5c/LwcC7Z09NTklQKchoAACgl3B5wcnJyFBcXp8jISHl5Od/UFRMTo8GDBzue9+7dW6tWrdLrr7+uH374QZ999plGjRqlG2+8UcHBwSVdOgAAKKXcepu4JG3cuFHJycmKjo7OtS41NVXJycmO51FRUcrIyNBrr72mp556SpUqVVLnzp01ffr0kiwZAACUcqXiGpySxDU4AACUPWXyGhwAAICiRMABAACWQ8ABAACWQ8ABAACWQ8ABAACWQ8ABAACWQ8ABAACWQ8ABAACWQ8ABAACWQ8ABAACWQ8ABAACWQ8ABAACWQ8ABAACWQ8ABAACWQ8ABAACWQ8ABAACWQ8ABAACWQ8ABAACWQ8ABAACWQ8ABAACWQ8ABAACWQ8ABAACWQ8ABAACWQ8ABAACWQ8ABAACWQ8ABAACWQ8ABAACWQ8ABAACWQ8ABAACWQ8ABAACWQ8ABAACW49aAExoaKpvNlusxcuTIPNtHRUXl2T48PLyEKwcAAKWZWwPOzp07lZqa6nhs2LBBkjRgwIA828+ePdup/YkTJxQUFJRvewAA8M/k5c6dV6tWzen5tGnT1KBBA3Xo0CHP9oGBgQoMDHQ8f/fdd/Xrr79qyJAhxVonAAAoW9wacC51/vx5JSQk6Mknn5TNZnOpz4IFC3T77berXr16+bbJzMxUZmam47ndbr/qWgEAQOlWai4yfvfdd3X27FlFRUW51D41NVXr1q3TsGHDCmwXGxvrOPITGBiokJCQIqgWAACUZjZjjHF3EZLUrVs3+fj46IMPPnCpfWxsrF566SWlpKTIx8cn33Z5HcEJCQlRenq6AgICrrpuAABQ/Ox2uwIDA11+/y4Vp6iOHz+ujRs3atWqVS61N8bozTff1AMPPFBguJEkX19f+fr6FkWZAACgjCgVp6ji4uJUvXp19ezZ06X2iYmJOnr0qIYOHVrMlQEAgLLI7QEnJydHcXFxioyMlJeX8wGlmJgYDR48OFefBQsWqE2bNmrevHlJlQkAAMoQtwecjRs3Kjk5WdHR0bnWpaamKjk52WlZenq63nnnHY7eAACAfJWai4xLSmEvUgIAAO5X2Pdvtx/BAQAAKGoEHAAAYDkEHAAAYDkEHAAAYDkEHAAAYDkEHAAAYDkEHAAAYDkEHAAAYDkEHAAAYDkEHAAAYDkEHAAAYDkEHAAAYDkEHAAAYDkEHAAAYDkEHAAAYDkEHAAAYDkEHAAAYDkEHAAAYDkEHAAAYDkEHAAAYDkEHAAAYDkEHAAAYDkEHAAAYDkEHAAAYDkEHAAAYDkEHAAAYDkEHAAAYDkEHAAAYDkEHAAAYDkEHAAAYDkEHAAAYDluDTihoaGy2Wy5HiNHjsy3T2Zmpp599lnVq1dPvr6+atCggd58880SrBoAAJR2Xu7c+c6dO5Wdne14fuDAAXXp0kUDBgzIt88999yj06dPa8GCBWrYsKHS0tKUlZVVEuUCAIAywq0Bp1q1ak7Pp02bpgYNGqhDhw55tv/oo4+UmJioH374QUFBQZL+OgoEAABwqVJzDc758+eVkJCg6Oho2Wy2PNu8//77uuGGGzRjxgzVrl1bjRs31ujRo/XHH3/ku93MzEzZ7XanBwAAsDa3HsG51LvvvquzZ88qKioq3zY//PCDtm3bpnLlymn16tX6+eef9fDDD+vMmTP5XocTGxurSZMmFVPVAACgNLIZY4y7i5Ckbt26ycfHRx988EG+bbp27apPP/1Up06dUmBgoCRp1apV6t+/v37//Xf5+fnl6pOZmanMzEzHc7vdrpCQEKWnpysgIKDoBwIAAIqc3W5XYGCgy+/fpeIIzvHjx7Vx40atWrWqwHa1atVS7dq1HeFGkq655hoZY/Tjjz+qUaNGufr4+vrK19e3yGsGAAClV6m4BicuLk7Vq1dXz549C2x38803KyUlRb/99ptj2ZEjR+Th4aE6deoUd5kAAKCMcHvAycnJUVxcnCIjI+Xl5XxAKSYmRoMHD3Y8HzRokKpUqaIhQ4bom2++0SeffKKnn35a0dHReZ6eAgAA/0xuDzgbN25UcnKyoqOjc61LTU1VcnKy43mFChW0YcMGnT17VjfccIPuu+8+9e7dW6+++mpJlgwAAEq5UnORcUkp7EVKAADA/Qr7/u32IzgAAABFjYADAAAsh4ADAAAsh4ADAAAsh4ADAAAsh4ADAAAsh4ADAAAsh4ADAAAsh4ADAAAsp1R8m3hJuvjBzXa73c2VAAAAV11833b1Cxj+cQEnIyNDkhQSEuLmSgAAQGFlZGQoMDDwsu3+cd9FlZOTo5SUFFWsWFE2m83d5TjY7XaFhIToxIkTlv2OLKuP0erjk6w/RsZXtll9fJL1x1jQ+IwxysjIUHBwsDw8Ln+FzT/uCI6Hh4fq1Knj7jLyFRAQYMkX7aWsPkarj0+y/hgZX9lm9fFJ1h9jfuNz5cjNRVxkDAAALIeAAwAALIeAU0r4+vpq4sSJ8vX1dXcpxcbqY7T6+CTrj5HxlW1WH59k/TEW5fj+cRcZAwAA6+MIDgAAsBwCDgAAsBwCDgAAsBwCTilns9n07rvvursMXAXmsOxjDss25q/su5I5JOCUsKioKN15553uLuOKxMbGqnXr1qpYsaKqV6+uO++8U4cPH3ZqY4zRc889p+DgYPn5+aljx446ePCgY/2ZM2f06KOPqkmTJvL391fdunU1atQopaenO21nypQpateunfz9/VWpUqWSGJ7LmMPLz2FSUpKGDh2qsLAw+fn5qUGDBpo4caLOnz9fYmMtCHPo2v/DPn36qG7duipXrpxq1aqlBx54QCkpKSUyzoIwf67N30WZmZlq2bKlbDab9u7dW5zDc1lJzCEBBy5LTEzUyJEjtWPHDm3YsEFZWVnq2rWrfv/9d0ebGTNmaNasWXrttde0c+dO1axZU126dHF8B1hKSopSUlI0c+ZM7d+/XwsXLtRHH32koUOHOu3r/PnzGjBggP73f/+3RMdodSU1h4cOHVJOTo7+/e9/6+DBg3r55Zc1f/58/etf/yrxMVtNSf4/7NSpk9566y0dPnxY77zzjr7//nv179+/RMdrNSU5fxc988wzCg4OLpHxlSoGJSoyMtL07dvXGGNMvXr1zMsvv+y0/rrrrjMTJ050PJdkVq9eXWL1FUZaWpqRZBITE40xxuTk5JiaNWuaadOmOdr8+eefJjAw0MyfPz/f7bz11lvGx8fHXLhwIde6uLg4ExgYWOS1Xw3mMLeC5vCiGTNmmLCwsKIr/iowh7m5Mofvvfeesdls5vz580U3gCvA/OWW3/ytXbvWNG3a1Bw8eNBIMnv27CmWcRRWScwhR3BwxS4eDg0KCpIkHTt2TKdOnVLXrl0dbXx9fdWhQwd9/vnnBW4nICBAXl7/uK9Gc7uSnMP09HTHflB0SmoOz5w5oyVLlqhdu3by9vYuwhH8sxXn/J0+fVrDhw/X4sWL5e/vX0wjKL0IOLgixhg9+eSTat++vZo3by5JOnXqlCSpRo0aTm1r1KjhWPd3v/zyi55//nmNGDGieAtGLiU5h99//73mzJmjhx56qIiqh1QyczhmzBiVL19eVapUUXJyst57770iHsU/V3HOnzFGUVFReuihh3TDDTcU0whKNwIOrsgjjzyir7/+WsuWLcu1zmazOT03xuRaJkl2u109e/ZUs2bNNHHixGKrFXkrqTlMSUlR9+7dNWDAAA0bNqxoioekkpnDp59+Wnv27NH69evl6empwYMHy/AB+EWiOOdvzpw5stvtiomJKfrCywgCjht5eHjk+kVx4cIFN1XjukcffVTvv/++tmzZojp16jiW16xZU5Jy/ZWRlpaW66+RjIwMde/eXRUqVNDq1avL7CFv5rDgOUxJSVGnTp3Utm1b/ec//ymGkVw95rDgOaxataoaN26sLl26aPny5Vq7dq127NhRDCO6Msxf3vO3efNm7dixQ76+vvLy8lLDhg0lSTfccIMiIyOLa1hXpLjmkIDjRtWqVVNqaqrjud1u17Fjx9xYUcGMMXrkkUe0atUqbd68WWFhYU7rw8LCVLNmTW3YsMGx7Pz580pMTFS7du0cy+x2u7p27SofHx+9//77KleuXImNoagxh/nP4cmTJ9WxY0f9z//8j+Li4uThUTp/3TCHrv8/vPgmlJmZWUSjuXrMX97z9+qrr2rfvn3au3ev9u7dq7Vr10qSVqxYoSlTphTjCAuvuOaQqzrdqHPnzlq4cKF69+6typUra/z48fL09HR3WfkaOXKkli5dqvfee08VK1Z0/IURGBgoPz8/2Ww2Pf7445o6daoaNWqkRo0aaerUqfL399egQYMk/fUXR9euXXXu3DklJCTIbrfLbrdL+utFfnH8ycnJOnPmjJKTk5Wdne347IaGDRuqQoUKJT/4fDCHec9hSkqKOnbsqLp162rmzJn66aefHDVc/Au1tGAO857DL7/8Ul9++aXat2+vypUr64cfftCECRPUoEEDtW3b1m3j/zvmL+/5q1u3rtN+L/7ebNCggdMRo9Kg2OawUPdc4ao98MADpl+/fsYYY9LT080999xjAgICTEhIiFm4cGGpvr1RUp6PuLg4R5ucnBwzceJEU7NmTePr62tuvfVWs3//fsf6LVu25LudY8eOOdpFRkbm2WbLli0lN+B8MIeXn8O4uLh825QGzOHl5/Drr782nTp1MkFBQcbX19eEhoaahx56yPz4448lPOLcmD/Xfo9e6tixY6XqNvGSmEPb/++IEtK9e3c1bNhQr732mrtLwRViDss+5rBsY/7KvpKYw9J5UtyCfv31V3344YfaunWrbr/9dneXgyvAHJZ9zGHZxvyVfSU5h1yDU0Kio6O1c+dOPfXUU+rbt6+7y8EVYA7LPuawbGP+yr6SnENOUQEAAMvhFBUAALAcAg4AALAcAg4AALAcAg4AALAcAg6AMmHr1q2y2Ww6e/asu0sBUAZwFxWAUqljx45q2bKlXnnlFUl/fR/PmTNnVKNGjTy/VRkALsXn4AAoE3x8fErd91gBKL04RQWg1ImKilJiYqJmz54tm80mm82mhQsXOp2iWrhwoSpVqqQ1a9aoSZMm8vf3V//+/fX7778rPj5eoaGhqly5sh599FFlZ2c7tn3+/Hk988wzql27tsqXL682bdpo69at7hkogGLDERwApc7s2bN15MgRNW/eXJMnT5YkHTx4MFe7c+fO6dVXX9Xy5cuVkZGhu+++W3fffbcqVaqktWvX6ocfflC/fv3Uvn17DRw4UJI0ZMgQJSUlafny5QoODtbq1avVvXt37d+/X40aNSrRcQIoPgQcAKVOYGCgfHx85O/v7zgtdejQoVztLly4oNdff10NGjSQJPXv31+LFy/W6dOnVaFCBTVr1kydOnXSli1bNHDgQH3//fdatmyZfvzxRwUHB0uSRo8erY8++khxcXGaOnVqyQ0SQLEi4AAos/z9/R3hRpJq1Kih0NBQVahQwWlZWlqaJGn37t0yxqhx48ZO28nMzFSVKlVKpmgAJYKAA6DM8vb2dnpus9nyXJaTkyNJysnJkaenp7766it5eno6tbs0FAEo+wg4AEolHx8fp4uDi0KrVq2UnZ2ttLQ03XLLLUW6bQClC3dRASiVQkND9cUXXygpKUk///yz4yjM1WjcuLHuu+8+DR48WKtWrdKxY8e0c+dOTZ8+XWvXri2CqgGUFgQcAKXS6NGj5enpqWbNmqlatWpKTk4uku3GxcVp8ODBeuqpp9SkSRP16dNHX3zxhUJCQopk+wBKBz7JGAAAWA5HcAAAgOUQcAAAgOUQcAAAgOUQcAAAgOUQcAAAgOUQcAAAgOUQcAAAgOUQcAAAgOUQcAAAgOUQcAAAgOUQcAAAgOUQcAAAgOX8P0Daz2nCecLwAAAAAElFTkSuQmCC",
+      "text/plain": [
+       "<Figure size 640x480 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "transport_model.mesh.DOX.isel(nface=207, time=slice(0, 5000)).plot()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 43,
+   "id": "e4ecd765",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[<matplotlib.lines.Line2D at 0x1c25c9f6750>]"
+      ]
+     },
+     "execution_count": 43,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAkoAAAHFCAYAAAANLdYJAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjguNCwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8fJSN1AAAACXBIWXMAAA9hAAAPYQGoP6dpAAA89klEQVR4nO3de1xVVeL38e/h7g0UURCveNdsUvGupFbi3SxzHCsvWabPWP7QLLMy01Kqqaa8T44jpnmpzPRnmFIZWaKjBWZqliViApk6gFpegPX84eN5OnNYeDARoc/79dqvl6y91t5rsQ6eL2vvs3EYY4wAAADgxqukOwAAAHC9IigBAABYEJQAAAAsCEoAAAAWBCUAAAALghIAAIAFQQkAAMCCoAQAAGBBUAIAALAgKKHYrV69WjfccIPKlSsnh8OhlJSUku7SdS81NVUOh6PAbdWqVR4d4/Tp04qJiVF4eLgCAgLUsmVLa9svv/xSt912mypWrKjKlSvrzjvv1A8//FDo8fft2yd/f385HA7t2rWryGP8vTwd38iRIwv8PjZt2vR3nX/OnDlq2LCh/Pz85HA4lJWV9buO90fw8ccfa9SoUWratKkqVKigmjVr6vbbb9cXX3zhUfsPP/xQPXr0UHh4uPz9/VW9enXdcsstio+Pt9bv2LGjypcvr5CQEI0cOVLHjh1zqfPMM89Yf9aK8vN2tRw7dkwjR45USEiIypcvr44dO+qjjz5yq/fkk0+qVatWCg4OVkBAgOrXr68HH3xQhw8fvqb9/SPwKekOoGz7+eefNWzYMPXq1Uvz58+Xv7+/GjduXNLdKjUefvhh3X333S5ljRo18qjtnXfeqZ07d+r5559X48aNtWLFCg0dOlT5+fkux/zmm2/UrVs3tWzZUm+99ZbOnj2rp59+WlFRUUpJSVG1atXcjp2Xl6dRo0YpJCRE6enpv2+QV8jT8UlSuXLl9PHHH7uVXamUlBSNHz9eDzzwgEaMGCEfHx9VqlTpio/3R7FgwQKdOHFC//M//6PmzZvr559/1ssvv6wOHTpo06ZNuuWWWwptf+LECd1www164IEHFBYWppMnT2rhwoXq27evli1bpnvvvddZNzExUb1791bfvn21bt06HTt2TJMnT9att96qXbt2yd/fX5L0wAMPqFevXm7nGj16tL7//vsC9xWXc+fO6dZbb1VWVpZee+01Va9eXfPmzVOvXr304YcfqmvXrs66WVlZGjp0qJo1a6ZKlSpp3759eu6557R+/Xrt3btXVatWvWb9LvMMUIw+++wzI8msXr26pLtSqhw6dMhIMn/729+uqP37779vJJkVK1a4lPfo0cOEh4eb3NxcZ9ngwYNNSEiIyc7OdpalpqYaX19f89hjjxV4/L/97W+mZs2a5rXXXjOSzM6dO6+onwUZMWKE6dq1a6F1ijK+ESNGmAoVKly1/hljzPLly40ks2PHjqt63LLup59+cis7deqUCQ0NNbfeeusVHfP8+fOmZs2aJioqyqW8bdu2pnnz5ubChQvOss8//9xIMvPnzy/0mIcOHTIOh8Pce++9V9SngnTt2tWMGDGi0Drz5s0zksy2bducZRcuXDDNmzc37dq1u+w54uPjjSSzePHi39td/AaX3lBsRo4cqS5dukiShgwZIofDoW7dukmSdu3apb/85S+qV6+eypUrp3r16mno0KEFLhsfPXpUDz74oGrXri0/Pz+Fh4frrrvu0k8//eSsk5OTo0mTJikiIkJ+fn6qWbOmYmJidObMGY/7e/z4cdWuXVudOnXShQsXnOX79u1ThQoVNGzYsCv8Tlx7a9euVcWKFTV48GCX8vvuu0/p6enasWOHJCk3N1cbNmzQoEGDFBgY6KxXt25dde/eXWvXrnU79nfffaenn35a8+fPd2nz33bt2qUBAwY4Lw20atVKb7311jUdX3Ho1q2bc+Wiffv2cjgcGjlypCQpISFBt99+u2rVqqWAgAA1bNhQY8aM0fHjx92O880332jo0KEKDQ2Vv7+/6tSpo+HDh+vcuXPOOpmZmRozZoxq1aolPz8/RUREaPr06crNzfW4v88++6x8fHx05MgRt32jRo1S1apVdfbs2SJ+F65M9erV3coqVqyo5s2bF9g/T/j6+qpy5cry8fn/F0iOHj2qnTt3atiwYS7lnTp1UuPGjQt8Xf/Wv/71Lxlj9MADD7jt+/DDD3XrrbcqMDBQ5cuXV+fOnQu8NHYl1q5dqyZNmqhjx47OMh8fH917773697//raNHjxba/tLq72/HjN+PoIRiM3XqVM2bN0+SNGvWLCUlJWn+/PmSLt6D06RJE7366qvatGmTXnjhBWVkZKht27YubypHjx5V27ZttXbtWk2cOFEbN27Uq6++qqCgIP3nP/+RJP3yyy/q2rWrli5dqvHjx2vjxo2aPHmy4uLiNGDAABljPOpvSEiIVq1apZ07d2ry5MnOYw8ePFh16tTRwoULC21vjFFubq5Hm6eef/55+fn5qXz58urSpYvWr1/vUbuvv/5azZo1c/sP809/+pNzvyR9//33+vXXX53l/1334MGDLm+il948+vXrpwEDBljPv2XLFnXu3FlZWVlauHCh1q1bp5YtW2rIkCGKi4vzaAxXY3yX/PrrrwoLC5O3t7dq1aqlhx56SCdPnryic8+fP19PPfWUJGnJkiVKSkrS1KlTJV38fnbs2FELFizQ5s2b9fTTT2vHjh3q0qWLS/jevXu32rZtq+3bt2vGjBnauHGjYmNjde7cOZ0/f17SxZDUrl07bdq0SU8//bQ2btyo+++/X7GxsRo9erTH/R0zZox8fHz0j3/8w6X85MmTWrVqle6//34FBARY2xfH6/q3srOz9eWXX+qGG27wuE1+fr5yc3OVnp6uadOm6dtvv9Ujjzzi3H9p/m2v6/9+ffz3sePi4tSwYUOXS12StHz5ckVHRyswMFBLly7VW2+9peDgYPXs2fOqhKWvv/7a2mdJ2rt3r9u+3Nxc/frrr0pOTlZMTIwaN26sO++883f3Bb9RoutZKPO2bNliJJm333670Hq5ubnm9OnTpkKFCua1115zlo8aNcr4+vqaffv2WdvGxsYaLy8vt8s/77zzjpFk4uPji9TnF154wUgya9euNSNGjDDlypUzX3311WXbXRqrJ9uhQ4cKPVZ6eroZPXq0eeutt8zWrVvNm2++aTp06GAkmUWLFl22L40aNTI9e/Ys8LiSzKxZs4wx//9SxMqVK93qzpo1y0gy6enpzrI5c+aYKlWqmMzMTGOMMUuWLCnw0lvTpk1Nq1atXC57GGNMv379TI0aNUxeXp6z7MKFCy7b8OHDzc033+xWnp+fX+TxGWPMK6+8Yl555RWzefNms3nzZvPkk0+a8uXLm6ZNm5pTp04V+n20sY37t/Lz882FCxfM4cOHjSSzbt06575bbrnFVK5c2Rw7dszafsyYMaZixYrm8OHDLuUvvfSSkWT27t3rcX9HjBhhqlevbs6dO+cse+GFF4yXl9dlX4uXxurJdiXuuece4+PjY3bt2uVxm549ezrPGRgYaN59912X/W+++aaRZJKSktzaPvjgg8bPz8967I0bNxpJJjY21qX8zJkzJjg42PTv39+lPC8vz9x0000ul8Yuzf1vt5tvvtkMHz7crfy3fH19zZgxY9z6tG3btgIvNWdkZLh8/9u3b2+OHj1qHRuuDOtzKBGnT5/Ws88+qzVr1ig1NVV5eXnOffv373f+e+PGjerevbuaNWtmPdaGDRvUokULtWzZ0uW32p49e8rhcOiTTz5R7969Pe7bo48+qk8//VRDhw7V2bNn9c9//lM33njjZdtFRkZq586dHp0jPDy80P01atTQ66+/7lI2ePBgtW/fXo8//rhGjhx52eV1h8Ph8T5P6h4+fFhTpkzRq6++qtDQUGv9gwcP6ptvvtFLL70kSS5z0qdPH23YsEEHDhxQs2bNlJqaqoiIiAKP4+vr6/L1li1bnJduPe2zJE2YMMFlX48ePdSqVSvdddddWrRokdv+3+PYsWN6+umn9f777ys9PV35+fnOffv379eAAQP0yy+/KDExUffff3+BN8pfsmHDBnXv3l3h4eEu38PevXtr0qRJSkxMVPPmzT3q1//8z/9o6dKlevvtt3XPPfcoPz9fCxYsUN++fVWvXr1C2/bv39/j13VRTZ06VW+++abmzJmjyMhIj9vNmTNHWVlZysjI0PLlyzVkyBAtXbpUQ4cOdalne40U9tpZvHixfHx8nJdTL9m2bZtOnjypESNGuK2e9erVSy+++KLOnDmjChUqKDExUd27d3c79qeffqo33njDpezQoUMuc1CUn9uQkBDt3LlT586d0/79+/Xiiy+qe/fu+uSTT1SjRg3rcVA0BCWUiLvvvlsfffSRpk6dqrZt2yowMFAOh0N9+vTRr7/+6qz3888/q1atWoUe66efftLBgwfd3lgvKej+kMJcuufk/fffV1hYmMf3JlWsWFEtW7b0qO6V3EPg6+urIUOG6PHHH9d3331XaHisWrWqTpw44VZ+6XJTcHCws54ka12Hw6HKlStLksaNG6cWLVpo0KBBzo/C//LLL5IuBt/s7GwFBQU57x2bNGmSJk2aVGD/Ls1JeHi425vw9OnTlZ6e7napqEmTJkUen80dd9yhChUqaPv27YXWK4r8/HxFR0crPT1dU6dO1Y033qgKFSooPz9fHTp0cL6u//Of/ygvL8+j1/X//u//XpXXdatWrRQVFaV58+bpnnvu0YYNG5Samur2PS5IcHCwgoKCPD6Xp6ZPn67nnntOM2fO1EMPPVSktr/95OeAAQPUu3dvjRs3TkOGDJGXl9dlX9e218fx48e1fv169e3bV2FhYS77Lr2u77rrLmu/Tp48qQoVKhT4S9OYMWMUHh6uadOmuZT/9pemor6ufXx81KZNG0lS586d1atXL0VEROj555/Xa6+9Zu0nioaghGsuOztbGzZs0LRp0/T44487y8+dO+d230i1atX0448/Fnq8kJAQlStXTv/617+s+4siIyND48aNU8uWLbV3715NmjRJs2fPvmw722+RBfnv3yI9Zf7f/VZeXoXfXnjjjTdq5cqVys3NdQlle/bskSS1aNFCktSgQQOVK1fOWf5be/bsUcOGDZ33r3z99dc6fPiwqlSp4la3e/fuCgoKUlZWlvP7PWXKFOu9EpdCj5+fn/M/+kuqVq2qU6dOuZVfyfgKY4y57PexKL7++mvt3r1bcXFxGjFihLP84MGDLvWCg4Pl7e3t0ev6T3/6k2bOnFng/sutSv638ePHa/Dgwfryyy81d+5cNW7cWD169Lhsu6VLl+q+++7z6BzGw/sBp0+frmeeeUbPPPOMnnjiCY/aFKZdu3b64IMP9PPPPys0NNQ5/3v27FGfPn1c6u7Zs8f6+li2bJnOnz9f4E3cl17Xc+bMUYcOHQpsf2mltVKlSm6v30qVKqlq1aqXfV3bfhaly7+ua9WqpfDwcH377beF1kPREJRwzTkcDhljnM8xueSf//ynyyU46eJlhmXLlunAgQMuKwq/1a9fP82aNUtVq1a1XsbxVF5enoYOHSqHw6GNGzfqzTff1KRJk9StW7fL3iB5NS+9FeTChQtavXq1QkJC1LBhw0Lr3nHHHVq0aJHWrFmjIUOGOMuXLl2q8PBwtW/fXtLF30j79++vd999Vy+++KLzWUBpaWnasmWLy2WpVatWuX066oMPPtALL7yghQsXOm/GbdKkiRo1aqTdu3dr1qxZRR6nJzwdn80777yjX375xfqGdyUuXRb579f1f6/alCtXTl27dtXbb7+tmTNnWoN8v379FB8frwYNGhQYTovqjjvuUJ06dfTII48oMTFRf//73wu9zHPJ1b709uyzz+qZZ57RU0895ba6ciWMMUpMTFTlypWdK0k1a9ZUu3bttHz5ck2aNEne3t6SpO3bt+vAgQOKiYkp8FiLFy9WeHh4gZfqO3furMqVK2vfvn1FXgHz1B133KG//vWv2rFjh/M1nJubq+XLl6t9+/aX/X/j4MGD+vHHHwv9oAWuQIneIYUyz3Yz980332yCg4PNokWLTEJCgnnqqadMjRo1TOXKlV2eNfLjjz+aGjVqmOrVq5tXX33VfPTRR2bNmjVm9OjRZv/+/cYYY06fPm1atWplatWqZV5++WWTkJBgNm3aZBYtWmQGDx5stm/f7nF/n3zySePl5WU+/PBDZ1n//v1N5cqVzQ8//PD7vhlFMGHCBPPQQw+ZlStXmi1btpg33njDtG3b1kgyS5Yscak7ffp04+3tbT755BOX8h49epgqVaqY119/3Xz88cdm9OjRRpJZvny5S739+/ebihUrmptvvtnEx8ebd99917Ro0cKEh4cXerOxMfabmj/++GPj7+9voqOjzYoVK0xiYqJZu3atmTVrlrnrrrsKPaYnz1HydHypqammU6dOZvbs2SY+Pt5s3LjRPP744yYgIMDccMMN5vTp0y7H7Nq1q0c3JRc07vPnz5sGDRqYunXrmhUrVpgPPvjAjBs3zjRu3NhIMtOmTXPWTUlJMRUrVjT169d39n/lypVm6NChJicnxxhz8cb0unXrmqZNm5r58+ebjz76yLz//vtm3rx5pm/fvubIkSOX7ed/u/RBhQoVKpisrKwit/+9Lt2I3qtXL5OUlOS2/daoUaOMt7e3SU1NdZYNGDDATJ061axZs8Z88sknZsWKFSY6OtpIMvPmzXNpv2XLFuPj42PuuOMOk5CQYN58801Tu3Zt06JFC3P27Fm3vm3fvt1IMk888YS1/8uWLTNeXl5myJAh5u233zaJiYnmnXfeMVOnTjVjx44tdOyePEfp7Nmz5oYbbjC1a9c2b775pklISDB33HGH8fHxcfn53r17t7nlllvM/PnzzQcffGA2b95sXn75ZVOrVi1TrVo1l+8Zfj+CEoqVLSj9+OOPZtCgQaZKlSqmUqVKplevXubrr782devWdfvP5MiRI2bUqFEmLCzM+Pr6mvDwcPPnP//Z5eF1p0+fNk899ZRp0qSJ8fPzM0FBQebGG280EyZMcH5C63I2b95svLy8XN7QjDHmxIkTpk6dOqZt27YunxoqTosXLzbt2rUzwcHBxsfHx1SpUsX07NnTbNq0ya3utGnTjCSzZcsWl/JTp06Z8ePHm7CwMOPn52f+9Kc/FfjpNmOM2bVrl7n11ltN+fLlTWBgoBk4cKA5ePDgZftZ2Ke/du/ebf785z+b6tWrG19fXxMWFmZuueUWs3DhwkKP6WlQ8mR8J0+eNHfccYepV6+eKVeunPHz8zONGjUyjz32WIFBITIy0oSFhV323LZx79u3z/To0cNUqlTJVKlSxQwePNikpaW5BaVLdQcPHmyqVq1q/Pz8TJ06dczIkSNd3sR//vlnM378eBMREWF8fX1NcHCwiYyMNE8++aRbyPNEamqqkXTZN/XicimI2rbfGjFihNsnRF944QXTtm1bU6VKFePt7W2qVq1qevbsaTZs2FDg+TZv3mw6dOhgAgICTHBwsBk+fHiBD700xpjRo0cbh8Nhvv/++0LHkJiYaPr27WuCg4ONr6+vqVmzpunbt+9lP9nrSVAyxpjMzEwzfPhwExwcbAICAkyHDh1MQkKCW517773XNGjQwJQvX974+fmZ+vXrm7Fjx5q0tLTLngNF4zDGw4vKAFCGnTp1SsHBwXr11Vc1bty4ku5OsZgzZ47Gjx+vr7/+ukjPLQL+yLhHCQB08aPbNWvWLNLDHEuL5ORkHTp0SDNmzNDtt99OSAKKgBUl/CHk5+e7PNOmIDz2H6VNXl5eoZ80czgc8vb2Vr169ZSZmamoqCgtW7bM7aPvAOwISvhDGDlypJYuXVpoHX4UUNp069ZNiYmJ1v1169ZVamrqtesQUAYRlPCHkJqaetkH9BX2fBPgenTgwAGdOnXKut/f39+jp8oDsCMoAQAAWFy9x9ICAACUMdy9eoXy8/OVnp6uSpUqefR0WwAAUPKMMTp16pTCw8M9+jNGBKUrlJ6ertq1a5d0NwAAwBU4cuTIZf84tURQumKX/ibWkSNHFBgYWMK9AQAAnsjJyVHt2rWd7+OXQ1C6QpcutwUGBhKUAAAoZTy9bYabuQEAACwISgAAABYEJQAAAAuCEgAAgAVBCQAAwIKgBAAAYEFQAgAAsCAoAQAAWBCUAAAALAhKAAAAFgQlAAAAC4ISAACABUEJAADAgqAEAABgQVACAACwICgBAABYEJQAAAAsCEoAAAAWBCUAAAALghIAAIAFQQkAAMCCoAQAAGBBUAIAALAgKAEAAFgQlAAAACwISgAAABYEJQAAAAuCEgAAgAVBCQAAwIKgBAAAYEFQAgAAsCAoAQAAWBCUAAAALAhKAAAAFgQlAAAAC4ISAACABUEJAADAgqAEAABgQVACAACwICgBAABYEJQAAAAsCEoAAAAWBCUAAACLEg9K8+fPV0REhAICAhQZGamtW7cWWj8xMVGRkZEKCAhQ/fr1tXDhQpf9cXFxcjgcbtvZs2eddWJjY9W2bVtVqlRJ1atX18CBA3XgwIFiGR8AACi9SjQorV69WjExMXryySeVnJysqKgo9e7dW2lpaQXWP3TokPr06aOoqCglJyfriSee0Pjx47VmzRqXeoGBgcrIyHDZAgICnPsTExM1btw4bd++XQkJCcrNzVV0dLTOnDlTrOMFAACli8MYY0rq5O3bt1fr1q21YMECZ1mzZs00cOBAxcbGutWfPHmy1q9fr/379zvLxo4dq927dyspKUnSxRWlmJgYZWVledyPn3/+WdWrV1diYqJuvvlmj9rk5OQoKChI2dnZCgwM9PhcAACg5BT1/bvEVpTOnz+vL774QtHR0S7l0dHR2rZtW4FtkpKS3Or37NlTu3bt0oULF5xlp0+fVt26dVWrVi3169dPycnJhfYlOztbkhQcHHwlQwEAAGVUiQWl48ePKy8vT6GhoS7loaGhyszMLLBNZmZmgfVzc3N1/PhxSVLTpk0VFxen9evXa+XKlQoICFDnzp313XffFXhMY4wmTpyoLl26qEWLFtb+njt3Tjk5OS4bAAAo23xKugMOh8Pla2OMW9nl6v+2vEOHDurQoYNzf+fOndW6dWvNmTNHs2fPdjveQw89pK+++kqfffZZof2MjY3V9OnTCx8MAAAoU0psRSkkJETe3t5uq0fHjh1zWzW6JCwsrMD6Pj4+qlq1aoFtvLy81LZt2wJXlB5++GGtX79eW7ZsUa1atQrt75QpU5Sdne3cjhw5Umh9AABQ+pVYUPLz81NkZKQSEhJcyhMSEtSpU6cC23Ts2NGt/ubNm9WmTRv5+voW2MYYo5SUFNWoUcOl7KGHHtK7776rjz/+WBEREZftr7+/vwIDA102AABQtpXopbeJEydq2LBhatOmjTp27KjXX39daWlpGjt2rKSLqzhHjx7VG2+8IeniJ9zmzp2riRMnavTo0UpKStLixYu1cuVK5zGnT5+uDh06qFGjRsrJydHs2bOVkpKiefPmOeuMGzdOK1as0Lp161SpUiXnKlVQUJDKlSt3Db8DAADgelaiQWnIkCE6ceKEZsyYoYyMDLVo0ULx8fGqW7euJCkjI8PlmUoRERGKj4/XhAkTNG/ePIWHh2v27NkaNGiQs05WVpYefPBBZWZmKigoSK1atdKnn36qdu3aOetcehxBt27dXPqzZMkSjRw5svgGDAAASpUSfY5SacZzlAAAKH1KzXOUAAAArncEJQAAAAuCEgAAgAVBCQAAwIKgBAAAYEFQAgAAsCAoAQAAWBCUAAAALAhKAAAAFgQlAAAAC4ISAACABUEJAADAgqAEAABgQVACAACwICgBAABYEJQAAAAsCEoAAAAWBCUAAAALghIAAIAFQQkAAMCCoAQAAGBBUAIAALAgKAEAAFgQlAAAACwISgAAABYEJQAAAAuCEgAAgAVBCQAAwIKgBAAAYEFQAgAAsCAoAQAAWBCUAAAALAhKAAAAFgQlAAAAC4ISAACABUEJAADAgqAEAABgQVACAACwICgBAABYEJQAAAAsCEoAAAAWBCUAAAALghIAAIAFQQkAAMCCoAQAAGBBUAIAALAgKAEAAFgQlAAAACwISgAAABYEJQAAAAuCEgAAgAVBCQAAwIKgBAAAYEFQAgAAsCAoAQAAWBCUAAAALEo8KM2fP18REREKCAhQZGSktm7dWmj9xMRERUZGKiAgQPXr19fChQtd9sfFxcnhcLhtZ8+eddb59NNP1b9/f4WHh8vhcOi9994rjqEBAIBSrkSD0urVqxUTE6Mnn3xSycnJioqKUu/evZWWllZg/UOHDqlPnz6KiopScnKynnjiCY0fP15r1qxxqRcYGKiMjAyXLSAgwLn/zJkzuummmzR37txiHR8AACjdHMYYU1Inb9++vVq3bq0FCxY4y5o1a6aBAwcqNjbWrf7kyZO1fv167d+/31k2duxY7d69W0lJSZIurijFxMQoKyvLoz44HA6tXbtWAwcOLFLfc3JyFBQUpOzsbAUGBhapLQAAKBlFff8usRWl8+fP64svvlB0dLRLeXR0tLZt21Zgm6SkJLf6PXv21K5du3ThwgVn2enTp1W3bl3VqlVL/fr1U3Jy8tUfAAAAKPNKLCgdP35ceXl5Cg0NdSkPDQ1VZmZmgW0yMzMLrJ+bm6vjx49Lkpo2baq4uDitX79eK1euVEBAgDp37qzvvvvud/X33LlzysnJcdkAAEDZVuI3czscDpevjTFuZZer/9vyDh066N5779VNN92kqKgovfXWW2rcuLHmzJnzu/oZGxuroKAg51a7du3fdTwAAHD9K7GgFBISIm9vb7fVo2PHjrmtGl0SFhZWYH0fHx9VrVq1wDZeXl5q27bt715RmjJlirKzs53bkSNHftfxAADA9a/EgpKfn58iIyOVkJDgUp6QkKBOnToV2KZjx45u9Tdv3qw2bdrI19e3wDbGGKWkpKhGjRq/q7/+/v4KDAx02QAAQNnmU5InnzhxooYNG6Y2bdqoY8eOev3115WWlqaxY8dKuriKc/ToUb3xxhuSLn7Cbe7cuZo4caJGjx6tpKQkLV68WCtXrnQec/r06erQoYMaNWqknJwczZ49WykpKZo3b56zzunTp3Xw4EHn14cOHVJKSoqCg4NVp06dazR6AABwvSvRoDRkyBCdOHFCM2bMUEZGhlq0aKH4+HjVrVtXkpSRkeHyTKWIiAjFx8drwoQJmjdvnsLDwzV79mwNGjTIWScrK0sPPvigMjMzFRQUpFatWunTTz9Vu3btnHV27dql7t27O7+eOHGiJGnEiBGKi4sr5lEDAIDSokSfo1Sa8RwlAABKn1LzHCUAAIDrHUEJAADAgqAEAABgQVACAACwICgBAABYEJQAAAAsCEoAAAAWBCUAAAALghIAAIAFQQkAAMCCoAQAAGBBUAIAALAgKAEAAFgQlAAAACwISgAAABYEJQAAAAuCEgAAgAVBCQAAwIKgBAAAYEFQAgAAsCAoAQAAWBCUAAAALAhKAAAAFgQlAAAAC4ISAACABUEJAADAgqAEAABgQVACAACwICgBAABYEJQAAAAsCEoAAAAWBCUAAAALghIAAIAFQQkAAMCCoAQAAGBBUAIAALAgKAEAAFgQlAAAACwISgAAABYEJQAAAAuCEgAAgAVBCQAAwIKgBAAAYEFQAgAAsCAoAQAAWBCUAAAALAhKAAAAFgQlAAAAC4ISAACABUEJAADAgqAEAABgQVACAACw8ClK5R07dmj9+vW6cOGCbrvtNkVHRxdXvwAAAEqcx0Fp7dq1Gjx4sAICAuTj46OXX35ZL7/8smJiYoqxewAAACXH40tvs2bN0siRI5WVlaWsrCxNnz5dzz33XHH2DQAAoEQ5jDHGk4qBgYHatWuXGjduLEk6d+6cKlSooMzMTIWEhBRrJ69HOTk5CgoKUnZ2tgIDA0u6OwAAwANFff/2eEXp9OnTqly5svNrf39/lStXTjk5OVfUUQAAgOtdkT71tmnTJq1fv9655efn66OPPnIpK6r58+crIiJCAQEBioyM1NatWwutn5iYqMjISAUEBKh+/fpauHChy/64uDg5HA637ezZs7/rvAAA4I+nSJ96GzFihFvZmDFjnP92OBzKy8vz+HirV69WTEyM5s+fr86dO+sf//iHevfurX379qlOnTpu9Q8dOqQ+ffpo9OjRWr58uT7//HP99a9/VbVq1TRo0CBnvcDAQB04cMClbUBAwBWfFwAA/DF5fI9ScWjfvr1at26tBQsWOMuaNWumgQMHKjY21q3+5MmTtX79eu3fv99ZNnbsWO3evVtJSUmSLq4oxcTEKCsr66qdtyDcowQAQOlTbPcoXW3nz5/XF1984fYspujoaG3btq3ANklJSW71e/bsqV27dunChQvOstOnT6tu3bqqVauW+vXrp+Tk5N91Xunizes5OTkuGwAAKNs8vvTm6f1HAwYM8Kje8ePHlZeXp9DQUJfy0NBQZWZmFtgmMzOzwPq5ubk6fvy4atSooaZNmyouLk433nijcnJy9Nprr6lz587avXu3GjVqdEXnlaTY2FhNnz7do7EBAICyweOgNHDgwMvWKeo9Spfa/JYxxq3scvV/W96hQwd16NDBub9z585q3bq15syZo9mzZ1/xeadMmaKJEyc6v87JyVHt2rWt9QEAQOnncVDKz8+/qicOCQmRt7e32yrOsWPH3FZ7LgkLCyuwvo+Pj6pWrVpgGy8vL7Vt21bffffdFZ9Xuvg4BH9//8uOCwAAlB0e36M0atQonTp16qqd2M/PT5GRkUpISHApT0hIUKdOnQps07FjR7f6mzdvVps2beTr61tgG2OMUlJSVKNGjSs+LwAA+IMyHvLy8jI//fSTp9U9smrVKuPr62sWL15s9u3bZ2JiYkyFChVMamqqMcaYxx9/3AwbNsxZ/4cffjDly5c3EyZMMPv27TOLFy82vr6+5p133nHWeeaZZ8wHH3xgvv/+e5OcnGzuu+8+4+PjY3bs2OHxeT2RnZ1tJJns7Oyr8J0AAADXQlHfvz2+9GaK4SkCQ4YM0YkTJzRjxgxlZGSoRYsWio+PV926dSVJGRkZSktLc9aPiIhQfHy8JkyYoHnz5ik8PFyzZ892eYZSVlaWHnzwQWVmZiooKEitWrXSp59+qnbt2nl8XgAAAKkIz1Hy8vLSTz/9pGrVqhV3n0oFnqMEAEDpU9T37yI9mbtx48aFfjJMkk6ePFmUQwIAAFy3ihSUpk+frqCgoOLqCwAAwHWlSEHpL3/5i6pXr15cfQEAALiuePx4gMtdcgMAAChrPA5KxfGpNwAAgOtZiT2ZGwAA4Hrn8YoSAADAHw1BCQAAwIKgBAAAYEFQAgAAsCAoAQAAWBCUAAAALAhKAAAAFgQlAAAAC4ISAACABUEJAADAgqAEAABgQVACAACwICgBAABYEJQAAAAsCEoAAAAWBCUAAAALghIAAIAFQQkAAMCCoAQAAGBBUAIAALAgKAEAAFgQlAAAACwISgAAABYEJQAAAAuCEgAAgAVBCQAAwIKgBAAAYEFQAgAAsCAoAQAAWBCUAAAALAhKAAAAFgQlAAAAC4ISAACABUEJAADAgqAEAABgQVACAACwICgBAABYEJQAAAAsCEoAAAAWBCUAAAALghIAAIAFQQkAAMCCoAQAAGBBUAIAALAgKAEAAFgQlAAAACwISgAAABYEJQAAAAuCEgAAgAVBCQAAwKLEg9L8+fMVERGhgIAARUZGauvWrYXWT0xMVGRkpAICAlS/fn0tXLjQWnfVqlVyOBwaOHCgS/mpU6cUExOjunXrqly5curUqZN27tx5NYYDAADKkBINSqtXr1ZMTIyefPJJJScnKyoqSr1791ZaWlqB9Q8dOqQ+ffooKipKycnJeuKJJzR+/HitWbPGre7hw4c1adIkRUVFue174IEHlJCQoGXLlmnPnj2Kjo7WbbfdpqNHj171MQIAgNLLYYwxJXXy9u3bq3Xr1lqwYIGzrFmzZho4cKBiY2Pd6k+ePFnr16/X/v37nWVjx47V7t27lZSU5CzLy8tT165ddd9992nr1q3KysrSe++9J0n69ddfValSJa1bt059+/Z1tmnZsqX69eun5557zqO+5+TkKCgoSNnZ2QoMDCzq0AEAQAko6vt3ia0onT9/Xl988YWio6NdyqOjo7Vt27YC2yQlJbnV79mzp3bt2qULFy44y2bMmKFq1arp/vvvdztGbm6u8vLyFBAQ4FJerlw5ffbZZ9b+njt3Tjk5OS4bAAAo20osKB0/flx5eXkKDQ11KQ8NDVVmZmaBbTIzMwusn5ubq+PHj0uSPv/8cy1evFiLFi0q8BiVKlVSx44d9eyzzyo9PV15eXlavny5duzYoYyMDGt/Y2NjFRQU5Nxq165dlOECAIBSqMRv5nY4HC5fG2Pcyi5X/1L5qVOndO+992rRokUKCQmxHmPZsmUyxqhmzZry9/fX7Nmzdffdd8vb29vaZsqUKcrOznZuR44c8WR4AACgFPMpqROHhITI29vbbfXo2LFjbqtGl4SFhRVY38fHR1WrVtXevXuVmpqq/v37O/fn5+dLknx8fHTgwAE1aNBADRo0UGJios6cOaOcnBzVqFFDQ4YMUUREhLW//v7+8vf3v9LhAgCAUqjEVpT8/PwUGRmphIQEl/KEhAR16tSpwDYdO3Z0q79582a1adNGvr6+atq0qfbs2aOUlBTnNmDAAHXv3l0pKSlul8sqVKigGjVq6D//+Y82bdqk22+//eoOEgAAlGoltqIkSRMnTtSwYcPUpk0bdezYUa+//rrS0tI0duxYSRcvdx09elRvvPGGpIufcJs7d64mTpyo0aNHKykpSYsXL9bKlSslSQEBAWrRooXLOSpXrixJLuWbNm2SMUZNmjTRwYMH9eijj6pJkya67777rsGoAQBAaVGiQWnIkCE6ceKEZsyYoYyMDLVo0ULx8fGqW7euJCkjI8PlmUoRERGKj4/XhAkTNG/ePIWHh2v27NkaNGhQkc6bnZ2tKVOm6Mcff1RwcLAGDRqkmTNnytfX96qODwAAlG4l+hyl0oznKAEAUPqUmucoAQAAXO8ISgAAABYEJQAAAAuCEgAAgAVBCQAAwIKgBAAAYEFQAgAAsCAoAQAAWBCUAAAALAhKAAAAFgQlAAAAC4ISAACABUEJAADAgqAEAABgQVACAACwICgBAABYEJQAAAAsCEoAAAAWBCUAAAALghIAAIAFQQkAAMCCoAQAAGBBUAIAALAgKAEAAFgQlAAAACwISgAAABYEJQAAAAuCEgAAgAVBCQAAwIKgBAAAYEFQAgAAsCAoAQAAWBCUAAAALAhKAAAAFgQlAAAAC4ISAACABUEJAADAgqAEAABgQVACAACwICgBAABYEJQAAAAsCEoAAAAWBCUAAAALghIAAIAFQQkAAMCCoAQAAGBBUAIAALAgKAEAAFgQlAAAACwISgAAABYEJQAAAAuCEgAAgAVBCQAAwIKgBAAAYEFQAgAAsCAoAQAAWJR4UJo/f74iIiIUEBCgyMhIbd26tdD6iYmJioyMVEBAgOrXr6+FCxda665atUoOh0MDBw50Kc/NzdVTTz2liIgIlStXTvXr19eMGTOUn59/NYYEAADKiBINSqtXr1ZMTIyefPJJJScnKyoqSr1791ZaWlqB9Q8dOqQ+ffooKipKycnJeuKJJzR+/HitWbPGre7hw4c1adIkRUVFue174YUXtHDhQs2dO1f79+/Xiy++qL/97W+aM2fOVR8jAAAovRzGGFNSJ2/fvr1at26tBQsWOMuaNWumgQMHKjY21q3+5MmTtX79eu3fv99ZNnbsWO3evVtJSUnOsry8PHXt2lX33Xeftm7dqqysLL333nvO/f369VNoaKgWL17sLBs0aJDKly+vZcuWedT3nJwcBQUFKTs7W4GBgUUZNgAAKCFFff8usRWl8+fP64svvlB0dLRLeXR0tLZt21Zgm6SkJLf6PXv21K5du3ThwgVn2YwZM1StWjXdf//9BR6nS5cu+uijj/Ttt99Kknbv3q3PPvtMffr0sfb33LlzysnJcdkAAEDZ5lNSJz5+/Ljy8vIUGhrqUh4aGqrMzMwC22RmZhZYPzc3V8ePH1eNGjX0+eefa/HixUpJSbGee/LkycrOzlbTpk3l7e2tvLw8zZw5U0OHDrW2iY2N1fTp0z0fIAAAKPVK/GZuh8Ph8rUxxq3scvUvlZ86dUr33nuvFi1apJCQEOsxVq9ereXLl2vFihX68ssvtXTpUr300ktaunSptc2UKVOUnZ3t3I4cOeLJ8AAAQClWYitKISEh8vb2dls9OnbsmNuq0SVhYWEF1vfx8VHVqlW1d+9epaamqn///s79lz7J5uPjowMHDqhBgwZ69NFH9fjjj+svf/mLJOnGG2/U4cOHFRsbqxEjRhR4bn9/f/n7+1/xeAEAQOlTYitKfn5+ioyMVEJCgkt5QkKCOnXqVGCbjh07utXfvHmz2rRpI19fXzVt2lR79uxRSkqKcxswYIC6d++ulJQU1a5dW5L0yy+/yMvLdeje3t48HgAAALgosRUlSZo4caKGDRumNm3aqGPHjnr99deVlpamsWPHSrp4uevo0aN64403JF38hNvcuXM1ceJEjR49WklJSVq8eLFWrlwpSQoICFCLFi1czlG5cmVJcinv37+/Zs6cqTp16uiGG25QcnKyXnnlFY0aNeoajBoAAJQWJRqUhgwZohMnTmjGjBnKyMhQixYtFB8fr7p160qSMjIyXJ6pFBERofj4eE2YMEHz5s1TeHi4Zs+erUGDBhXpvHPmzNHUqVP117/+VceOHVN4eLjGjBmjp59++qqODwAAlG4l+hyl0oznKAEAUPqUmucoAQAAXO8ISgAAABYEJQAAAAuCEgAAgAVBCQAAwIKgBAAAYEFQAgAAsCAoAQAAWBCUAAAALAhKAAAAFgQlAAAAC4ISAACABUEJAADAgqAEAABgQVACAACwICgBAABYEJQAAAAsCEoAAAAWBCUAAAALghIAAIAFQQkAAMCCoAQAAGBBUAIAALAgKAEAAFgQlAAAACwISgAAABYEJQAAAAuCEgAAgAVBCQAAwIKgBAAAYEFQAgAAsCAoAQAAWBCUAAAALAhKAAAAFgQlAAAAC4ISAACABUEJAADAgqAEAABgQVACAACwICgBAABYEJQAAAAsCEoAAAAWBCUAAAALn5LuQGlljJEk5eTklHBPAACApy69b196H78cgtIVOnXqlCSpdu3aJdwTAABQVKdOnVJQUNBl6zmMp5EKLvLz85Wenq5KlSrJ4XCUdHeccnJyVLt2bR05ckSBgYEl3Z1iUdbHyPhKt7I+Pqnsj7Gsj08q+2MsbHzGGJ06dUrh4eHy8rr8HUisKF0hLy8v1apVq6S7YRUYGFgmX/y/VdbHyPhKt7I+Pqnsj7Gsj08q+2O0jc+TlaRLuJkbAADAgqAEAABgQVAqY/z9/TVt2jT5+/uXdFeKTVkfI+Mr3cr6+KSyP8ayPj6p7I/xao6Pm7kBAAAsWFECAACwICgBAABYEJQAAAAsCEp/EA6HQ++9915JdwO/A3NYujF/pR9zWPpdyRwSlEqpkSNHauDAgSXdjSsSGxurtm3bqlKlSqpevboGDhyoAwcOuNQxxuiZZ55ReHi4ypUrp27dumnv3r3O/SdPntTDDz+sJk2aqHz58qpTp47Gjx+v7Oxsl+PMnDlTnTp1Uvny5VW5cuVrMTyPMYeXn8PU1FTdf//9ioiIULly5dSgQQNNmzZN58+fv2ZjtWH+PPsZHDBggOrUqaOAgADVqFFDw4YNU3p6+jUZ5+Uwh57N4SXnzp1Ty5Yt5XA4lJKSUpzD89i1mEOCEq65xMREjRs3Ttu3b1dCQoJyc3MVHR2tM2fOOOu8+OKLeuWVVzR37lzt3LlTYWFh6tGjh/Nv7KWnpys9PV0vvfSS9uzZo7i4OH3wwQe6//77Xc51/vx5DR48WP/n//yfazrGsu5azeE333yj/Px8/eMf/9DevXv197//XQsXLtQTTzxxzcdcllzLn8Hu3bvrrbfe0oEDB7RmzRp9//33uuuuu67peMuiazmHlzz22GMKDw+/JuO7rhiUSiNGjDC33367McaYunXrmr///e8u+2+66SYzbdo059eSzNq1a69Z/4ri2LFjRpJJTEw0xhiTn59vwsLCzPPPP++sc/bsWRMUFGQWLlxoPc5bb71l/Pz8zIULF9z2LVmyxAQFBV31vv8ezKG7wubwkhdffNFERERcvc5fIebPnSfzt27dOuNwOMz58+ev3gCuEHPozjaH8fHxpmnTpmbv3r1GkklOTi6WcRTVtZhDVpRQ4i4t8wYHB0uSDh06pMzMTEVHRzvr+Pv7q2vXrtq2bVuhxwkMDJSPD3/C8Fq7lnOYnZ3tPA+ujms1fydPntSbb76pTp06ydfX9yqOAMU5hz/99JNGjx6tZcuWqXz58sU0gusXQQklyhijiRMnqkuXLmrRooUkKTMzU5IUGhrqUjc0NNS577+dOHFCzz77rMaMGVO8HYabazmH33//vebMmaOxY8depd7jWszf5MmTVaFCBVWtWlVpaWlat27dVR7FH1txzqExRiNHjtTYsWPVpk2bYhrB9Y2ghBL10EMP6auvvtLKlSvd9jkcDpevjTFuZZKUk5Ojvn37qnnz5po2bVqx9RUFu1ZzmJ6erl69emnw4MF64IEHrk7ncU3m79FHH1VycrI2b94sb29vDR8+XIY/CnHVFOcczpkzRzk5OZoyZcrV73gpQVAqA7y8vNz+07lw4UIJ9cZzDz/8sNavX68tW7aoVq1azvKwsDBJcvut59ixY26/HZ06dUq9evVSxYoVtXbt2lK7nM8cFj6H6enp6t69uzp27KjXX3+9GEby+zB/hc9fSEiIGjdurB49emjVqlWKj4/X9u3bi2FEV445LHgOP/74Y23fvl3+/v7y8fFRw4YNJUlt2rTRiBEjimtYV6S45pCgVAZUq1ZNGRkZzq9zcnJ06NChEuxR4Ywxeuihh/Tuu+/q448/VkREhMv+iIgIhYWFKSEhwVl2/vx5JSYmqlOnTs6ynJwcRUdHy8/PT+vXr1dAQMA1G8PVxhza5/Do0aPq1q2bWrdurSVLlsjL6/r7b4v58/xn8NIb2blz567SaK4O5rDgOZw9e7Z2796tlJQUpaSkKD4+XpK0evVqzZw5sxhHWHTFNYfc9VoG3HLLLYqLi1P//v1VpUoVTZ06Vd7e3iXdLatx48ZpxYoVWrdunSpVquT8jScoKEjlypWTw+FQTEyMZs2apUaNGqlRo0aaNWuWypcvr7vvvlvSxd+AoqOj9csvv2j58uXKyclRTk6OpIs/LJfGn5aWppMnTyotLU15eXnOZ380bNhQFStWvPaDt2AOC57D9PR0devWTXXq1NFLL72kn3/+2dmHS78xXw+Yv4Ln79///rf+/e9/q0uXLqpSpYp++OEHPf3002rQoIE6duxYYuMvCHNY8BzWqVPH5byX/t9s0KCBywrW9aDY5rBIn5HDdWPYsGFm0KBBxhhjsrOzzZ///GcTGBhoateubeLi4q7rj7VKKnBbsmSJs05+fr6ZNm2aCQsLM/7+/ubmm282e/bsce7fsmWL9TiHDh1y1hsxYkSBdbZs2XLtBmzBHF5+DpcsWWKtU9KYv8vP31dffWW6d+9ugoODjb+/v6lXr54ZO3as+fHHH6/xiAvGHHr2/+hvHTp06Lp6PMC1mEPH/2uIUqZXr15q2LCh5s6dW9JdwRViDks35q/0Yw5Lv2sxh9ffxX4U6j//+Y/ef/99ffLJJ7rttttKuju4Asxh6cb8lX7MYel3LeeQe5RKmVGjRmnnzp165JFHdPvtt5d0d3AFmMPSjfkr/ZjD0u9aziGX3gAAACy49AYAAGBBUAIAALAgKAEAAFgQlAAAACwISgD+UD755BM5HA5lZWWVdFcAlAJ86g1AmdatWze1bNlSr776qqSLf+/q5MmTCg0NLfCvqAPAb/EcJQB/KH5+ftfV34kDcH3j0huAMmvkyJFKTEzUa6+9JofDIYfDobi4OJdLb3FxcapcubI2bNigJk2aqHz58rrrrrt05swZLV26VPXq1VOVKlX08MMPKy8vz3ns8+fP67HHHlPNmjVVoUIFtW/fXp988knJDBRAsWFFCUCZ9dprr+nbb79VixYtNGPGDEnS3r173er98ssvmj17tlatWqVTp07pzjvv1J133qnKlSsrPj5eP/zwgwYNGqQuXbpoyJAhkqT77rtPqampWrVqlcLDw7V27Vr16tVLe/bsUaNGja7pOAEUH4ISgDIrKChIfn5+Kl++vPNy2zfffONW78KFC1qwYIEaNGggSbrrrru0bNky/fTTT6pYsaKaN2+u7t27a8uWLRoyZIi+//57rVy5Uj/++KPCw8MlSZMmTdIHH3ygJUuWaNasWddukACKFUEJwB9e+fLlnSFJkkJDQ1WvXj1VrFjRpezYsWOSpC+//FLGGDVu3NjlOOfOnVPVqlWvTacBXBMEJQB/eL6+vi5fOxyOAsvy8/MlSfn5+fL29tYXX3whb29vl3q/DVcASj+CEoAyzc/Pz+Um7KuhVatWysvL07FjxxQVFXVVjw3g+sKn3gCUafXq1dOOHTuUmpqq48ePO1eFfo/GjRvrnnvu0fDhw/Xuu+/q0KFD2rlzp1544QXFx8dfhV4DuF4QlACUaZMmTZK3t7eaN2+uatWqKS0t7aocd8mSJRo+fLgeeeQRNWnSRAMGDNCOHTtUu3btq3J8ANcHnswNAABgwYoSAACABUEJAADAgqAEAABgQVACAACwICgBAABYEJQAAAAsCEoAAAAWBCUAAAALghIAAIAFQQkAAMCCoAQAAGBBUAIAALD4v8oYujnFl7X7AAAAAElFTkSuQmCC",
+      "text/plain": [
+       "<Figure size 640x480 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "transport_model.mesh.TIP.isel(nface=207, time=slice(0, 5000)).plot()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 44,
+   "id": "c7e3d3e4",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[<matplotlib.lines.Line2D at 0x1c25d3fd490>]"
+      ]
+     },
+     "execution_count": 44,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAkoAAAHFCAYAAAANLdYJAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjguNCwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8fJSN1AAAACXBIWXMAAA9hAAAPYQGoP6dpAAA6R0lEQVR4nO3de1xVZd7///eWswfwgIGkIp4tm1HRFBXTmUQzNcscpyZTM9N7Mm90LFMr01KmwzSFx8m8xWw8NGOWt2HKnUZW5GiBmZnTAcIEMjQBLeV0/f7wy/61Z3PpRtEt9Ho+HuvxiGt91lrXta9t+81aay8cxhgjAAAAuKnj7Q4AAABcqQhKAAAAFgQlAAAAC4ISAACABUEJAADAgqAEAABgQVACAACwICgBAABYEJQAAAAsCEqosTZs2KBrr71WQUFBcjgcysjI8HaXrnhZWVlyOByVLuvXr/doHydPnlR8fLwiIiIUGBioLl26WLf9+OOPdeONN6p+/fpq2LChbrvtNn399ddudXl5eZoyZYpat26toKAgRUZGasKECcrOzr6o8V4IT8c3bty4Sl/Hjh07XtTxFy1apLZt28rf318Oh0MnTpy4qP39UvzrX//SoEGD1KBBA9WvX18DBgzQ+++/71ZX1XlbtGiROnbsqICAAEVFRWnevHkqKSnxqE8lJSWaN2+eWrVqpYCAAHXs2FGLFi26qHHi8vP1dgeAC/H9999rzJgxGjx4sJYuXaqAgAC1b9/e292qMR544AHdeeedLm3t2rXzaNvbbrtNe/bs0Z///Ge1b99ea9eu1R133KHy8nKXfX7++efq37+/unTpoldffVWnT5/WY489ptjYWGVkZKhp06aSpDNnzqhfv3764YcfNG/ePF1zzTU6dOiQ5s6dq23btungwYNq0KBB9Q2+msYnSUFBQdqxY4db24XKyMjQ1KlTde+992rs2LHy9fW9rGOvqfbs2aN+/frp+uuv15o1a2SM0dNPP63f/va32rlzp2JiYlzqPZ23BQsW6NFHH9XDDz+suLg47dmzR4888oiOHDmiF1988bz9+uMf/6g1a9boiSeeUI8ePbRt2zb993//t4qKijR79uyLGzQuHwPUQO+9956RZDZs2ODtrtQomZmZRpJ55plnLmj7N99800gya9eudWkfOHCgiYiIMKWlpc62UaNGmdDQUFNQUOBsy8rKMn5+fuahhx5ytqWkpBhJ5qWXXnLZ59q1a40k89prr11QX//T2LFjzQ033HDOmqqMb+zYsaZevXrV0rcKr7zyipFkdu/eXa37re0GDRpkwsLCzKlTp5xthYWFJjQ01PTu3dul1tN5y8/PN4GBgea+++5zaV+wYIFxOBzmwIED59z+008/NQ6HwyxcuNClfeLEiSYoKMgcO3bsvH3AlYFLb6hxxo0bp759+0qSRo8eLYfDof79+0uS9u7dq9///vdq1aqVgoKC1KpVK91xxx365ptv3PZz5MgR3XfffWrRooX8/f0VERGh22+/Xd99952zprCwUDNmzFBUVJT8/f119dVXKz4+XqdOnfK4v/n5+WrRooV69+7tcsr+s88+U7169TRmzJgLfCUuv02bNql+/foaNWqUS/v48eOVk5Oj3bt3S5JKS0u1ZcsWjRw5UsHBwc66yMhIDRgwQJs2bXK2+fn5SZJCQkJc9tmwYUNJUmBgoEv73r17NXz4cDVu3FiBgYHq2rWrXn311cs6vkuhf//+uuuuuyRJPXv2lMPh0Lhx4yRJKSkpuuWWW9S8eXMFBgaqbdu2mjRpkvLz89328/nnn+uOO+5QWFiYAgIC1LJlS9199906c+aMsyYvL0+TJk1S8+bN5e/v77ykVFpa6nF/n3jiCfn6+urw4cNu6+655x41adJEp0+fruKrcGHef/999e/fX3Xr1nW2NWjQQP369dMHH3yg3NzcKu/zrbfe0unTpzV+/HiX9vHjx8sYo9dff/2c27/++usyxlS6/U8//aS33nqryn2CdxCUUOM8+uijWrJkiSRp4cKFSktL09KlSyWdvQenQ4cOev7557Vt2zY99dRTys3NVY8ePVw+VI4cOaIePXpo06ZNmj59urZu3arnn39eISEh+uGHHyRJP/74o2644QatXr1aU6dO1datWzVz5kwlJSVp+PDhMsZ41N/Q0FCtX79ee/bs0cyZM537HjVqlFq2bKnly5efc3tjjEpLSz1aPPXnP/9Z/v7+qlu3rvr27avNmzd7tN2nn36qTp06ydfX9ar9r371K+d6Sfrqq6/0008/Odv/s/bLL790foj26dNH0dHRevzxx7Vnzx6dPHlSH3/8sWbPnq1u3brpxhtvdG67c+dO9enTRydOnNDy5cv1xhtvqEuXLho9erSSkpI8Hv/Fjq/CTz/9pPDwcPn4+Kh58+aaMmWKjh8/fkHHXrp0qR555BFJ0qpVq5SWlqZHH31U0tnXMyYmRsuWLdP27dv12GOPaffu3erbt69L+N63b5969OihDz/8UPPnz9fWrVuVkJCgM2fOqLi4WNLZkHT99ddr27Zteuyxx7R161ZNmDBBCQkJmjhxosf9nTRpknx9ffW3v/3Npf348eNav369JkyY4BZyf64639fFxcUKCAhwa69o279/v0u7J/NWMdfXXXedS3uzZs0UGhrq9l74T59++qmaNm2q8PBwl3bbewlXMK+ezwIu0M6dO40k849//OOcdaWlpebkyZOmXr165oUXXnC233PPPcbPz8989tln1m0TEhJMnTp1zJ49e1za//nPfxpJJjk5uUp9fuqpp4wks2nTJjN27FgTFBRkPvnkk/NuVzFWT5bMzMxz7isnJ8dMnDjRvPrqq2bXrl3m73//u+nVq5eRZFasWHHevrRr184MGjSo0v1Kcl5meP/9940ks27dOrfahQsXGkkmJyfH2VZYWGiGDRvmMpb+/fu7XZ7o2LGj6dq1qykpKXFpHzp0qGnWrJkpKytztpWUlLgsd999t+nXr59be3l5eZXHZ4wxzz33nHnuuefM9u3bzfbt282cOXNM3bp1TceOHU1RUdH5XspKrVq1ykhye8/9XHl5uSkpKTHffPONkWTeeOMN57rf/OY3pmHDhubo0aPW7SdNmmTq169vvvnmG5f2Z5991kg67yWlnxs7dqy56qqrzJkzZ5xtTz31lKlTp85534sVY/VkOZ8uXbqY9u3bu81/69at3S6lejpvEydONAEBAZUer3379iYuLu6cfRo4cKDp0KFDpev8/f3dLunhysXN3KhVTp48qSeeeEIbN25UVlaWysrKnOsOHjzo/O+tW7dqwIAB6tSpk3VfW7ZsUefOndWlSxeX32oHDRokh8Ohd955RzfddJPHfXvwwQf17rvv6o477tDp06f10ksvuf22Wpno6Gjt2bPHo2NEREScc32zZs3cbkIdNWqUevbsqYcffljjxo1zO5vynxwOh8frPKktKSnR6NGj9emnn2rFihXq0KGDMjMz9eSTT2rgwIHasWOHQkJC9OWXX+rzzz/Xs88+K0kuczJkyBBt2bJFhw4dUqdOnZSVlaWoqKhKj1txqa/Czp07nZduqzK+adOmuawbOHCgunbtqttvv10rVqxwW38xjh49qscee0xvvvmmcnJyVF5e7lx38OBBDR8+XD/++KNSU1M1YcIE543yldmyZYsGDBigiIgIl9fwpptu0owZM5SamqprrrnGo37993//t1avXq1//OMf+sMf/qDy8nItW7ZMN998s1q1anXObYcNG+bx+/p8HnjgAU2YMEFTpkzRnDlzVF5ernnz5jkvudep8/9fPKnKvFXlvV7VGk+2x5WBoIRa5c4779Tbb7+tRx99VD169FBwcLAcDoeGDBmin376yVn3/fffq3nz5ufc13fffacvv/zS7YO1QmX3h5xLxT0nb775psLDwz2+N6l+/frq0qWLR7XnCzmV8fPz0+jRo/Xwww/riy++OGd4bNKkiY4dO+bWXnHZonHjxs46SdZah8PhvAdp5cqV2rp1q/bs2aPu3btLkmJjY9W3b1+1adNGzz//vObOneu8d2zGjBmaMWNGpf2rmJOIiAi3D+F58+YpJyfH7VJRhw4dqjw+m1tvvVX16tXThx9+eM66qigvL1dcXJxycnL06KOP6rrrrlO9evVUXl6uXr16Od/XP/zwg8rKyjx6X//v//5vtbyvu3btqtjYWC1ZskR/+MMftGXLFmVlZbm9xpVp3Lix231pF+qee+7R999/ryeffFLLli2TJMXExGjGjBl66qmndPXVV59z+8rmreIeqx9//NHl3ifp7PshOjr6nPts0qRJpY8sOXXqlIqLi8/7XsKVg6CEWqOgoEBbtmzR3Llz9fDDDzvbz5w543b/QdOmTfXtt9+ec3+hoaEKCgrS//zP/1jXV0Vubq7uv/9+denSRQcOHNCMGTOUmJh43u1SU1M1YMAAj46RmZl53t/kK2P+3/1WP//NuzLXXXed1q1bp9LSUpdQVnEPSOfOnSVJbdq0UVBQkNu9IRW1bdu2dd6/kpGRIR8fH3Xr1s2lrnXr1mrSpInzXo6K13vWrFm67bbbKu1fRejx9/d3hq4KTZo0UVFRkVv7hYzvXIwx530dq+LTTz/Vvn37lJSUpLFjxzrbv/zyS5e6xo0by8fHx6P39a9+9SstWLCg0vXnOyv5n6ZOnapRo0bp448/1uLFi9W+fXsNHDjwvNutXr3a7UZnG+PB/YAzZ85UfHy8vvjiCzVo0ECRkZGaNGmS6tWrd95QU3GMn89bxdne/fv3q2fPns72vLw85efnn/e9cN1112n9+vXKy8tzuU+pKu8lXBkISqg1HA6HjDFuN3W+9NJLLpfgpLOXGdasWaNDhw65nFH4uaFDh2rhwoVq0qSJ9TKOp8rKynTHHXfI4XBo69at+vvf/64ZM2aof//+1g/9CtV56a0yJSUl2rBhg0JDQ9W2bdtz1t56661asWKFNm7cqNGjRzvbV69erYiICOcHiq+vr4YNG6bXXntNTz/9tPNZQNnZ2dq5c6fL5Y2IiAiVlZVpz549Lh9I//73v3Xs2DHnGZIOHTqoXbt22rdvnxYuXFjlcXrC0/HZ/POf/9SPP/6oXr16VVufKi7R/Of7+j/P2gQFBemGG27QP/7xDy1YsMAa5IcOHark5GS1adNGjRo1uuj+3XrrrWrZsqX+9Kc/KTU1VX/96189uqxUnZfeKgQEBDgDSHZ2tjZs2KCJEyee99lWlc3b4MGDFRgYqKSkJJd5T0pKksPh0IgRI865z1tuuUWPPPKIVq9e7fwSR8X2QUFBGjx48AWMEF7h1TukgAtku5m7X79+pnHjxmbFihUmJSXFPPLII6ZZs2amYcOGZuzYsc66b7/91jRr1sxcddVV5vnnnzdvv/222bhxo5k4caI5ePCgMcaYkydPmq5du5rmzZubv/zlLyYlJcVs27bNrFixwowaNcp8+OGHHvd3zpw5pk6dOub//u//nG3Dhg0zDRs2NF9//fXFvRhVMG3aNDNlyhSzbt06s3PnTvPyyy+bHj16GElm1apVLrXz5s0zPj4+5p133nFpHzhwoGnUqJF58cUXzY4dO8zEiRONJPPKK6+41B08eNDUr1/f9OvXzyQnJ5vXXnvNdO7c2URERLjcbJydnW0aNmxorr76arNs2TKzY8cO89JLL5nWrVubevXqmc8//9xZu2PHDhMQEGDi4uLM2rVrTWpqqtm0aZNZuHChuf322885dk+eo+Tp+LKyskzv3r1NYmKiSU5ONlu3bjUPP/ywCQwMNNdee605efKkyz5vuOEGj25Kruxm7uLiYtOmTRsTGRlp1q5da9566y1z//33m/bt2xtJZu7cuc7ajIwMU79+fdO6dWtn/9etW2fuuOMOU1hYaIw5e2N6ZGSk6dixo1m6dKl5++23zZtvvmmWLFlibr75ZnP48OHz9vM/VXxRoV69eubEiRNV3v5i7d+/3zz++ONmy5YtJiUlxTz77LMmNDTUdO/e3eUG7arO25NPPmkcDoeZPXu2eeedd8wzzzxjAgICzMSJE13qVq9ebXx8fMzq1atd2u+9914TEBBgnnnmGfPOO++Y2bNnG4fDYRYsWHDpXgxUO4ISaiRbUPr222/NyJEjTaNGjUyDBg3M4MGDzaeffmoiIyNdgpIxxhw+fNjcc889Jjw83Pj5+ZmIiAjzu9/9znz33XfOmpMnT5pHHnnEdOjQwfj7+5uQkBBz3XXXmWnTppm8vDyP+rp9+3ZTp04dlw80Y4w5duyYadmypenRo4fLt4YupZUrV5rrr7/eNG7c2Pj6+ppGjRqZQYMGmW3btrnVzp0710gyO3fudGkvKioyU6dONeHh4cbf39/86le/qvTbbcYYs3fvXvPb3/7W1K1b1wQHB5sRI0aYL7/80q3uiy++MGPGjDGtWrUyAQEBpmXLlmb06NGVfgNr37595ne/+5256qqrjJ+fnwkPDze/+c1vzPLly885dk+DkifjO378uLn11ltNq1atTFBQkPH39zft2rUzDz30UKVBITo62oSHh5/32LZvvX322Wdm4MCBpkGDBqZRo0Zm1KhRJjs72y0oVdSOGjXKNGnSxPj7+5uWLVuacePGmdOnTztrvv/+ezN16lQTFRVl/Pz8TOPGjU10dLSZM2eOW1jwRFZWlpFkJk+eXOVtq8OhQ4ecvyT5+/ubtm3bmkceecRtLFWdN2OMeeGFF0z79u2dr+XcuXNNcXGxS03FvP3nLxvFxcVm7ty5pmXLlsbf39+0b9/eJCYmVuvYcek5jPHwYTAAgCorKipS48aN9fzzz+v+++/3dncuiUWLFmnq1Kn69NNPde2113q7O0C14h4lALiE3n33XV199dVVephjTZGenq7MzEzNnz9ft9xyCyEJtRJnlICLUF5e7vJMm8pcyFf2AW8qKys75zfNHA6HfHx81KpVK+Xl5Sk2NlZr1qxxewo1UBsQlICLMG7cOK1evfqcNfwTQ03Tv39/paamWtdHRkYqKyvr8nUI8CKCEnARsrKyzvuAvnM9twe4Eh06dEhFRUXW9QEBAR49VR6oDQhKAAAAFtX3+FgAAIBahrtML1B5eblycnLUoEED/rghAAA1hDFGRUVFioiI8OjPDRGULlBOTo5atGjh7W4AAIALcPjw4fP+EWmJoHTBKv521eHDhxUcHOzl3gAAAE8UFhaqRYsWzs/x8yEoXaCKy23BwcEEJQAAahhPb5vhZm4AAAALghIAAIAFQQkAAMCCoAQAAGBBUAIAALAgKAEAAFgQlAAAACwISgAAABYEJQAAAAuCEgAAgAVBCQAAwIKgBAAAYEFQAgAAsCAoAQAAWBCUAAAALAhKAAAAFgQlAAAAC4ISAACABUEJAADAgqAEAABgQVACAACwICgBAABYEJQAAAAsCEoAAAAWBCUAAAALghIAAIAFQQkAAMCCoAQAAGBBUAIAALAgKAEAAFgQlAAAACwISgAAABYEJQAAAAuCEgAAgAVBCQAAwIKgBAAAYEFQAgAAsCAoAQAAWBCUAAAALAhKAAAAFgQlAAAAC4ISAACABUEJAADAwutBaenSpYqKilJgYKCio6O1a9euc9anpqYqOjpagYGBat26tZYvX+6yPikpSQ6Hw205ffq0syYhIUE9evRQgwYNdNVVV2nEiBE6dOjQJRkfAACoubwalDZs2KD4+HjNmTNH6enpio2N1U033aTs7OxK6zMzMzVkyBDFxsYqPT1ds2fP1tSpU7Vx40aXuuDgYOXm5rosgYGBzvWpqam6//779eGHHyolJUWlpaWKi4vTqVOnLul4AQBAzeIwxhhvHbxnz57q1q2bli1b5mzr1KmTRowYoYSEBLf6mTNnavPmzTp48KCzbfLkydq3b5/S0tIknT2jFB8frxMnTnjcj++//15XXXWVUlNT1a9fP4+2KSwsVEhIiAoKChQcHOzxsQAAgPdU9fPba2eUiouL9dFHHykuLs6lPS4uTh988EGl26SlpbnVDxo0SHv37lVJSYmz7eTJk4qMjFTz5s01dOhQpaenn7MvBQUFkqTGjRtfyFAAAEAt5bWglJ+fr7KyMoWFhbm0h4WFKS8vr9Jt8vLyKq0vLS1Vfn6+JKljx45KSkrS5s2btW7dOgUGBqpPnz764osvKt2nMUbTp09X37591blzZ2t/z5w5o8LCQpcFAADUbr7e7oDD4XD52Rjj1na++p+39+rVS7169XKu79Onj7p166ZFixYpMTHRbX9TpkzRJ598ovfee++c/UxISNC8efPOPRgAAFCreO2MUmhoqHx8fNzOHh09etTtrFGF8PDwSut9fX3VpEmTSrepU6eOevToUekZpQceeECbN2/Wzp071bx583P2d9asWSooKHAuhw8fPmc9AACo+bwWlPz9/RUdHa2UlBSX9pSUFPXu3bvSbWJiYtzqt2/fru7du8vPz6/SbYwxysjIULNmzVzapkyZotdee007duxQVFTUefsbEBCg4OBglwUAANRuXr30Nn36dI0ZM0bdu3dXTEyMXnzxRWVnZ2vy5MmSzp7FOXLkiF5++WVJZ7/htnjxYk2fPl0TJ05UWlqaVq5cqXXr1jn3OW/ePPXq1Uvt2rVTYWGhEhMTlZGRoSVLljhr7r//fq1du1ZvvPGGGjRo4DxLFRISoqCgoMv4CgAAgCuZV4PS6NGjdezYMc2fP1+5ubnq3LmzkpOTFRkZKUnKzc11eaZSVFSUkpOTNW3aNC1ZskQRERFKTEzUyJEjnTUnTpzQfffdp7y8PIWEhKhr16569913df311ztrKh5H0L9/f5f+rFq1SuPGjbt0AwYAADWKV5+jVJPxHCUAAGqeGvMcJQAAgCsdQQkAAMCCoAQAAGBBUAIAALAgKAEAAFgQlAAAACwISgAAABYEJQAAAAuCEgAAgAVBCQAAwIKgBAAAYEFQAgAAsCAoAQAAWBCUAAAALAhKAAAAFgQlAAAAC4ISAACABUEJAADAgqAEAABgQVACAACwICgBAABYEJQAAAAsCEoAAAAWBCUAAAALghIAAIAFQQkAAMCCoAQAAGBBUAIAALAgKAEAAFgQlAAAACwISgAAABYEJQAAAAuCEgAAgAVBCQAAwIKgBAAAYEFQAgAAsCAoAQAAWBCUAAAALAhKAAAAFgQlAAAAC4ISAACABUEJAADAgqAEAABgQVACAACwICgBAABYEJQAAAAsCEoAAAAWBCUAAAALghIAAIAFQQkAAMCCoAQAAGBBUAIAALAgKAEAAFgQlAAAACwISgAAABYEJQAAAAuvB6WlS5cqKipKgYGBio6O1q5du85Zn5qaqujoaAUGBqp169Zavny5y/qkpCQ5HA635fTp086ad999V8OGDVNERIQcDodef/31SzE0AABQw3k1KG3YsEHx8fGaM2eO0tPTFRsbq5tuuknZ2dmV1mdmZmrIkCGKjY1Venq6Zs+eralTp2rjxo0udcHBwcrNzXVZAgMDnetPnTqlX//611q8ePElHR8AAKjZHMYY462D9+zZU926ddOyZcucbZ06ddKIESOUkJDgVj9z5kxt3rxZBw8edLZNnjxZ+/btU1pamqSzZ5Ti4+N14sQJj/rgcDi0adMmjRgxokp9LywsVEhIiAoKChQcHFylbQEAgHdU9fPba2eUiouL9dFHHykuLs6lPS4uTh988EGl26SlpbnVDxo0SHv37lVJSYmz7eTJk4qMjFTz5s01dOhQpaenV/8AAABAree1oJSfn6+ysjKFhYW5tIeFhSkvL6/SbfLy8iqtLy0tVX5+viSpY8eOSkpK0ubNm7Vu3ToFBgaqT58++uKLLy6qv2fOnFFhYaHLAgAAajev38ztcDhcfjbGuLWdr/7n7b169dJdd92lX//614qNjdWrr76q9u3ba9GiRRfVz4SEBIWEhDiXFi1aXNT+AADAlc9rQSk0NFQ+Pj5uZ4+OHj3qdtaoQnh4eKX1vr6+atKkSaXb1KlTRz169LjoM0qzZs1SQUGBczl8+PBF7Q8AAFz5vBaU/P39FR0drZSUFJf2lJQU9e7du9JtYmJi3Oq3b9+u7t27y8/Pr9JtjDHKyMhQs2bNLqq/AQEBCg4OdlkAAEDt5uvNg0+fPl1jxoxR9+7dFRMToxdffFHZ2dmaPHmypLNncY4cOaKXX35Z0tlvuC1evFjTp0/XxIkTlZaWppUrV2rdunXOfc6bN0+9evVSu3btVFhYqMTERGVkZGjJkiXOmpMnT+rLL790/pyZmamMjAw1btxYLVu2vEyjBwAAVzqvBqXRo0fr2LFjmj9/vnJzc9W5c2clJycrMjJSkpSbm+vyTKWoqCglJydr2rRpWrJkiSIiIpSYmKiRI0c6a06cOKH77rtPeXl5CgkJUdeuXfXuu+/q+uuvd9bs3btXAwYMcP48ffp0SdLYsWOVlJR0iUcNAABqCq8+R6km4zlKAADUPDXmOUoAAABXOoISAACABUEJAADAgqAEAABgQVACAACwICgBAABYEJQAAAAsCEoAAAAWBCUAAAALghIAAIAFQQkAAMCCoAQAAGBBUAIAALAgKAEAAFgQlAAAACwISgAAABYEJQAAAAuCEgAAgAVBCQAAwIKgBAAAYEFQAgAAsCAoAQAAWBCUAAAALAhKAAAAFgQlAAAAC4ISAACABUEJAADAgqAEAABgQVACAACwICgBAABYEJQAAAAsCEoAAAAWBCUAAAALghIAAIAFQQkAAMCCoAQAAGBBUAIAALAgKAEAAFgQlAAAACwISgAAABYEJQAAAAuCEgAAgAVBCQAAwIKgBAAAYEFQAgAAsCAoAQAAWBCUAAAALAhKAAAAFgQlAAAAC4ISAACABUEJAADAgqAEAABg4VuV4t27d2vz5s0qKSnRjTfeqLi4uEvVLwAAAK/zOCht2rRJo0aNUmBgoHx9ffWXv/xFf/nLXxQfH38JuwcAAOA9Hl96W7hwocaNG6cTJ07oxIkTmjdvnp588slL2TcAAACvchhjjCeFwcHB2rt3r9q3by9JOnPmjOrVq6e8vDyFhoZe0k5eiQoLCxUSEqKCggIFBwd7uzsAAMADVf389viM0smTJ9WwYUPnzwEBAQoKClJhYeEFdRQAAOBKV6VvvW3btk2bN292LuXl5Xr77bdd2qpq6dKlioqKUmBgoKKjo7Vr165z1qempio6OlqBgYFq3bq1li9f7rI+KSlJDofDbTl9+vRFHRcAAPzyVOlbb2PHjnVrmzRpkvO/HQ6HysrKPN7fhg0bFB8fr6VLl6pPnz7629/+pptuukmfffaZWrZs6VafmZmpIUOGaOLEiXrllVf0/vvv649//KOaNm2qkSNHOuuCg4N16NAhl20DAwMv+LgAAOCXyeN7lC6Fnj17qlu3blq2bJmzrVOnThoxYoQSEhLc6mfOnKnNmzfr4MGDzrbJkydr3759SktLk3T2jFJ8fLxOnDhRbcetDPcoAQBQ81yye5SqW3FxsT766CO3ZzHFxcXpgw8+qHSbtLQ0t/pBgwZp7969KikpcbadPHlSkZGRat68uYYOHar09PSLOq509ub1wsJClwUAANRuHl968/T+o+HDh3tUl5+fr7KyMoWFhbm0h4WFKS8vr9Jt8vLyKq0vLS1Vfn6+mjVrpo4dOyopKUnXXXedCgsL9cILL6hPnz7at2+f2rVrd0HHlaSEhATNmzfPo7EBAIDaweOgNGLEiPPWVPUepYptfs4Y49Z2vvqft/fq1Uu9evVyru/Tp4+6deumRYsWKTEx8YKPO2vWLE2fPt35c2FhoVq0aGGtBwAANZ/HQam8vLxaDxwaGiofHx+3szhHjx51O9tTITw8vNJ6X19fNWnSpNJt6tSpox49euiLL7644ONKZx+HEBAQcN5xAQCA2sPje5TuueceFRUVVduB/f39FR0drZSUFJf2lJQU9e7du9JtYmJi3Oq3b9+u7t27y8/Pr9JtjDHKyMhQs2bNLvi4AADgF8p4qE6dOua7777ztNwj69evN35+fmblypXms88+M/Hx8aZevXomKyvLGGPMww8/bMaMGeOs//rrr03dunXNtGnTzGeffWZWrlxp/Pz8zD//+U9nzeOPP27eeust89VXX5n09HQzfvx44+vra3bv3u3xcT1RUFBgJJmCgoJqeCUAAMDlUNXPb48vvZlL8BSB0aNH69ixY5o/f75yc3PVuXNnJScnKzIyUpKUm5ur7OxsZ31UVJSSk5M1bdo0LVmyRBEREUpMTHR5htKJEyd03333KS8vTyEhIerataveffddXX/99R4fFwAAQKrCc5Tq1Kmj7777Tk2bNr3UfaoReI4SAAA1T1U/v6v0ZO727duf85thknT8+PGq7BIAAOCKVaWgNG/ePIWEhFyqvgAAAFxRqhSUfv/73+uqq666VH0BAAC4onj8eIDzXXIDAACobTwOSpfiW28AAABXMq89mRsAAOBK5/EZJQAAgF8aghIAAIAFQQkAAMCCoAQAAGBBUAIAALAgKAEAAFgQlAAAACwISgAAABYEJQAAAAuCEgAAgAVBCQAAwIKgBAAAYEFQAgAAsCAoAQAAWBCUAAAALAhKAAAAFgQlAAAAC4ISAACABUEJAADAgqAEAABgQVACAACwICgBAABYEJQAAAAsCEoAAAAWBCUAAAALghIAAIAFQQkAAMCCoAQAAGBBUAIAALAgKAEAAFgQlAAAACwISgAAABYEJQAAAAuCEgAAgAVBCQAAwIKgBAAAYEFQAgAAsCAoAQAAWBCUAAAALAhKAAAAFgQlAAAAC4ISAACABUEJAADAgqAEAABgQVACAACwICgBAABYEJQAAAAsCEoAAAAWBCUAAAALghIAAICF14PS0qVLFRUVpcDAQEVHR2vXrl3nrE9NTVV0dLQCAwPVunVrLV++3Fq7fv16ORwOjRgxwqW9qKhI8fHxioyMVFBQkHr37q09e/ZUx3AAAEAt4tWgtGHDBsXHx2vOnDlKT09XbGysbrrpJmVnZ1dan5mZqSFDhig2Nlbp6emaPXu2pk6dqo0bN7rVfvPNN5oxY4ZiY2Pd1t17771KSUnRmjVrtH//fsXFxenGG2/UkSNHqn2MAACg5nIYY4y3Dt6zZ09169ZNy5Ytc7Z16tRJI0aMUEJCglv9zJkztXnzZh08eNDZNnnyZO3bt09paWnOtrKyMt1www0aP368du3apRMnTuj111+XJP30009q0KCB3njjDd18883Obbp06aKhQ4fqySef9KjvhYWFCgkJUUFBgYKDg6s6dAAA4AVV/fz22hml4uJiffTRR4qLi3Npj4uL0wcffFDpNmlpaW71gwYN0t69e1VSUuJsmz9/vpo2baoJEya47aO0tFRlZWUKDAx0aQ8KCtJ7771n7e+ZM2dUWFjosgAAgNrNa0EpPz9fZWVlCgsLc2kPCwtTXl5epdvk5eVVWl9aWqr8/HxJ0vvvv6+VK1dqxYoVle6jQYMGiomJ0RNPPKGcnByVlZXplVde0e7du5Wbm2vtb0JCgkJCQpxLixYtqjJcAABQA3n9Zm6Hw+HyszHGre189RXtRUVFuuuuu7RixQqFhoZa97FmzRoZY3T11VcrICBAiYmJuvPOO+Xj42PdZtasWSooKHAuhw8f9mR4AACgBvP11oFDQ0Pl4+Pjdvbo6NGjbmeNKoSHh1da7+vrqyZNmujAgQPKysrSsGHDnOvLy8slSb6+vjp06JDatGmjNm3aKDU1VadOnVJhYaGaNWum0aNHKyoqytrfgIAABQQEXOhwAQBADeS1M0r+/v6Kjo5WSkqKS3tKSop69+5d6TYxMTFu9du3b1f37t3l5+enjh07av/+/crIyHAuw4cP14ABA5SRkeF2uaxevXpq1qyZfvjhB23btk233HJL9Q4SAADUaF47oyRJ06dP15gxY9S9e3fFxMToxRdfVHZ2tiZPnizp7OWuI0eO6OWXX5Z09htuixcv1vTp0zVx4kSlpaVp5cqVWrdunSQpMDBQnTt3djlGw4YNJcmlfdu2bTLGqEOHDvryyy/14IMPqkOHDho/fvxlGDUAAKgpvBqURo8erWPHjmn+/PnKzc1V586dlZycrMjISElSbm6uyzOVoqKilJycrGnTpmnJkiWKiIhQYmKiRo4cWaXjFhQUaNasWfr222/VuHFjjRw5UgsWLJCfn1+1jg8AANRsXn2OUk3Gc5QAAKh5asxzlAAAAK50BCUAAAALghIAAIAFQQkAAMCCoAQAAGBBUAIAALAgKAEAAFgQlAAAACwISgAAABYEJQAAAAuCEgAAgAVBCQAAwIKgBAAAYEFQAgAAsCAoAQAAWBCUAAAALAhKAAAAFgQlAAAAC4ISAACABUEJAADAgqAEAABgQVACAACwICgBAABYEJQAAAAsCEoAAAAWBCUAAAALghIAAIAFQQkAAMCCoAQAAGBBUAIAALAgKAEAAFgQlAAAACwISgAAABYEJQAAAAuCEgAAgAVBCQAAwIKgBAAAYEFQAgAAsCAoAQAAWBCUAAAALAhKAAAAFgQlAAAAC4ISAACABUEJAADAgqAEAABgQVACAACwICgBAABYEJQAAAAsCEoAAAAWBCUAAAALghIAAIAFQQkAAMCCoAQAAGBBUAIAALAgKAEAAFgQlAAAACy8HpSWLl2qqKgoBQYGKjo6Wrt27TpnfWpqqqKjoxUYGKjWrVtr+fLl1tr169fL4XBoxIgRLu2lpaV65JFHFBUVpaCgILVu3Vrz589XeXl5dQwJAADUEl4NShs2bFB8fLzmzJmj9PR0xcbG6qabblJ2dnal9ZmZmRoyZIhiY2OVnp6u2bNna+rUqdq4caNb7TfffKMZM2YoNjbWbd1TTz2l5cuXa/HixTp48KCefvppPfPMM1q0aFG1jxEAANRcDmOM8dbBe/bsqW7dumnZsmXOtk6dOmnEiBFKSEhwq585c6Y2b96sgwcPOtsmT56sffv2KS0tzdlWVlamG264QePHj9euXbt04sQJvf766871Q4cOVVhYmFauXOlsGzlypOrWras1a9Z41PfCwkKFhISooKBAwcHBVRk2AADwkqp+fnvtjFJxcbE++ugjxcXFubTHxcXpgw8+qHSbtLQ0t/pBgwZp7969KikpcbbNnz9fTZs21YQJEyrdT9++ffX222/r3//+tyRp3759eu+99zRkyBBrf8+cOaPCwkKXBQAA1G6+3jpwfn6+ysrKFBYW5tIeFhamvLy8SrfJy8urtL60tFT5+flq1qyZ3n//fa1cuVIZGRnWY8+cOVMFBQXq2LGjfHx8VFZWpgULFuiOO+6wbpOQkKB58+Z5PkAAAFDjef1mbofD4fKzMcat7Xz1Fe1FRUW66667tGLFCoWGhlr3sWHDBr3yyitau3atPv74Y61evVrPPvusVq9ebd1m1qxZKigocC6HDx/2ZHgAAKAG89oZpdDQUPn4+LidPTp69KjbWaMK4eHhldb7+vqqSZMmOnDggLKysjRs2DDn+opvsvn6+urQoUNq06aNHnzwQT388MP6/e9/L0m67rrr9M033yghIUFjx46t9NgBAQEKCAi44PECAICax2tnlPz9/RUdHa2UlBSX9pSUFPXu3bvSbWJiYtzqt2/fru7du8vPz08dO3bU/v37lZGR4VyGDx+uAQMGKCMjQy1atJAk/fjjj6pTx3XoPj4+PB4AAAC48NoZJUmaPn26xowZo+7duysmJkYvvviisrOzNXnyZElnL3cdOXJEL7/8sqSz33BbvHixpk+frokTJyotLU0rV67UunXrJEmBgYHq3LmzyzEaNmwoSS7tw4YN04IFC9SyZUtde+21Sk9P13PPPad77rnnMowaAADUFF4NSqNHj9axY8c0f/585ebmqnPnzkpOTlZkZKQkKTc31+WZSlFRUUpOTta0adO0ZMkSRUREKDExUSNHjqzScRctWqRHH31Uf/zjH3X06FFFRERo0qRJeuyxx6p1fAAAoGbz6nOUajKeowQAQM1TY56jBAAAcKUjKAEAAFgQlAAAACwISgAAABYEJQAAAAuCEgAAgAVBCQAAwIKgBAAAYEFQAgAAsCAoAQAAWBCUAAAALAhKAAAAFgQlAAAAC4ISAACABUEJAADAgqAEAABgQVACAACwICgBAABYEJQAAAAsCEoAAAAWBCUAAAALghIAAIAFQQkAAMCCoAQAAGBBUAIAALAgKAEAAFgQlAAAACwISgAAABYEJQAAAAuCEgAAgAVBCQAAwIKgBAAAYEFQAgAAsCAoAQAAWBCUAAAALAhKAAAAFgQlAAAAC4ISAACABUEJAADAgqAEAABgQVACAACwICgBAABYEJQAAAAsfL3dgZrKGCNJKiws9HJPAACApyo+tys+x8+HoHSBioqKJEktWrTwck8AAEBVFRUVKSQk5Lx1DuNppIKL8vJy5eTkqEGDBnI4HN7ujlNhYaFatGihw4cPKzg42NvduSRq+xgZX81W28cn1f4x1vbxSbV/jOcanzFGRUVFioiIUJ06578DiTNKF6hOnTpq3ry5t7thFRwcXCvf/D9X28fI+Gq22j4+qfaPsbaPT6r9Y7SNz5MzSRW4mRsAAMCCoAQAAGBBUKplAgICNHfuXAUEBHi7K5dMbR8j46vZavv4pNo/xto+Pqn2j7E6x8fN3AAAABacUQIAALAgKAEAAFgQlAAAACwISr8QDodDr7/+ure7gYvAHNZszF/NxxzWfBcyhwSlGmrcuHEaMWKEt7txQRISEtSjRw81aNBAV111lUaMGKFDhw651Bhj9PjjjysiIkJBQUHq37+/Dhw44Fx//PhxPfDAA+rQoYPq1q2rli1baurUqSooKHDZz4IFC9S7d2/VrVtXDRs2vBzD8xhzeP45zMrK0oQJExQVFaWgoCC1adNGc+fOVXFx8WUbqw3z59m/weHDh6tly5YKDAxUs2bNNGbMGOXk5FyWcZ4Pc+jZHFY4c+aMunTpIofDoYyMjEs5PI9djjkkKOGyS01N1f33368PP/xQKSkpKi0tVVxcnE6dOuWsefrpp/Xcc89p8eLF2rNnj8LDwzVw4EDn39jLyclRTk6Onn32We3fv19JSUl66623NGHCBJdjFRcXa9SoUfqv//qvyzrG2u5yzeHnn3+u8vJy/e1vf9OBAwf017/+VcuXL9fs2bMv+5hrk8v5b3DAgAF69dVXdejQIW3cuFFfffWVbr/99ss63trocs5hhYceekgRERGXZXxXFIMaaezYseaWW24xxhgTGRlp/vrXv7qs//Wvf23mzp3r/FmS2bRp02XrX1UcPXrUSDKpqanGGGPKy8tNeHi4+fOf/+ysOX36tAkJCTHLly+37ufVV181/v7+pqSkxG3dqlWrTEhISLX3/WIwh+7ONYcVnn76aRMVFVV9nb9AzJ87T+bvjTfeMA6HwxQXF1ffAC4Qc+jONofJycmmY8eO5sCBA0aSSU9PvyTjqKrLMYecUYLXVZzmbdy4sSQpMzNTeXl5iouLc9YEBATohhtu0AcffHDO/QQHB8vXlz9heLldzjksKChwHgfV43LN3/Hjx/X3v/9dvXv3lp+fXzWOAJdyDr/77jtNnDhRa9asUd26dS/RCK5cBCV4lTFG06dPV9++fdW5c2dJUl5eniQpLCzMpTYsLMy57j8dO3ZMTzzxhCZNmnRpOww3l3MOv/rqKy1atEiTJ0+upt7jcszfzJkzVa9ePTVp0kTZ2dl64403qnkUv2yXcg6NMRo3bpwmT56s7t27X6IRXNkISvCqKVOm6JNPPtG6devc1jkcDpefjTFubZJUWFiom2++Wddcc43mzp17yfqKyl2uOczJydHgwYM1atQo3XvvvdXTeVyW+XvwwQeVnp6u7du3y8fHR3fffbcMfxSi2lzKOVy0aJEKCws1a9as6u94DUFQqgXq1Knj9j+dkpISL/XGcw888IA2b96snTt3qnnz5s728PBwSXL7refo0aNuvx0VFRVp8ODBql+/vjZt2lRjT+czh+eew5ycHA0YMEAxMTF68cUXL8FILg7zd+75Cw0NVfv27TVw4ECtX79eycnJ+vDDDy/BiC4cc1j5HO7YsUMffvihAgIC5Ovrq7Zt20qSunfvrrFjx16qYV2QSzWHBKVaoGnTpsrNzXX+XFhYqMzMTC/26NyMMZoyZYpee+017dixQ1FRUS7ro6KiFB4erpSUFGdbcXGxUlNT1bt3b2dbYWGh4uLi5O/vr82bNyswMPCyjaG6MYf2OTxy5Ij69++vbt26adWqVapT58r73xbz5/m/wYoPsjNnzlTTaKoHc1j5HCYmJmrfvn3KyMhQRkaGkpOTJUkbNmzQggULLuEIq+5SzSF3vdYCv/nNb5SUlKRhw4apUaNGevTRR+Xj4+Ptblndf//9Wrt2rd544w01aNDA+RtPSEiIgoKC5HA4FB8fr4ULF6pdu3Zq166dFi5cqLp16+rOO++UdPY3oLi4OP3444965ZVXVFhYqMLCQkln/7FUjD87O1vHjx9Xdna2ysrKnM/+aNu2rerXr3/5B2/BHFY+hzk5Oerfv79atmypZ599Vt9//72zDxW/MV8JmL/K5+9f//qX/vWvf6lv375q1KiRvv76az322GNq06aNYmJivDb+yjCHlc9hy5YtXY5b8f/NNm3auJzBuhJcsjms0nfkcMUYM2aMGTlypDHGmIKCAvO73/3OBAcHmxYtWpikpKQr+mutkipdVq1a5awpLy83c+fONeHh4SYgIMD069fP7N+/37l+586d1v1kZmY668aOHVtpzc6dOy/fgC2Yw/PP4apVq6w13sb8nX/+PvnkEzNgwADTuHFjExAQYFq1amUmT55svv3228s84soxh579f/TnMjMzr6jHA1yOOXT8vw1RwwwePFht27bV4sWLvd0VXCDmsGZj/mo+5rDmuxxzeOVd7Mc5/fDDD3rzzTf1zjvv6MYbb/R2d3ABmMOajfmr+ZjDmu9yziH3KNUw99xzj/bs2aM//elPuuWWW7zdHVwA5rBmY/5qPuaw5rucc8ilNwAAAAsuvQEAAFgQlAAAACwISgAAABYEJQAAAAuCEoBflHfeeUcOh0MnTpzwdlcA1AB86w1Arda/f3916dJFzz//vKSzf+/q+PHjCgsLq/SvqAPAz/EcJQC/KP7+/lfU34kDcGXj0huAWmvcuHFKTU3VCy+8IIfDIYfDoaSkJJdLb0lJSWrYsKG2bNmiDh06qG7durr99tt16tQprV69Wq1atVKjRo30wAMPqKyszLnv4uJiPfTQQ7r66qtVr1499ezZU++88453BgrgkuGMEoBa64UXXtC///1vde7cWfPnz5ckHThwwK3uxx9/VGJiotavX6+ioiLddtttuu2229SwYUMlJyfr66+/1siRI9W3b1+NHj1akjR+/HhlZWVp/fr1ioiI0KZNmzR48GDt379f7dq1u6zjBHDpEJQA1FohISHy9/dX3bp1nZfbPv/8c7e6kpISLVu2TG3atJEk3X777VqzZo2+++471a9fX9dcc40GDBignTt3avTo0frqq6+0bt06ffvtt4qIiJAkzZgxQ2+99ZZWrVqlhQsXXr5BArikCEoAfvHq1q3rDEmSFBYWplatWql+/foubUePHpUkffzxxzLGqH379i77OXPmjJo0aXJ5Og3gsiAoAfjF8/Pzc/nZ4XBU2lZeXi5JKi8vl4+Pjz766CP5+Pi41P08XAGo+QhKAGo1f39/l5uwq0PXrl1VVlamo0ePKjY2tlr3DeDKwrfeANRqrVq10u7du5WVlaX8/HznWaGL0b59e/3hD3/Q3Xffrddee02ZmZnas2ePnnrqKSUnJ1dDrwFcKQhKAGq1GTNmyMfHR9dcc42aNm2q7OzsatnvqlWrdPfdd+tPf/qTOnTooOHDh2v37t1q0aJFtewfwJWBJ3MDAABYcEYJAADAgqAEAABgQVACAACwICgBAABYEJQAAAAsCEoAAAAWBCUAAAALghIAAIAFQQkAAMCCoAQAAGBBUAIAALAgKAEAAFj8f0cSh0KE4qaRAAAAAElFTkSuQmCC",
+      "text/plain": [
+       "<Figure size 640x480 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "transport_model.mesh.TIP.isel(nface=151, time=slice(0, 5000)).plot()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 45,
+   "id": "124a7880",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "18ff976a44a945f392793a261ec22806",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "BokehModel(combine_events=True, render_bundle={'docs_json': {'daffa232-5185-485a-9c76-51170f2fdc30': {'version…"
+      ]
+     },
+     "execution_count": 45,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "transport_model.plot(\n",
+    "    crs='EPSG:26916',\n",
+    "    constituent_name='Ap',\n",
+    "    clim=(10, 25),\n",
+    "    cmap='RdYlBu_r',\n",
+    "    filter_empty = True\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 46,
+   "id": "742b621c",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYUAAAGFCAYAAAASI+9IAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjguNCwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8fJSN1AAAACXBIWXMAAA9hAAAPYQGoP6dpAAAE4ElEQVR4nO3VMQHAMAzAsKz8OWefKbSHhMCfv93dAYCZObcDAHiHKQAQUwAgpgBATAGAmAIAMQUAYgoAxBQAiCkAEFMAIKYAQEwBgJgCADEFAGIKAMQUAIgpABBTACCmAEBMAYCYAgAxBQBiCgDEFACIKQAQUwAgpgBATAGAmAIAMQUAYgoAxBQAiCkAEFMAIKYAQEwBgJgCADEFAGIKAMQUAIgpABBTACCmAEBMAYCYAgAxBQBiCgDEFACIKQAQUwAgpgBATAGAmAIAMQUAYgoAxBQAiCkAEFMAIKYAQEwBgJgCADEFAGIKAMQUAIgpABBTACCmAEBMAYCYAgAxBQBiCgDEFACIKQAQUwAgpgBATAGAmAIAMQUAYgoAxBQAiCkAEFMAIKYAQEwBgJgCADEFAGIKAMQUAIgpABBTACCmAEBMAYCYAgAxBQBiCgDEFACIKQAQUwAgpgBATAGAmAIAMQUAYgoAxBQAiCkAEFMAIKYAQEwBgJgCADEFAGIKAMQUAIgpABBTACCmAEBMAYCYAgAxBQBiCgDEFACIKQAQUwAgpgBATAGAmAIAMQUAYgoAxBQAiCkAEFMAIKYAQEwBgJgCADEFAGIKAMQUAIgpABBTACCmAEBMAYCYAgAxBQBiCgDEFACIKQAQUwAgpgBATAGAmAIAMQUAYgoAxBQAiCkAEFMAIKYAQEwBgJgCADEFAGIKAMQUAIgpABBTACCmAEBMAYCYAgAxBQBiCgDEFACIKQAQUwAgpgBATAGAmAIAMQUAYgoAxBQAiCkAEFMAIKYAQEwBgJgCADEFAGIKAMQUAIgpABBTACCmAEBMAYCYAgAxBQBiCgDEFACIKQAQUwAgpgBATAGAmAIAMQUAYgoAxBQAiCkAEFMAIKYAQEwBgJgCADEFAGIKAMQUAIgpABBTACCmAEBMAYCYAgAxBQBiCgDEFACIKQAQUwAgpgBATAGAmAIAMQUAYgoAxBQAiCkAEFMAIKYAQEwBgJgCADEFAGIKAMQUAIgpABBTACCmAEBMAYCYAgAxBQBiCgDEFACIKQAQUwAgpgBATAGAmAIAMQUAYgoAxBQAiCkAEFMAIKYAQEwBgJgCADEFAGIKAMQUAIgpABBTACCmAEBMAYCYAgAxBQBiCgDEFACIKQAQUwAgpgBATAGAmAIAMQUAYgoAxBQAiCkAEFMAIKYAQEwBgJgCADEFAGIKAMQUAIgpABBTACCmAEBMAYCYAgAxBQBiCgDEFACIKQAQUwAgpgBATAGAmAIAMQUAYgoAxBQAiCkAEFMAIKYAQEwBgJgCADEFAGIKAMQUAIgpABBTACCmAEBMAYCYAgAxBQBiCgDEFACIKQAQUwAgpgBATAGAmAIAMQUAYgoAxBQAiCkAEFMAIKYAQEwBgJgCADEFAGIKAMQUAIgpABBTACCmAEBMAYCYAgAxBQBiCgDEFACIKQAQUwAgpgBATAGAmAIAMQUAYgoAxBQAiCkAEFMAIKYAQEwBgJgCADEFAGIKAMQUAIgpABBTACCmAEBMAYCYAgAxBQBiCgDEFACIKQAQUwAgpgBATAGAmAIAMQUAYgoAxBQAiCkAEFMAIKYAQEwBgJgCADEFAGIKAMQUAIgpABBTACCmAEBMAYCYAgAxBQBiCgDEFACIKQAQUwAgpgBAfu8DBwYENNNsAAAAAElFTkSuQmCC",
+      "text/plain": [
+       "<Figure size 640x480 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "transport_model.static_plot(\n",
+    "    plotting_timestep=1000,\n",
+    "    crs='EPSG:26916',\n",
+    "    constituent_name='Ap',\n",
+    "    clim=(0, 15),\n",
+    "    cmap='RdYlBu_r',\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 47,
+   "id": "639c4bd0",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYUAAAGFCAYAAAASI+9IAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjguNCwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8fJSN1AAAACXBIWXMAAA9hAAAPYQGoP6dpAAAE4klEQVR4nO3VMQHAMAzAsHT82QVQ95nCdkgI/Pns7h0AmJnn6wAA/sMUAIgpABBTACCmAEBMAYCYAgAxBQBiCgDEFACIKQAQUwAgpgBATAGAmAIAMQUAYgoAxBQAiCkAEFMAIKYAQEwBgJgCADEFAGIKAMQUAIgpABBTACCmAEBMAYCYAgAxBQBiCgDEFACIKQAQUwAgpgBATAGAmAIAMQUAYgoAxBQAiCkAEFMAIKYAQEwBgJgCADEFAGIKAMQUAIgpABBTACCmAEBMAYCYAgAxBQBiCgDEFACIKQAQUwAgpgBATAGAmAIAMQUAYgoAxBQAiCkAEFMAIKYAQEwBgJgCADEFAGIKAMQUAIgpABBTACCmAEBMAYCYAgAxBQBiCgDEFACIKQAQUwAgpgBATAGAmAIAMQUAYgoAxBQAiCkAEFMAIKYAQEwBgJgCADEFAGIKAMQUAIgpABBTACCmAEBMAYCYAgAxBQBiCgDEFACIKQAQUwAgpgBATAGAmAIAMQUAYgoAxBQAiCkAEFMAIKYAQEwBgJgCADEFAGIKAMQUAIgpABBTACCmAEBMAYCYAgAxBQBiCgDEFACIKQAQUwAgpgBATAGAmAIAMQUAYgoAxBQAiCkAEFMAIKYAQEwBgJgCADEFAGIKAMQUAIgpABBTACCmAEBMAYCYAgAxBQBiCgDEFACIKQAQUwAgpgBATAGAmAIAMQUAYgoAxBQAiCkAEFMAIKYAQEwBgJgCADEFAGIKAMQUAIgpABBTACCmAEBMAYCYAgAxBQBiCgDEFACIKQAQUwAgpgBATAGAmAIAMQUAYgoAxBQAiCkAEFMAIKYAQEwBgJgCADEFAGIKAMQUAIgpABBTACCmAEBMAYCYAgAxBQBiCgDEFACIKQAQUwAgpgBATAGAmAIAMQUAYgoAxBQAiCkAEFMAIKYAQEwBgJgCADEFAGIKAMQUAIgpABBTACCmAEBMAYCYAgAxBQBiCgDEFACIKQAQUwAgpgBATAGAmAIAMQUAYgoAxBQAiCkAEFMAIKYAQEwBgJgCADEFAGIKAMQUAIgpABBTACCmAEBMAYCYAgAxBQBiCgDEFACIKQAQUwAgpgBATAGAmAIAMQUAYgoAxBQAiCkAEFMAIKYAQEwBgJgCADEFAGIKAMQUAIgpABBTACCmAEBMAYCYAgAxBQBiCgDEFACIKQAQUwAgpgBATAGAmAIAMQUAYgoAxBQAiCkAEFMAIKYAQEwBgJgCADEFAGIKAMQUAIgpABBTACCmAEBMAYCYAgAxBQBiCgDEFACIKQAQUwAgpgBATAGAmAIAMQUAYgoAxBQAiCkAEFMAIKYAQEwBgJgCADEFAGIKAMQUAIgpABBTACCmAEBMAYCYAgAxBQBiCgDEFACIKQAQUwAgpgBATAGAmAIAMQUAYgoAxBQAiCkAEFMAIKYAQEwBgJgCADEFAGIKAMQUAIgpABBTACCmAEBMAYCYAgAxBQBiCgDEFACIKQAQUwAgpgBATAGAmAIAMQUAYgoAxBQAiCkAEFMAIKYAQEwBgJgCADEFAGIKAMQUAIgpABBTACCmAEBMAYCYAgAxBQBiCgDEFACIKQAQUwAgpgBATAGAmAIAMQUAYgoAxBQAiCkAEFMAIKYAQEwBgJgCADEFAGIKAMQUAIgpABBTACAvvGsGgvLmXk8AAAAASUVORK5CYII=",
+      "text/plain": [
+       "<Figure size 640x480 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "transport_model.static_plot(\n",
+    "    plotting_timestep=5000,\n",
+    "    crs='EPSG:26916',\n",
+    "    constituent_name='Ap',\n",
+    "    clim=(0, 550),\n",
+    "    cmap='RdYlBu_r',\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 48,
+   "id": "d3c8887b",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYUAAAGFCAYAAAASI+9IAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjguNCwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8fJSN1AAAACXBIWXMAAA9hAAAPYQGoP6dpAAAE4klEQVR4nO3VMQHAMAzAsHT82QVQ95nCdkgI/Pns7h0AmJnn6wAA/sMUAIgpABBTACCmAEBMAYCYAgAxBQBiCgDEFACIKQAQUwAgpgBATAGAmAIAMQUAYgoAxBQAiCkAEFMAIKYAQEwBgJgCADEFAGIKAMQUAIgpABBTACCmAEBMAYCYAgAxBQBiCgDEFACIKQAQUwAgpgBATAGAmAIAMQUAYgoAxBQAiCkAEFMAIKYAQEwBgJgCADEFAGIKAMQUAIgpABBTACCmAEBMAYCYAgAxBQBiCgDEFACIKQAQUwAgpgBATAGAmAIAMQUAYgoAxBQAiCkAEFMAIKYAQEwBgJgCADEFAGIKAMQUAIgpABBTACCmAEBMAYCYAgAxBQBiCgDEFACIKQAQUwAgpgBATAGAmAIAMQUAYgoAxBQAiCkAEFMAIKYAQEwBgJgCADEFAGIKAMQUAIgpABBTACCmAEBMAYCYAgAxBQBiCgDEFACIKQAQUwAgpgBATAGAmAIAMQUAYgoAxBQAiCkAEFMAIKYAQEwBgJgCADEFAGIKAMQUAIgpABBTACCmAEBMAYCYAgAxBQBiCgDEFACIKQAQUwAgpgBATAGAmAIAMQUAYgoAxBQAiCkAEFMAIKYAQEwBgJgCADEFAGIKAMQUAIgpABBTACCmAEBMAYCYAgAxBQBiCgDEFACIKQAQUwAgpgBATAGAmAIAMQUAYgoAxBQAiCkAEFMAIKYAQEwBgJgCADEFAGIKAMQUAIgpABBTACCmAEBMAYCYAgAxBQBiCgDEFACIKQAQUwAgpgBATAGAmAIAMQUAYgoAxBQAiCkAEFMAIKYAQEwBgJgCADEFAGIKAMQUAIgpABBTACCmAEBMAYCYAgAxBQBiCgDEFACIKQAQUwAgpgBATAGAmAIAMQUAYgoAxBQAiCkAEFMAIKYAQEwBgJgCADEFAGIKAMQUAIgpABBTACCmAEBMAYCYAgAxBQBiCgDEFACIKQAQUwAgpgBATAGAmAIAMQUAYgoAxBQAiCkAEFMAIKYAQEwBgJgCADEFAGIKAMQUAIgpABBTACCmAEBMAYCYAgAxBQBiCgDEFACIKQAQUwAgpgBATAGAmAIAMQUAYgoAxBQAiCkAEFMAIKYAQEwBgJgCADEFAGIKAMQUAIgpABBTACCmAEBMAYCYAgAxBQBiCgDEFACIKQAQUwAgpgBATAGAmAIAMQUAYgoAxBQAiCkAEFMAIKYAQEwBgJgCADEFAGIKAMQUAIgpABBTACCmAEBMAYCYAgAxBQBiCgDEFACIKQAQUwAgpgBATAGAmAIAMQUAYgoAxBQAiCkAEFMAIKYAQEwBgJgCADEFAGIKAMQUAIgpABBTACCmAEBMAYCYAgAxBQBiCgDEFACIKQAQUwAgpgBATAGAmAIAMQUAYgoAxBQAiCkAEFMAIKYAQEwBgJgCADEFAGIKAMQUAIgpABBTACCmAEBMAYCYAgAxBQBiCgDEFACIKQAQUwAgpgBATAGAmAIAMQUAYgoAxBQAiCkAEFMAIKYAQEwBgJgCADEFAGIKAMQUAIgpABBTACCmAEBMAYCYAgAxBQBiCgDEFACIKQAQUwAgpgBATAGAmAIAMQUAYgoAxBQAiCkAEFMAIKYAQEwBgJgCADEFAGIKAMQUAIgpABBTACAvvGsGgvLmXk8AAAAASUVORK5CYII=",
+      "text/plain": [
+       "<Figure size 640x480 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "transport_model.static_plot(\n",
+    "    plotting_timestep=1000,\n",
+    "    crs='EPSG:26916',\n",
+    "    constituent_name='DOX',\n",
+    "    clim=(3, 9),\n",
+    "    cmap='RdYlBu_r',\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 49,
+   "id": "c0af23be",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYUAAAGFCAYAAAASI+9IAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjguNCwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8fJSN1AAAACXBIWXMAAA9hAAAPYQGoP6dpAAAE4klEQVR4nO3VMQHAMAzAsHT82QVQ95nCdkgI/Pns7h0AmJnn6wAA/sMUAIgpABBTACCmAEBMAYCYAgAxBQBiCgDEFACIKQAQUwAgpgBATAGAmAIAMQUAYgoAxBQAiCkAEFMAIKYAQEwBgJgCADEFAGIKAMQUAIgpABBTACCmAEBMAYCYAgAxBQBiCgDEFACIKQAQUwAgpgBATAGAmAIAMQUAYgoAxBQAiCkAEFMAIKYAQEwBgJgCADEFAGIKAMQUAIgpABBTACCmAEBMAYCYAgAxBQBiCgDEFACIKQAQUwAgpgBATAGAmAIAMQUAYgoAxBQAiCkAEFMAIKYAQEwBgJgCADEFAGIKAMQUAIgpABBTACCmAEBMAYCYAgAxBQBiCgDEFACIKQAQUwAgpgBATAGAmAIAMQUAYgoAxBQAiCkAEFMAIKYAQEwBgJgCADEFAGIKAMQUAIgpABBTACCmAEBMAYCYAgAxBQBiCgDEFACIKQAQUwAgpgBATAGAmAIAMQUAYgoAxBQAiCkAEFMAIKYAQEwBgJgCADEFAGIKAMQUAIgpABBTACCmAEBMAYCYAgAxBQBiCgDEFACIKQAQUwAgpgBATAGAmAIAMQUAYgoAxBQAiCkAEFMAIKYAQEwBgJgCADEFAGIKAMQUAIgpABBTACCmAEBMAYCYAgAxBQBiCgDEFACIKQAQUwAgpgBATAGAmAIAMQUAYgoAxBQAiCkAEFMAIKYAQEwBgJgCADEFAGIKAMQUAIgpABBTACCmAEBMAYCYAgAxBQBiCgDEFACIKQAQUwAgpgBATAGAmAIAMQUAYgoAxBQAiCkAEFMAIKYAQEwBgJgCADEFAGIKAMQUAIgpABBTACCmAEBMAYCYAgAxBQBiCgDEFACIKQAQUwAgpgBATAGAmAIAMQUAYgoAxBQAiCkAEFMAIKYAQEwBgJgCADEFAGIKAMQUAIgpABBTACCmAEBMAYCYAgAxBQBiCgDEFACIKQAQUwAgpgBATAGAmAIAMQUAYgoAxBQAiCkAEFMAIKYAQEwBgJgCADEFAGIKAMQUAIgpABBTACCmAEBMAYCYAgAxBQBiCgDEFACIKQAQUwAgpgBATAGAmAIAMQUAYgoAxBQAiCkAEFMAIKYAQEwBgJgCADEFAGIKAMQUAIgpABBTACCmAEBMAYCYAgAxBQBiCgDEFACIKQAQUwAgpgBATAGAmAIAMQUAYgoAxBQAiCkAEFMAIKYAQEwBgJgCADEFAGIKAMQUAIgpABBTACCmAEBMAYCYAgAxBQBiCgDEFACIKQAQUwAgpgBATAGAmAIAMQUAYgoAxBQAiCkAEFMAIKYAQEwBgJgCADEFAGIKAMQUAIgpABBTACCmAEBMAYCYAgAxBQBiCgDEFACIKQAQUwAgpgBATAGAmAIAMQUAYgoAxBQAiCkAEFMAIKYAQEwBgJgCADEFAGIKAMQUAIgpABBTACCmAEBMAYCYAgAxBQBiCgDEFACIKQAQUwAgpgBATAGAmAIAMQUAYgoAxBQAiCkAEFMAIKYAQEwBgJgCADEFAGIKAMQUAIgpABBTACCmAEBMAYCYAgAxBQBiCgDEFACIKQAQUwAgpgBATAGAmAIAMQUAYgoAxBQAiCkAEFMAIKYAQEwBgJgCADEFAGIKAMQUAIgpABBTACAvvGsGgvLmXk8AAAAASUVORK5CYII=",
+      "text/plain": [
+       "<Figure size 640x480 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "transport_model.static_plot(\n",
+    "    plotting_timestep=1000,\n",
+    "    crs='EPSG:26916',\n",
+    "    constituent_name='NH4',\n",
+    "    clim=(0, 2),\n",
+    "    cmap='RdYlBu_r',\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 50,
+   "id": "01dec69d",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYUAAAGFCAYAAAASI+9IAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjguNCwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8fJSN1AAAACXBIWXMAAA9hAAAPYQGoP6dpAAAE4klEQVR4nO3VMQHAMAzAsHT82QVQ95nCdkgI/Pns7h0AmJnn6wAA/sMUAIgpABBTACCmAEBMAYCYAgAxBQBiCgDEFACIKQAQUwAgpgBATAGAmAIAMQUAYgoAxBQAiCkAEFMAIKYAQEwBgJgCADEFAGIKAMQUAIgpABBTACCmAEBMAYCYAgAxBQBiCgDEFACIKQAQUwAgpgBATAGAmAIAMQUAYgoAxBQAiCkAEFMAIKYAQEwBgJgCADEFAGIKAMQUAIgpABBTACCmAEBMAYCYAgAxBQBiCgDEFACIKQAQUwAgpgBATAGAmAIAMQUAYgoAxBQAiCkAEFMAIKYAQEwBgJgCADEFAGIKAMQUAIgpABBTACCmAEBMAYCYAgAxBQBiCgDEFACIKQAQUwAgpgBATAGAmAIAMQUAYgoAxBQAiCkAEFMAIKYAQEwBgJgCADEFAGIKAMQUAIgpABBTACCmAEBMAYCYAgAxBQBiCgDEFACIKQAQUwAgpgBATAGAmAIAMQUAYgoAxBQAiCkAEFMAIKYAQEwBgJgCADEFAGIKAMQUAIgpABBTACCmAEBMAYCYAgAxBQBiCgDEFACIKQAQUwAgpgBATAGAmAIAMQUAYgoAxBQAiCkAEFMAIKYAQEwBgJgCADEFAGIKAMQUAIgpABBTACCmAEBMAYCYAgAxBQBiCgDEFACIKQAQUwAgpgBATAGAmAIAMQUAYgoAxBQAiCkAEFMAIKYAQEwBgJgCADEFAGIKAMQUAIgpABBTACCmAEBMAYCYAgAxBQBiCgDEFACIKQAQUwAgpgBATAGAmAIAMQUAYgoAxBQAiCkAEFMAIKYAQEwBgJgCADEFAGIKAMQUAIgpABBTACCmAEBMAYCYAgAxBQBiCgDEFACIKQAQUwAgpgBATAGAmAIAMQUAYgoAxBQAiCkAEFMAIKYAQEwBgJgCADEFAGIKAMQUAIgpABBTACCmAEBMAYCYAgAxBQBiCgDEFACIKQAQUwAgpgBATAGAmAIAMQUAYgoAxBQAiCkAEFMAIKYAQEwBgJgCADEFAGIKAMQUAIgpABBTACCmAEBMAYCYAgAxBQBiCgDEFACIKQAQUwAgpgBATAGAmAIAMQUAYgoAxBQAiCkAEFMAIKYAQEwBgJgCADEFAGIKAMQUAIgpABBTACCmAEBMAYCYAgAxBQBiCgDEFACIKQAQUwAgpgBATAGAmAIAMQUAYgoAxBQAiCkAEFMAIKYAQEwBgJgCADEFAGIKAMQUAIgpABBTACCmAEBMAYCYAgAxBQBiCgDEFACIKQAQUwAgpgBATAGAmAIAMQUAYgoAxBQAiCkAEFMAIKYAQEwBgJgCADEFAGIKAMQUAIgpABBTACCmAEBMAYCYAgAxBQBiCgDEFACIKQAQUwAgpgBATAGAmAIAMQUAYgoAxBQAiCkAEFMAIKYAQEwBgJgCADEFAGIKAMQUAIgpABBTACCmAEBMAYCYAgAxBQBiCgDEFACIKQAQUwAgpgBATAGAmAIAMQUAYgoAxBQAiCkAEFMAIKYAQEwBgJgCADEFAGIKAMQUAIgpABBTACCmAEBMAYCYAgAxBQBiCgDEFACIKQAQUwAgpgBATAGAmAIAMQUAYgoAxBQAiCkAEFMAIKYAQEwBgJgCADEFAGIKAMQUAIgpABBTACAvvGsGgvLmXk8AAAAASUVORK5CYII=",
+      "text/plain": [
+       "<Figure size 640x480 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "transport_model.static_plot(\n",
+    "    plotting_timestep=1000,\n",
+    "    crs='EPSG:26916',\n",
+    "    constituent_name='NO3',\n",
+    "    clim=(0, 1.25),\n",
+    "    cmap='RdYlBu_r',\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 51,
+   "id": "a96eb135",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYUAAAGFCAYAAAASI+9IAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjguNCwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8fJSN1AAAACXBIWXMAAA9hAAAPYQGoP6dpAAAE4klEQVR4nO3VMQHAMAzAsHT82QVQ95nCdkgI/Pns7h0AmJnn6wAA/sMUAIgpABBTACCmAEBMAYCYAgAxBQBiCgDEFACIKQAQUwAgpgBATAGAmAIAMQUAYgoAxBQAiCkAEFMAIKYAQEwBgJgCADEFAGIKAMQUAIgpABBTACCmAEBMAYCYAgAxBQBiCgDEFACIKQAQUwAgpgBATAGAmAIAMQUAYgoAxBQAiCkAEFMAIKYAQEwBgJgCADEFAGIKAMQUAIgpABBTACCmAEBMAYCYAgAxBQBiCgDEFACIKQAQUwAgpgBATAGAmAIAMQUAYgoAxBQAiCkAEFMAIKYAQEwBgJgCADEFAGIKAMQUAIgpABBTACCmAEBMAYCYAgAxBQBiCgDEFACIKQAQUwAgpgBATAGAmAIAMQUAYgoAxBQAiCkAEFMAIKYAQEwBgJgCADEFAGIKAMQUAIgpABBTACCmAEBMAYCYAgAxBQBiCgDEFACIKQAQUwAgpgBATAGAmAIAMQUAYgoAxBQAiCkAEFMAIKYAQEwBgJgCADEFAGIKAMQUAIgpABBTACCmAEBMAYCYAgAxBQBiCgDEFACIKQAQUwAgpgBATAGAmAIAMQUAYgoAxBQAiCkAEFMAIKYAQEwBgJgCADEFAGIKAMQUAIgpABBTACCmAEBMAYCYAgAxBQBiCgDEFACIKQAQUwAgpgBATAGAmAIAMQUAYgoAxBQAiCkAEFMAIKYAQEwBgJgCADEFAGIKAMQUAIgpABBTACCmAEBMAYCYAgAxBQBiCgDEFACIKQAQUwAgpgBATAGAmAIAMQUAYgoAxBQAiCkAEFMAIKYAQEwBgJgCADEFAGIKAMQUAIgpABBTACCmAEBMAYCYAgAxBQBiCgDEFACIKQAQUwAgpgBATAGAmAIAMQUAYgoAxBQAiCkAEFMAIKYAQEwBgJgCADEFAGIKAMQUAIgpABBTACCmAEBMAYCYAgAxBQBiCgDEFACIKQAQUwAgpgBATAGAmAIAMQUAYgoAxBQAiCkAEFMAIKYAQEwBgJgCADEFAGIKAMQUAIgpABBTACCmAEBMAYCYAgAxBQBiCgDEFACIKQAQUwAgpgBATAGAmAIAMQUAYgoAxBQAiCkAEFMAIKYAQEwBgJgCADEFAGIKAMQUAIgpABBTACCmAEBMAYCYAgAxBQBiCgDEFACIKQAQUwAgpgBATAGAmAIAMQUAYgoAxBQAiCkAEFMAIKYAQEwBgJgCADEFAGIKAMQUAIgpABBTACCmAEBMAYCYAgAxBQBiCgDEFACIKQAQUwAgpgBATAGAmAIAMQUAYgoAxBQAiCkAEFMAIKYAQEwBgJgCADEFAGIKAMQUAIgpABBTACCmAEBMAYCYAgAxBQBiCgDEFACIKQAQUwAgpgBATAGAmAIAMQUAYgoAxBQAiCkAEFMAIKYAQEwBgJgCADEFAGIKAMQUAIgpABBTACCmAEBMAYCYAgAxBQBiCgDEFACIKQAQUwAgpgBATAGAmAIAMQUAYgoAxBQAiCkAEFMAIKYAQEwBgJgCADEFAGIKAMQUAIgpABBTACCmAEBMAYCYAgAxBQBiCgDEFACIKQAQUwAgpgBATAGAmAIAMQUAYgoAxBQAiCkAEFMAIKYAQEwBgJgCADEFAGIKAMQUAIgpABBTACAvvGsGgvLmXk8AAAAASUVORK5CYII=",
+      "text/plain": [
+       "<Figure size 640x480 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "transport_model.static_plot(\n",
+    "    plotting_timestep=5000,\n",
+    "    crs='EPSG:26916',\n",
+    "    constituent_name='TIP',\n",
+    "    clim=(0, 65),\n",
+    "    cmap='RdYlBu_r',\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 52,
+   "id": "5377d829",
+   "metadata": {},
+   "outputs": [
+    {
+     "ename": "AttributeError",
+     "evalue": "'Dataset' object has no attribute 'temperature'",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[1;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[1;31mAttributeError\u001b[0m                            Traceback (most recent call last)",
+      "Cell \u001b[1;32mIn[52], line 1\u001b[0m\n\u001b[1;32m----> 1\u001b[0m \u001b[43mtransport_model\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mmesh\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mtemperature\u001b[49m\u001b[38;5;241m.\u001b[39misel(nface\u001b[38;5;241m=\u001b[39m\u001b[38;5;241m217\u001b[39m, time\u001b[38;5;241m=\u001b[39m\u001b[38;5;28mslice\u001b[39m(\u001b[38;5;241m100\u001b[39m, TIME_STEPS))\u001b[38;5;241m.\u001b[39mplot()\n",
+      "File \u001b[1;32mc:\\Users\\rushmore\\AppData\\Local\\miniconda3\\envs\\clearwater_riverine\\Lib\\site-packages\\xarray\\core\\common.py:285\u001b[0m, in \u001b[0;36mAttrAccessMixin.__getattr__\u001b[1;34m(self, name)\u001b[0m\n\u001b[0;32m    283\u001b[0m         \u001b[38;5;28;01mwith\u001b[39;00m suppress(\u001b[38;5;167;01mKeyError\u001b[39;00m):\n\u001b[0;32m    284\u001b[0m             \u001b[38;5;28;01mreturn\u001b[39;00m source[name]\n\u001b[1;32m--> 285\u001b[0m \u001b[38;5;28;01mraise\u001b[39;00m \u001b[38;5;167;01mAttributeError\u001b[39;00m(\n\u001b[0;32m    286\u001b[0m     \u001b[38;5;124mf\u001b[39m\u001b[38;5;124m\"\u001b[39m\u001b[38;5;132;01m{\u001b[39;00m\u001b[38;5;28mtype\u001b[39m(\u001b[38;5;28mself\u001b[39m)\u001b[38;5;241m.\u001b[39m\u001b[38;5;18m__name__\u001b[39m\u001b[38;5;132;01m!r}\u001b[39;00m\u001b[38;5;124m object has no attribute \u001b[39m\u001b[38;5;132;01m{\u001b[39;00mname\u001b[38;5;132;01m!r}\u001b[39;00m\u001b[38;5;124m\"\u001b[39m\n\u001b[0;32m    287\u001b[0m )\n",
+      "\u001b[1;31mAttributeError\u001b[0m: 'Dataset' object has no attribute 'temperature'"
+     ]
+    }
+   ],
+   "source": [
+    "transport_model.mesh.temperature.isel(nface=217, time=slice(100, TIME_STEPS)).plot()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "eab93216",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "transport_model.mesh.temperature.isel(nface=207, time=slice(0, TIME_STEPS)).plot()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "57dd8774",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "np.shape(transport_model.constituent_dict['temperature'].input_array)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "eaa7b560-a7ba-4737-a9c3-bd090bc8a7d6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "transport_model.mesh.temperature.isel(nface=165, time=slice(1000, TIME_STEPS)).plot()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "af441d7e-19d2-41a3-b7ff-6e0126993469",
+   "metadata": {},
+   "source": [
+    "## Plot Results"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "793d31d6-9ef8-4692-bd58-981e3dee7fb1",
+   "metadata": {},
+   "source": [
+    "### Built-In Functions\n",
+    "Use the built-in plotting function:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "440784b0-77a7-46fa-a73a-20b40ab2fd42",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "transport_model.plot(\n",
+    "    crs='EPSG:26916',\n",
+    "    clim=(5, 26)\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b6aadcb2-4186-4aac-a036-0f2c1e9978f6",
+   "metadata": {},
+   "source": [
+    "### Build Panel Apps\n",
+    "\n",
+    "#### Interactive Timeseries Plotting\n",
+    "This is an exmaple of an interactive map that allows you to click on a single cell and see the timeseries for that cell:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6dc19e97-9725-4f80-864b-2d034623314a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from clearwater_riverine.variables import (\n",
+    "    NUMBER_OF_REAL_CELLS,\n",
+    "    CONCENTRATION,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8cae6e61-9877-447d-bece-7b7dacfd3851",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# create inputs for panel app\n",
+    "ds = transport_model.mesh\n",
+    "gdf = transport_model.gdf\n",
+    "time_index = 60\n",
+    "mn_val = 4\n",
+    "mval = 25\n",
+    "date_value = ds.time.isel(time=time_index).values"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "374633ff-30cf-48a3-b5c3-6bc73d690f88",
+   "metadata": {},
+   "source": [
+    "Start by creating a base map of a plan view of Sumwere Creek using the `geoviews` library. Including the `hover` and `tap` tools allows users to hover over the plot to see values and turns on the ability to use the tap stream that allows users to click on a cell and receive feedback from that tap. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "95fb690b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ras_sub_df = gdf[(gdf.datetime == date_value) & (gdf.concentration != 0)]\n",
+    "units = ds[CONCENTRATION].Units\n",
+    "ras_map = gv.Polygons(\n",
+    "    ras_sub_df,\n",
+    "    vdims=['concentration', 'cell']).opts(\n",
+    "        height = 800,\n",
+    "        width = 800,\n",
+    "        color='concentration',\n",
+    "        cmap='RdYlBu_r',\n",
+    "        line_width = 0.1,\n",
+    "        tools = ['hover', 'tap'],\n",
+    "        clabel = f\"Concentration ({units})\",\n",
+    "        xaxis=None,\n",
+    "        yaxis=None,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "10c064e1-58d7-44b5-90a5-e914f50a1e88",
+   "metadata": {},
+   "source": [
+    "The cell below defines the tap stream and initializes an empty list of plots to display. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f5b8a690",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tap_stream = hv.streams.Tap(source=ras_map, x=None, y=None)\n",
+    "plots = []"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "086f5ae1-61c9-43ec-8dd7-3d97233ca903",
+   "metadata": {},
+   "source": [
+    "The `tap_plot` function identifies which cell has been clicked and generates a timeseries plot for that cell."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5b2c8431-06e6-44ca-8f5a-6f2ffae4f51b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def tap_plot(x, y):\n",
+    "    # filter data\n",
+    "    clicked_data = ras_sub_df.cx[x:x, y:y]\n",
+    "    if x != None and y != None:\n",
+    "        # identify cell number and pull concentration timeseries for that cell\n",
+    "        cell = clicked_data['cell'].iloc[0]\n",
+    "        cs = ds.concentration.isel(nface=cell, time=slice(0, TIME_STEPS))\n",
+    "\n",
+    "        # Create timeseries plot\n",
+    "        curve = hv.Curve(\n",
+    "            cs,\n",
+    "        ).opts(\n",
+    "            title=f'Time series',\n",
+    "            height=800,\n",
+    "            width=800,\n",
+    "            line_width=5,\n",
+    "            fontsize= {'title': 18, 'labels': 16, 'xticks': 12, 'yticks': 12},\n",
+    "            ylabel= 'Water Temperature (C)'\n",
+    "        )\n",
+    "\n",
+    "        # Append to list of plots (allows multiple lines to appear at the same time)\n",
+    "        plots.append(curve)\n",
+    "        # Return an overlay of all the plots\n",
+    "        return hv.Overlay(plots).opts(legend_position='right')\n",
+    "    else:\n",
+    "        # Create an empty timeseries plot telling users to click on a cell to generate a timeseries\n",
+    "        xs = np.linspace(-5,5,100)\n",
+    "        empty_curve = hv.Curve((xs,-(xs-2)**2)).opts(\n",
+    "            title=f'Time series',\n",
+    "            line_color='white',\n",
+    "            height=800, \n",
+    "            width=800,\n",
+    "            xaxis=None,\n",
+    "            yaxis=None,\n",
+    "        )* hv.Text(0, -20, \"Please click a cell on the map to display a timeseries.\")\n",
+    "        return empty_curve\n",
+    "\n",
+    "# Create Dynamic Map that references the tap stream.\n",
+    "tap_dmap = hv.DynamicMap(tap_plot, streams=[tap_stream])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6d3d9114-6daa-486f-beaf-629e7f06911c",
+   "metadata": {},
+   "source": [
+    "The following function and button allows users to clear all timeseries plots if they wish to start fresh:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bf70743d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def reset_tap_stream(event):\n",
+    "    global plots\n",
+    "    tap_stream.event(x=None, y=None)\n",
+    "    plots = []\n",
+    "    \n",
+    "button = pn.widgets.Button(name='Reset', button_type='primary')\n",
+    "button.on_click(reset_tap_stream)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1bea5541-de92-4f29-86ab-e0d8df1f7167",
+   "metadata": {},
+   "source": [
+    "Now display the plot:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1c1661ac-e670-4752-ae8f-8889bf81288a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "layout = pn.Row(\n",
+    "    ras_map,\n",
+    "    tap_dmap.opts(\n",
+    "        hv.opts.Curve(framewise=True, yaxis='right'),\n",
+    "       ),\n",
+    "    button\n",
+    "    )\n",
+    "layout.servable()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "38a9609e-9090-413b-bbd3-b9fd0017f1cf",
+   "metadata": {},
+   "source": [
+    "#### Dynamic Map Visualization\n",
+    "Make a plot with a scrubber bar that shows a map over time:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8fbb429e-0939-4513-9f35-a893f22f109c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ds = transport_model.mesh\n",
+    "gdf = transport_model.gdf\n",
+    "import hvplot.pandas "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9d7bb0cb-32fd-4f96-916d-a084e60e4e6a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# eliminate cells without any temperature\n",
+    "gdf_sub = gdf[gdf.concentration != 0]\n",
+    "gdf_subset = gdf_sub[(gdf_sub['datetime'] > '2022-05-13 08:00:00')]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7937eec0-e050-43ff-8a3c-57bbb72abfc0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plot_to_save = gdf_subset.hvplot(\n",
+    "    geo=True,\n",
+    "    groupby=\"datetime\",\n",
+    "    # z = 'concentration',\n",
+    "    c = 'concentration', # minute_gdf_subset.concentration,\n",
+    "    clim=(4, 25),\n",
+    "    cmap='RdYlBu_r',\n",
+    "    clabel='Water Temperature (C)',\n",
+    "    line_width = 0.1,\n",
+    "    height=700,\n",
+    "    width=800,\n",
+    "    widget_location='bottom',\n",
+    "    line_color='white',\n",
+    "    \n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b62985fb-0876-4bf8-b79e-a5a30a8731f7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plot_to_save"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "id": "09061d44-666a-40fc-8388-8acc597b72d0",
+   "metadata": {},
+   "source": [
+    "plot_to_save.save(filename='data_temp/output.html', embed=True)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.9"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/src/clearwater_riverine/linalg.py
+++ b/src/clearwater_riverine/linalg.py
@@ -63,7 +63,7 @@ class LHS:
                                              (np.isin(mesh.nedge, self.internal_edges)))[0]
         flow_in_indices = np.where((mesh[ADVECTION_COEFFICIENT][t] < 0) & \
                                    (np.isin(mesh.nedge, self.internal_edges)))[0]
-        empty_cells = np.where(mesh[VOLUME][t+1] == 0)[0][0:self.nreal_count]
+        empty_cells = np.where((mesh[VOLUME][t+1] == 0) & (np.arange(len(mesh[VOLUME][t+1])) < self.nreal_count))[0][0:self.nreal_count]
 
         # initialize arrays that will define the sparse matrix 
         len_val = self.internal_edge_count * 2 + self.nreal_count * 2 + \


### PR DESCRIPTION
In the linalg module, I previously defined empty cells as the following:
 `empty_cells = np.where((mesh[VOLUME][t+1] == 0)))[0][0:self.nreal_count]`

This does not correctly parse only real cells if 
1. There are non-empty cells within the real cells
2. There are empty cells within non-real cells 

I added the following, which fixes the issue. 
 `empty_cells = np.where((mesh[VOLUME][t+1] == 0) & (np.arange(len(transport_model.mesh['volume'][t+1])) < self.nreal_count))[0][0:self.nreal_count]`

I don't understand why the changes you made altered the representation of volume in the non-real cells, but if you feel OK to proceed this is a good bug fix to include either way!