### PR TITLE
reorder calculated variables for chunking

### DIFF
--- a/src/clearwater_riverine/model.py
+++ b/src/clearwater_riverine/model.py
@@ -328,20 +328,25 @@ class ClearwaterRiverine:
 
     def __update_calculated_variables(self):
         """Initialize calculated variables."""
+        # unregister
+        for calculated_variable, calculate in self.__calculated_variables.items():
+            if calculate and calculated_variable in self.registry:
+                self.registry.unregister(calculated_variable)
+        
+        # recalculate and register
         for calculated_variable, calculate in self.__calculated_variables.items():
             if calculate:
                 # if calculated_variable not in self.registry:
                 # TODO: add logic to set calculated variables in order of dependencies
-                calculation_method = CALCULATED_VARIABLE_MAP[calculated_variable]
-                calculated_result = calculation_method(
-                    registry=self.registry,
-                )
-                if calculated_variable in self.registry:
-                    self.registry.unregister(calculated_variable)
-                self.registry.register(
-                    calculated_variable,
-                    calculated_result,
-                )
+                if calculated_variable not in self.registry:
+                    calculation_method = CALCULATED_VARIABLE_MAP[calculated_variable]
+                    calculated_result = calculation_method(
+                        registry=self.registry,
+                    )
+                    self.registry.register(
+                        calculated_variable,
+                        calculated_result,
+                    )
 
 
     def __init_output_store(self):


### PR DESCRIPTION
Working on some testing scripts for clearwater-modules, I discovered that saving a yaml for iterative model runs reordered the riverine config, which exposed an issue with the calculated variables like wetted surface area and average depth. previously, it was just by chance that the variables were listed in the order of calculation that they were re-calculated and then re-registered. however, if they were in a different order, old variables were not un-registered and re-calculated in the correct order and I got alignment errors. This fixes that bug. 