### PR TITLE
Updates to loading constituents

### DIFF
--- a/src/clearwater_riverine/constituents.py
+++ b/src/clearwater_riverine/constituents.py
@@ -4,6 +4,7 @@ from typing import (
     Optional
 )
 from pathlib import Path
+import warnings
 
 import pandas as pd
 import xarray as xr
@@ -63,7 +64,14 @@ class Constituent:
                 input_array=self.input_array,
             )
         elif method == 'load':
-            self.units = mesh[name].Units
+            try:
+                self.units = mesh[name].Units
+            except AttributeError as err:
+                warnings.warn(
+                    f'Constituent {self.name} does not have units defined',
+                    UserWarning       
+                )
+
             self.set_value_range(mesh)
 
 

--- a/src/clearwater_riverine/transport.py
+++ b/src/clearwater_riverine/transport.py
@@ -17,12 +17,13 @@ from typing import (
 )
 from pathlib import Path
 import warnings
+import inspect
 
 from clearwater_riverine.mesh import (
     instantiate_model_mesh,
     load_model_mesh
 )
-from clearwater_riverine import variables
+import clearwater_riverine.variables
 from clearwater_riverine.variables import (
     ADVECTION_COEFFICIENT,
     COEFFICIENT_TO_DIFFUSION_TERM,
@@ -32,8 +33,6 @@ from clearwater_riverine.variables import (
     CHANGE_IN_TIME,
     NUMBER_OF_REAL_CELLS,
     VOLUME,
-    HYDRODYNAMIC_VARIABLES,
-    TOPOLOGY_VARIABLES,
 )
 from clearwater_riverine.utilities import UnitConverter
 from clearwater_riverine.linalg import LHS, RHS
@@ -65,8 +64,6 @@ CONVERSIONS = {'Metric': {'Liters': 0.001},
                'Imperial': {'Liters': 0.0353147},
                'Unknown': {'Liters': 0.001},
                }
-
-
 
 class ClearwaterRiverine:
     """ Creates Clearwater Riverine water quality model.
@@ -785,9 +782,9 @@ class ClearwaterRiverine:
         plt.show()
 
     def _determine_constituents(self):
+        defined_variables = [f[1] for f in inspect.getmembers(clearwater_riverine.variables)]
         self.constituents = [
             f for f in self.mesh.data_vars
             if FACES in self.mesh[f].dims
-            and f not in HYDRODYNAMIC_VARIABLES
-            and f not in TOPOLOGY_VARIABLES
+            and f not in defined_variables
         ]

--- a/src/clearwater_riverine/variables.py
+++ b/src/clearwater_riverine/variables.py
@@ -8,6 +8,7 @@ EDGE_NODES = 'edge_nodes'
 FACE_NODES = 'face_nodes'
 EDGE_FACE_CONNECTIVITY = 'edge_face_connectivity'
 FACES = 'nface'
+MESH_2D = 'mesh_2d'
 
 # Available Variables
 EDGES_FACE1 = 'edges_face1'
@@ -15,6 +16,7 @@ EDGES_FACE2 = 'edges_face2'
 NUMBER_OF_REAL_CELLS = 'nreal'
 VOLUME = 'volume'
 FACE_SURFACE_AREA = 'faces_surface_area'
+WETTED_SURFACE_AREA = 'wetted_surface_area'
 EDGE_VELOCITY = 'edge_velocity'
 EDGE_LENGTH = 'edge_length'
 CHANGE_IN_TIME = 'dt'
@@ -30,31 +32,3 @@ COEFFICIENT_TO_DIFFUSION_TERM  = 'coeff_to_diffusion'
 SUM_OF_COEFFICIENTS_TO_DIFFUSION_TERM = 'sum_coeff_to_diffusion'
 GHOST_CELL_VOLUMES_IN = 'ghost_volumes_in'
 GHOST_CELL_VOLUMES_OUT = 'ghost_volumes_out'
-
-# Water Quality
-POLLUTANT_LOAD = 'pollutant_load'
-CONCENTRATION = 'concentration'
-
-TOPOLOGY_VARIABLES = [
-    'mesh2d',
-    FACE_NODES,
-    EDGE_NODES,
-    EDGE_FACE_CONNECTIVITY,
-    EDGES_FACE1,
-    EDGES_FACE2,
-]
-
-HYDRODYNAMIC_VARIABLES = [
-    FACE_SURFACE_AREA,
-    EDGE_VELOCITY,
-    EDGE_LENGTH,
-    WATER_SURFACE_ELEVATION,
-    VOLUME,
-    FLOW_ACROSS_FACE,
-    ADVECTION_COEFFICIENT,
-    EDGE_VERTICAL_AREA,
-    FACE_TO_FACE_DISTANCE,
-    DIFFUSION_COEFFICIENT,
-    CHANGE_IN_TIME,
-    'wetted_surface_area',
-]


### PR DESCRIPTION
This updates the loading capabilities of ClearwaterRiverine to address some issues that @jrutyna was running into when adding new non-constituent variables to the model:
1. The `_determine_constituents` function parses which variables are constituents when loading a Clearwater Riverine mesh from a netcdf or zarr file. The function had previously used `HYDRODYNAMIC_VARIABLES` / `TOPOLOGICAL_VARIABLES` lists defined in `variables.py` to exclude certain variables from the list of constituents. However, this meant that when adding new variables to ClearwaterRiverine, you'd have to add the variable itself and then add it to one of these lists. We now dynamically load a list of all variables defined in `variables.py` in `_determine_constituents` and exclude those from the list of potential constituents. 
2. I add warnings to `constituents.py` when instantiating Constituent. When loading a dataset, it will check for units, but if they don't exist, it will just issue a warning rather than failing.